### PR TITLE
(Chore) profile validations

### DIFF
--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -26,10 +26,7 @@ const EditProfile = props => {
     setErrors(profile.getErrors())
     if (!profile.isValid()) return
 
-    Promise.all([
-      userStorage.setProfileField('email', profile.email, 'masked'),
-      userStorage.setProfileField('mobile', profile.mobile, 'masked')
-    ])
+    userStorage.setProfile(profile)
   }
   return (
     <Wrapper>

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -23,8 +23,9 @@ const EditProfile = props => {
   }, [profile.fullName])
 
   const handleSaveButton = () => {
-    setErrors(profile.getErrors())
-    if (!profile.isValid()) return
+    const { isValid, errors } = profile.validate()
+    setErrors(errors)
+    if (!isValid) return
 
     userStorage.setProfile(profile)
   }

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -22,20 +22,10 @@ const EditProfile = props => {
     userStorage.getPrivateProfile(profile).then(setProfile)
   }, [profile.fullName])
 
-  /**
-   * checks errors and returns true if at least one error was found
-   */
-  const checkErrors = () => {
-    const emailErrorMessage = isEmail(profile.email) ? '' : 'Please enter an email in format: yourname@example.com'
-    const mobileErrorMessage = isMobilePhone(profile.mobile) ? '' : 'Please enter a valid phone format'
-
-    log.debug({ email: emailErrorMessage, mobile: mobileErrorMessage })
-    setErrors({ email: emailErrorMessage, mobile: mobileErrorMessage })
-    return !(emailErrorMessage === '' && mobileErrorMessage === '')
-  }
-
   const handleSaveButton = () => {
-    if (checkErrors()) return
+    setErrors(profile.getErrors())
+    if (!profile.isValid()) return
+
     Promise.all([
       userStorage.setProfileField('email', profile.email, 'masked'),
       userStorage.setProfileField('mobile', profile.mobile, 'masked')

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -4,8 +4,6 @@ import { Wrapper, Section, CustomButton, UserAvatar } from '../common'
 import logger from '../../lib/logger/pino-logger'
 import GDStore from '../../lib/undux/GDStore'
 import { useWrappedUserStorage } from '../../lib/gundb/useWrappedStorage'
-import isEmail from 'validator/lib/isEmail'
-import isMobilePhone from '../../lib/validators/isMobilePhone'
 
 import ProfileDataTable from './ProfileDataTable'
 
@@ -16,25 +14,34 @@ const EditProfile = props => {
   const userStorage = useWrappedUserStorage()
 
   const [profile, setProfile] = useState(store.get('profile'))
+  const [saving, setSaving] = useState()
   const [errors, setErrors] = useState({})
-  const { loading: saving } = store.get('currentScreen')
+  const { loading } = store.get('currentScreen')
   useEffect(() => {
     userStorage.getPrivateProfile(profile).then(setProfile)
   }, [profile.fullName])
 
-  const handleSaveButton = () => {
+  const handleSaveButton = async () => {
     const { isValid, errors } = profile.validate()
     setErrors(errors)
     if (!isValid) return
 
-    userStorage.setProfile(profile)
+    setSaving(true)
+    await userStorage.setProfile(profile)
+    setSaving(false)
   }
   return (
     <Wrapper>
       <Section style={styles.section}>
         <Section.Row style={styles.centered}>
           <UserAvatar profile={profile} />
-          <CustomButton loading={saving} mode="outlined" style={styles.saveButton} onPress={handleSaveButton}>
+          <CustomButton
+            disabled={loading}
+            loading={saving}
+            mode="outlined"
+            style={styles.saveButton}
+            onPress={handleSaveButton}
+          >
             Save
           </CustomButton>
         </Section.Row>

--- a/src/components/signup/EmailForm.js
+++ b/src/components/signup/EmailForm.js
@@ -4,6 +4,7 @@ import { HelperText, TextInput } from 'react-native-paper'
 import isEmail from 'validator/lib/isEmail'
 import { Wrapper, Title } from './components'
 import logger from '../../lib/logger/pino-logger'
+import { getEmailErrorMessage } from '../../lib/gundb/UserModel'
 
 const log = logger.child({ from: 'EmailForm' })
 
@@ -43,7 +44,7 @@ export default class EmailForm extends React.Component<Props, State> {
   }
 
   checkErrors = () => {
-    const errorMessage = isEmail(this.state.email) ? '' : 'Please enter an email in format: yourname@example.com'
+    const errorMessage = getEmailErrorMessage(this.state.email)
 
     this.setState({ errorMessage })
   }

--- a/src/components/signup/EmailForm.js
+++ b/src/components/signup/EmailForm.js
@@ -1,10 +1,9 @@
 // @flow
 import React from 'react'
 import { HelperText, TextInput } from 'react-native-paper'
-import isEmail from 'validator/lib/isEmail'
 import { Wrapper, Title } from './components'
 import logger from '../../lib/logger/pino-logger'
-import { getEmailErrorMessage } from '../../lib/gundb/UserModel'
+import { userModelValidations } from '../../lib/gundb/UserModel'
 
 const log = logger.child({ from: 'EmailForm' })
 
@@ -44,7 +43,7 @@ export default class EmailForm extends React.Component<Props, State> {
   }
 
   checkErrors = () => {
-    const errorMessage = getEmailErrorMessage(this.state.email)
+    const errorMessage = userModelValidations.email(this.state.email)
 
     this.setState({ errorMessage })
   }

--- a/src/components/signup/PhoneForm.web.js
+++ b/src/components/signup/PhoneForm.web.js
@@ -6,7 +6,7 @@ import 'react-phone-number-input/style.css'
 
 import isMobilePhone from '../../lib/validators/isMobilePhone'
 import { Description, Title, Wrapper } from './components'
-import { getMobileErrorMessage } from '../../lib/gundb/UserModel'
+import { userModelValidations } from '../../lib/gundb/UserModel'
 
 type Props = {
   // callback to report to parent component
@@ -43,7 +43,7 @@ export default class PhoneForm extends React.Component<Props, State> {
   }
 
   checkErrors = () => {
-    const errorMessage = getMobileErrorMessage(this.state.mobile)
+    const errorMessage = userModelValidations.mobile(this.state.mobile)
     this.setState({ errorMessage })
   }
 

--- a/src/components/signup/PhoneForm.web.js
+++ b/src/components/signup/PhoneForm.web.js
@@ -6,6 +6,7 @@ import 'react-phone-number-input/style.css'
 
 import isMobilePhone from '../../lib/validators/isMobilePhone'
 import { Description, Title, Wrapper } from './components'
+import { getMobileErrorMessage } from '../../lib/gundb/UserModel'
 
 type Props = {
   // callback to report to parent component
@@ -19,7 +20,7 @@ export type MobileRecord = {
   errorMessage: string
 }
 
-type State = MobileRecord & { valid?: boolean }
+type State = MobileRecord
 
 export default class PhoneForm extends React.Component<Props, State> {
   state = {
@@ -42,8 +43,7 @@ export default class PhoneForm extends React.Component<Props, State> {
   }
 
   checkErrors = () => {
-    const errorMessage = isMobilePhone(this.state.mobile) ? '' : 'Please enter a valid phone format'
-
+    const errorMessage = getMobileErrorMessage(this.state.mobile)
     this.setState({ errorMessage })
   }
 

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -8,7 +8,6 @@ import SmsForm from './SmsForm'
 import EmailConfirmation from './EmailConfirmation'
 import FaceRecognition from './FaceRecognition'
 import SignupCompleted from './SignupCompleted'
-import { CustomDialog } from '../common/'
 import NavBar from '../appNavigation/NavBar'
 
 import { createSwitchNavigator } from '@react-navigation/core'
@@ -16,15 +15,14 @@ import logger from '../../lib/logger/pino-logger'
 
 import { useWrappedApi } from '../../lib/API/useWrappedApi'
 import goodWallet from '../../lib/wallet/GoodWallet'
-
-import type { UserRecord } from '../../lib/API/api'
 import userStorage from '../../lib/gundb/UserStorage'
 import type { SMSRecord } from './SmsForm'
 import GDStore from '../../lib/undux/GDStore'
+import { getUserModel, type UserModel } from '../../lib/gundb/UserModel'
 
 const log = logger.child({ from: 'SignupState' })
 
-export type SignupState = UserRecord & SMSRecord & { loading?: boolean }
+export type SignupState = UserModel & SMSRecord
 
 const SignupWizardNavigator = createSwitchNavigator({
   Name: NameForm,
@@ -39,10 +37,12 @@ const SignupWizardNavigator = createSwitchNavigator({
 const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any }) => {
   const API = useWrappedApi()
   const initialState: SignupState = {
+    ...getUserModel({
+      fullName: '',
+      email: '',
+      mobile: ''
+    }),
     pubkey: goodWallet.account,
-    fullName: '',
-    email: '',
-    mobile: '',
     smsValidated: false,
     isEmailConfirmed: false,
     jwt: ''
@@ -52,7 +52,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
   const store = GDStore.useStore()
   const { loading } = store.get('currentScreen')
   function saveProfile() {
-    ;['fullName', 'email', 'mobile'].forEach(field => userStorage.setProfileField(field, state[field], 'masked'))
+    userStorage.setProfile(state)
   }
 
   const done = async (data: { [string]: string }) => {

--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -3,19 +3,25 @@ import type { UserRecord } from '../api'
 import isEmail from 'validator/lib/isEmail'
 import isMobilePhone from '../validators/isMobilePhone'
 
+type Validation = {
+  isValid: boolean,
+  errors: {}
+}
 type ModelValidator = {
   isValid: () => boolean,
-  getErrors: () => {}
+  getErrors: () => {},
+  validate: () => Validation
 }
-
 type UserModel = UserRecord & ModelValidator
 
 export function getUserModel(record: UserRecord): UserModel {
+  const _isValid = errors => Object.keys(errors).every(key => errors[key] === '')
+
   return {
     ...record,
     isValid: function() {
-      console.log(this, 'isValid()')
-      return this.email && isEmail(this.email) && this.mobile && isMobilePhone(this.mobile)
+      const errors = this.getErrors()
+      return _isValid(errors)
     },
     getErrors: function() {
       console.log(this, 'getErrors()')
@@ -24,6 +30,9 @@ export function getUserModel(record: UserRecord): UserModel {
       const mobileErrorMessage = isMobilePhone(this.mobile) ? '' : 'Please enter a valid phone format'
 
       return { email: emailErrorMessage, mobile: mobileErrorMessage }
+    },
+    validate: function() {
+      return { isValid: this.isValid(), errors: this.getErrors() }
     }
   }
 }

--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -27,27 +27,25 @@ export const getMobileErrorMessage = (mobile?: string) => {
   return ''
 }
 
+export const userModelValidations = {
+  email: getEmailErrorMessage,
+  mobile: getMobileErrorMessage
+}
+
 export function getUserModel(record: UserRecord): UserModel {
   const _isValid = errors => Object.keys(errors).every(key => errors[key] === '')
 
-  const validations = {
-    email: getEmailErrorMessage,
-    mobile: getMobileErrorMessage
-  }
-
   return {
     ...record,
-    isValid: function(key) {
-      const errors = this.getErrors(key)
+    isValid: function() {
+      const errors = this.getErrors()
       return _isValid(errors)
     },
-    getErrors: function(key) {
-      if (key) return { [key]: validations[key](this[key]) }
-
-      return { email: validations.email(this.email), mobile: validations.mobile(this.mobile) }
+    getErrors: function() {
+      return { email: userModelValidations.email(this.email), mobile: userModelValidations.mobile(this.mobile) }
     },
-    validate: function(key) {
-      return { isValid: this.isValid(key), errors: this.getErrors(key) }
+    validate: function() {
+      return { isValid: this.isValid(), errors: this.getErrors() }
     }
   }
 }

--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -12,7 +12,7 @@ type ModelValidator = {
   getErrors: () => {},
   validate: () => Validation
 }
-type UserModel = UserRecord & ModelValidator
+export type UserModel = UserRecord & ModelValidator
 
 export function getUserModel(record: UserRecord): UserModel {
   const _isValid = errors => Object.keys(errors).every(key => errors[key] === '')

--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -1,0 +1,29 @@
+// @flow
+import type { UserRecord } from '../api'
+import isEmail from 'validator/lib/isEmail'
+import isMobilePhone from '../validators/isMobilePhone'
+
+type ModelValidator = {
+  isValid: () => boolean,
+  getErrors: () => {}
+}
+
+type UserModel = UserRecord & ModelValidator
+
+export function getUserModel(record: UserRecord): UserModel {
+  return {
+    ...record,
+    isValid: function() {
+      console.log(this, 'isValid()')
+      return this.email && isEmail(this.email) && this.mobile && isMobilePhone(this.mobile)
+    },
+    getErrors: function() {
+      console.log(this, 'getErrors()')
+
+      const emailErrorMessage = isEmail(this.email) ? '' : 'Please enter an email in format: yourname@example.com'
+      const mobileErrorMessage = isMobilePhone(this.mobile) ? '' : 'Please enter a valid phone format'
+
+      return { email: emailErrorMessage, mobile: mobileErrorMessage }
+    }
+  }
+}

--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -14,13 +14,13 @@ export type ModelValidator = {
 }
 export type UserModel = UserRecord & ModelValidator
 
-export const getEmailErrorMessage = (email?: string) => {
+const getEmailErrorMessage = (email?: string) => {
   if (!email) return 'Email is required'
   if (!isEmail(email)) return 'Please enter an email in format: yourname@example.com'
 
   return ''
 }
-export const getMobileErrorMessage = (mobile?: string) => {
+const getMobileErrorMessage = (mobile?: string) => {
   if (!mobile) return 'Mobile is required'
   if (!isMobilePhone(mobile)) return 'Please enter a valid phone format'
 

--- a/src/lib/gundb/UserStorage.js
+++ b/src/lib/gundb/UserStorage.js
@@ -2,7 +2,7 @@
 import { default as goodWallet, GoodWallet } from '../wallet/GoodWallet'
 import pino from '../logger/pino-logger'
 import { find, merge, orderBy, toPairs, takeWhile, flatten } from 'lodash'
-import { getUserModel } from './UserModel'
+import { getUserModel, type UserModel } from './UserModel'
 
 const logger = pino.child({ from: 'UserStorage' })
 
@@ -155,6 +155,14 @@ class UserStorage {
       },
       { wait: WAIT }
     )
+  }
+
+  async setProfile(profile: UserModel) {
+    if (!profile.isValid()) return
+    return Promise.all([
+      this.setProfileField('email', profile.email, 'masked'),
+      this.setProfileField('mobile', profile.mobile, 'masked')
+    ])
   }
 
   async setProfileField(field: string, value: string, privacy: FieldPrivacy): Promise<ACK> {

--- a/src/lib/gundb/UserStorage.js
+++ b/src/lib/gundb/UserStorage.js
@@ -158,8 +158,13 @@ class UserStorage {
   }
 
   async setProfile(profile: UserModel) {
-    if (!profile.isValid()) return
+    const { errors, isValid } = profile.validate()
+    if (!isValid) {
+      throw new Error(errors)
+    }
+
     return Promise.all([
+      this.setProfileField('fullName', profile.fullName, 'masked'),
       this.setProfileField('email', profile.email, 'masked'),
       this.setProfileField('mobile', profile.mobile, 'masked')
     ])

--- a/src/lib/gundb/UserStorage.js
+++ b/src/lib/gundb/UserStorage.js
@@ -2,6 +2,8 @@
 import { default as goodWallet, GoodWallet } from '../wallet/GoodWallet'
 import pino from '../logger/pino-logger'
 import { find, merge, orderBy, toPairs, takeWhile, flatten } from 'lodash'
+import { getUserModel } from './UserModel'
+
 const logger = pino.child({ from: 'UserStorage' })
 
 const WAIT = 99
@@ -127,17 +129,23 @@ class UserStorage {
   }
 
   async getDisplayProfile(profile: {}): Promise<any> {
-    return Object.keys(profile).reduce((acc, currKey, arr) => ({ ...acc, [currKey]: profile[currKey].display }), {})
+    const displayProfile = Object.keys(profile).reduce(
+      (acc, currKey, arr) => ({ ...acc, [currKey]: profile[currKey].display }),
+      {}
+    )
+    return getUserModel(displayProfile)
   }
 
   async getPrivateProfile(profile: {}) {
     const keys = Object.keys(profile)
-    return Promise.all(keys.map(currKey => this.getProfileFieldValue(currKey))).then(values => {
-      return values.reduce((acc, currValue, index) => {
-        const currKey = keys[index]
-        return { ...acc, [currKey]: currValue }
-      }, {})
-    })
+    return Promise.all(keys.map(currKey => this.getProfileFieldValue(currKey)))
+      .then(values => {
+        return values.reduce((acc, currValue, index) => {
+          const currKey = keys[index]
+          return { ...acc, [currKey]: currValue }
+        }, {})
+      })
+      .then(getUserModel)
   }
 
   getProfile(callback: any => void) {

--- a/src/lib/gundb/__tests__/UserModel.js
+++ b/src/lib/gundb/__tests__/UserModel.js
@@ -1,5 +1,5 @@
 // @flow
-import { getUserModel } from '../UserModel'
+import { getUserModel, userModelValidations } from '../UserModel'
 
 describe('UserModel', () => {
   let validProfile
@@ -58,18 +58,7 @@ describe('UserModel', () => {
   })
 
   it('isValid only a field', () => {
-    const model = getUserModel(validProfile)
-    delete model.email
-
-    expect(model.isValid('mobile')).toBeTruthy()
-  })
-
-  it('validate should return isValid and errors with only a field', () => {
-    const model = getUserModel(validProfile)
-    delete model.email
-    const { isValid, errors } = model.validate('mobile')
-    expect(isValid).toBeTruthy()
-    expect(errors.mobile).toBe('')
-    expect(errors.email).toBeUndefined()
+    expect(userModelValidations.mobile('fake')).not.toBe('')
+    expect(userModelValidations.mobile('+22222222222')).toBe('')
   })
 })

--- a/src/lib/gundb/__tests__/UserModel.js
+++ b/src/lib/gundb/__tests__/UserModel.js
@@ -1,0 +1,51 @@
+// @flow
+import { getUserModel } from '../UserModel'
+
+describe('UserModel', () => {
+  let validProfile
+  beforeEach(() => {
+    validProfile = {
+      email: 'john@doe.com',
+      mobile: '+22222222222'
+    }
+  })
+  it('Valid Profile isValid() should be true', () => {
+    const model = getUserModel(validProfile)
+    expect(model.isValid()).toBeTruthy()
+  })
+
+  it('Invalid Profile isValid() should false', () => {
+    validProfile.email = 'fakeemail'
+    const model = getUserModel(validProfile)
+    expect(model.isValid()).toBeFalsy()
+  })
+
+  it('Invalid email should get error on email property', () => {
+    validProfile.email = 'fakeemail'
+    const model = getUserModel(validProfile)
+    const errors = model.getErrors()
+    expect(errors.mobile).toBe('')
+    expect(errors.email).not.toBe('')
+  })
+
+  it('validate a valid profile should return an object with valid and no errors', () => {
+    const model = getUserModel(validProfile)
+    const { isValid, errors } = model.validate()
+
+    expect(isValid).toBeTruthy()
+    expect(errors.mobile).toBe('')
+    expect(errors.email).toBe('')
+  })
+
+  it('validate a inValid profile should return an object with valid in false and errors', () => {
+    validProfile.email = 'fake'
+    validProfile.mobile = 'fake'
+
+    const model = getUserModel(validProfile)
+    const { isValid, errors } = model.validate()
+
+    expect(isValid).toBeFalsy()
+    expect(errors.mobile).not.toBe('')
+    expect(errors.email).not.toBe('')
+  })
+})

--- a/src/lib/gundb/__tests__/UserModel.js
+++ b/src/lib/gundb/__tests__/UserModel.js
@@ -20,6 +20,14 @@ describe('UserModel', () => {
     expect(model.isValid()).toBeFalsy()
   })
 
+  it('Profile without email isValid() should false', () => {
+    delete validProfile.email
+    const model = getUserModel(validProfile)
+    const { isValid, errors } = model.validate()
+    expect(isValid).toBeFalsy()
+    expect(errors.email).toBe('Email is required')
+  })
+
   it('Invalid email should get error on email property', () => {
     validProfile.email = 'fakeemail'
     const model = getUserModel(validProfile)
@@ -47,5 +55,21 @@ describe('UserModel', () => {
     expect(isValid).toBeFalsy()
     expect(errors.mobile).not.toBe('')
     expect(errors.email).not.toBe('')
+  })
+
+  it('isValid only a field', () => {
+    const model = getUserModel(validProfile)
+    delete model.email
+
+    expect(model.isValid('mobile')).toBeTruthy()
+  })
+
+  it('validate should return isValid and errors with only a field', () => {
+    const model = getUserModel(validProfile)
+    delete model.email
+    const { isValid, errors } = model.validate('mobile')
+    expect(isValid).toBeTruthy()
+    expect(errors.mobile).toBe('')
+    expect(errors.email).toBeUndefined()
   })
 })

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -283,6 +283,10 @@ describe('UserStorage', () => {
   })
 
   it('update profile field uses privacy settings', async done => {
+    // Making sure that privacy default is not override in other tests
+    await userStorage.setProfileField('mobile', '+22222222211', 'masked')
+    await userStorage.setProfileField('email', 'new@domain.com', 'masked')
+
     const profileData = {
       fullName: 'New Name',
       email: 'new@email.com',
@@ -314,6 +318,18 @@ describe('UserStorage', () => {
           x: '',
           id: ''
         })
+        done()
+      })
+    })
+  })
+
+  it(`update profile doesn't change privacy settings`, async done => {
+    const email = 'johndoe@blah.com'
+    await userStorage.setProfileField('email', email, 'public')
+    await userStorage.setProfile(getUserModel({ email, fullName: 'full name', mobile: '+22222222222' }))
+    await userStorage.subscribeProfileUpdates(updatedProfile => {
+      userStorage.getDisplayProfile(updatedProfile).then(result => {
+        expect(result.email).toBe(email)
         done()
       })
     })

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -230,7 +230,7 @@ describe('UserStorage', () => {
     })
   })
 
-  it.only('gets display profile', async done => {
+  it('gets display profile', async done => {
     await userStorage.setProfileField('x', '', 'public')
     await userStorage.setProfileField('mobile', '', 'public')
     await userStorage.setProfileField('phone', '', 'public')
@@ -238,7 +238,8 @@ describe('UserStorage', () => {
     await userStorage.setProfileField('name', 'hadar2', 'public')
     await userStorage.setProfileField('id', 'z123', 'private')
     userStorage.getProfile(profile => {
-      userStorage.getDisplayProfile(profile).then(displayProfile => {
+      userStorage.getDisplayProfile(profile).then(result => {
+        const { isValid, getErrors, validate, ...displayProfile } = result
         expect(displayProfile).toEqual({
           id: '',
           name: 'hadar2',
@@ -252,7 +253,7 @@ describe('UserStorage', () => {
     })
   })
 
-  it.only('gets private profile', async done => {
+  it('gets private profile', async done => {
     await userStorage.setProfileField('x', '', 'public')
     await userStorage.setProfileField('mobile', '', 'public')
     await userStorage.setProfileField('phone', '', 'public')
@@ -260,7 +261,9 @@ describe('UserStorage', () => {
     await userStorage.setProfileField('name', 'hadar2', 'public')
     await userStorage.setProfileField('id', 'z123', 'private')
     await userStorage.getProfile(profile => {
-      userStorage.getPrivateProfile(profile).then(privateProfile => {
+      userStorage.getPrivateProfile(profile).then(result => {
+        const { isValid, getErrors, validate, ...privateProfile } = result
+
         expect(privateProfile).toEqual({
           id: 'z123',
           name: 'hadar2',

--- a/src/lib/undux/effects/profile.js
+++ b/src/lib/undux/effects/profile.js
@@ -7,7 +7,7 @@ const withProfile: Effects<State> = (store: Store) => {
   store.on('isLoggedInCitizen').subscribe(isLoggedInCitizen => {
     if (!isLoggedInCitizen) return
 
-    userStorage.getProfile(profile => {
+    userStorage.subscribeProfileUpdates(profile => {
       userStorage.getDisplayProfile(profile).then(store.set('profile'))
     })
   })

--- a/src/lib/undux/utils/wrapper.js
+++ b/src/lib/undux/utils/wrapper.js
@@ -29,13 +29,12 @@ function Handler(store, params) {
 
   this.errorHandler = error => {
     let message = 'Unknown Error'
+    console.log({ error })
     if (error.response && error.response.data) {
       message = error.response.data.message
-    }
-    if (error.message) {
+    } else if (error.message) {
       message = error.message
-    }
-    if (error.err) {
+    } else if (error.err) {
       message = error.err
     }
     store.set('currentScreen')({


### PR DESCRIPTION
[164809205](https://www.pivotaltracker.com/story/show/164809205)

Changes
---

### Added UserModel

Re uses UserRecord and adds validation layer

```
export type ModelValidator = {
  isValid: (key: string) => boolean,
  getErrors: (key: string) => {},
  validate: (key: string) => Validation
}
export type UserModel = UserRecord & ModelValidator
```

Then you can do 
```
const { errors, isValid } = profile.validate()
```

This is being used in UserStorage to avoid saving an invalid profile and now we are only saving user profiles via `userStorage.setProfile`

### Added validation functions in model

Since validation functions being used in model validation are also exported from UserModel these validations are consistent across the app

```
export const getEmailErrorMessage = (email?: string) => {...}
userModelValidations = { email: getEmailErrorMessage, ... }
```