### PR TITLE
Fix GunDB initialization

### DIFF
--- a/src/lib/gundb/gundb.js
+++ b/src/lib/gundb/gundb.js
@@ -11,4 +11,4 @@ const initGunDB = () => {
   }
 }
 
-export default initGunDB()
+export default initGunDB


### PR DESCRIPTION
After 310a8a23be26f42b1e5709dc914ca6087ec02744 the GunDB instance can not be initialized and fail with the following error:

```
Unhandled Rejection (TypeError): (0 , _gundb.default) is not a function
```
