### PR TITLE
(Bug) Send flow back dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12266,7 +12266,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12631,7 +12632,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12679,6 +12681,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12717,11 +12720,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,7 +2340,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2679,7 +2679,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2961,7 +2961,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -3238,7 +3238,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -3334,7 +3334,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -6645,7 +6645,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -6653,7 +6653,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -6687,7 +6687,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -7914,7 +7914,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -7926,7 +7926,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -7996,7 +7996,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -8142,7 +8142,7 @@
         },
         "regexpu-core": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
@@ -9245,7 +9245,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -9418,7 +9418,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -10187,7 +10187,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -10726,7 +10726,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
@@ -12297,8 +12297,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12650,8 +12649,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12698,7 +12696,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12737,13 +12734,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -12811,7 +12806,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -13748,7 +13743,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -14898,7 +14893,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
@@ -15697,7 +15692,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -18168,7 +18163,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -18801,7 +18796,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -19773,7 +19768,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -19797,7 +19792,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
@@ -20049,7 +20044,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -20065,7 +20060,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -27182,7 +27177,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -27840,7 +27835,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -28779,7 +28774,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-hex-prefix": {
@@ -29515,7 +29510,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -29899,7 +29894,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -30852,7 +30847,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -32296,7 +32291,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -32313,7 +32308,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",

--- a/src/components/AppSwitch.js
+++ b/src/components/AppSwitch.js
@@ -94,7 +94,7 @@ class AppSwitch extends React.Component<LoadingProps, {}> {
           onDismiss={(...args) => {
             const currentDialogData = { ...dialogData }
             store.set('currentScreen')({ dialogData: { visible: false } })
-            dialogData.onDismiss && dialogData.onDismiss(currentDialogData)
+            currentDialogData.onDismiss && currentDialogData.onDismiss(currentDialogData)
           }}
         />
         <SceneView navigation={descriptor.navigation} component={descriptor.getComponent()} />

--- a/src/components/appNavigation/NavBar.js
+++ b/src/components/appNavigation/NavBar.js
@@ -4,7 +4,7 @@ import { View, Text, StyleSheet } from 'react-native'
 import backButton from '../../assets/backButton.png'
 
 type NavBarProps = {
-  goBack: () => void,
+  goBack?: () => void,
   title: string
 }
 /**
@@ -17,7 +17,7 @@ class NavBar extends React.Component<NavBarProps> {
     return (
       <View style={styles.navBar}>
         <View style={styles.left}>
-          <View style={styles.backButton} onClick={this.props.goBack} />
+          {this.props.goBack && <View style={styles.backButton} onClick={this.props.goBack} />}
         </View>
         <Text style={styles.title}>{this.props.title}</Text>
         <View style={styles.right} />

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -7,7 +7,15 @@ import { createNavigator, SwitchRouter, SceneView, Route } from '@react-navigati
 import NavBar from './NavBar'
 import { CustomButton, type ButtonProps } from '../common'
 
-const wrappNavigatedComponent = Component => props => {
+/**
+ * Wrapper that prevents to load a screen if:
+ * shouldNavigateToComponent is present in component and not complaining
+ * This function can be written in every component that needs to prevent access
+ * if there is not in a correct navigation flow.
+ * Example: doesn't makes sense to navigate to Amount if there is no nextRoutes
+ * @param {React.Component} Component
+ */
+const wrapNavigatedComponent = Component => props => {
   const { shouldNavigateToComponent } = Component
   if (shouldNavigateToComponent && !shouldNavigateToComponent(props)) {
     const NewComponent = props => {
@@ -115,7 +123,7 @@ class AppView extends Component<{ descriptors: any, navigation: any, navigationC
         {!navigationBarHidden && <NavBar goBack={backButtonHidden ? undefined : this.pop} title={title || activeKey} />}
         <SceneView
           navigation={descriptor.navigation}
-          component={wrappNavigatedComponent(descriptor.getComponent())}
+          component={wrapNavigatedComponent(descriptor.getComponent())}
           screenProps={{
             ...screenProps,
             navigationConfig,

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -6,6 +6,7 @@ import { createNavigator, SwitchRouter, SceneView, Route } from '@react-navigati
 
 import NavBar from './NavBar'
 import { CustomButton, type ButtonProps } from '../common'
+import logger from '../../lib/logger/pino-logger'
 
 /**
  * getComponent gets the component and props and returns the same component except when
@@ -66,19 +67,21 @@ class AppView extends Component<{ descriptors: any, navigation: any, navigationC
   push = (nextRoute, params) => {
     const { navigation } = this.props
     const route = navigation.state.routes[navigation.state.index].key
-    this.setState((state, props) => {
-      return {
-        stack: [
-          ...state.stack,
-          {
-            route,
-            state: state.currentState
-          }
-        ],
-        currentState: params
-      }
-    })
-    navigation.navigate(nextRoute)
+    this.setState(
+      (state, props) => {
+        return {
+          stack: [
+            ...state.stack,
+            {
+              route,
+              state: state.currentState
+            }
+          ],
+          currentState: params
+        }
+      },
+      state => navigation.navigate(nextRoute)
+    )
   }
 
   /**

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -220,15 +220,15 @@ export const DoneButton = (props: DoneButtonProps) => {
   const { disabled, screenProps, children, mode, color, style } = props
 
   return (
-    <Button
-      mode={mode || 'text'}
+    <CustomButton
+      mode={mode || 'outlined'}
       color={color || '#575757'}
       style={style}
       disabled={disabled}
       onPress={screenProps.goToRoot}
     >
       {children || 'Done'}
-    </Button>
+    </CustomButton>
   )
 }
 

--- a/src/components/dashboard/Amount.js
+++ b/src/components/dashboard/Amount.js
@@ -54,4 +54,9 @@ Amount.navigationOptions = {
   title: RECEIVE_TITLE
 }
 
+Amount.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return !!screenState.nextRoutes
+}
+
 export default Amount

--- a/src/components/dashboard/FaceRecognition.js
+++ b/src/components/dashboard/FaceRecognition.js
@@ -18,10 +18,6 @@ type Props = {
 }
 
 class FaceRecognition extends React.Component<Props> {
-  handleSubmit = () => {
-    this.props.screenProps.doneCallback({ isEmailConfirmed: true })
-  }
-
   handleClaim = async () => {
     try {
       const goodWalletWrapped = wrapper(goodWallet, this.props.store)
@@ -32,7 +28,7 @@ class FaceRecognition extends React.Component<Props> {
           title: 'Success',
           message: `You've claimed your GD`,
           dismissText: 'YAY!',
-          onDismiss: this._handleDismissDialog
+          onDismiss: this.props.screenProps.goToRoot
         },
         loading: true
       })
@@ -41,18 +37,12 @@ class FaceRecognition extends React.Component<Props> {
     }
   }
 
-  _handleDismissDialog = dialogData => {
-    const { title } = dialogData
-    // TODO: Improve this flow
-    if (title === 'Success') this.props.screenProps.pop()
-  }
-
   render() {
-    this.props.screenProps.data = { name: 'John' }
+    const { fullName } = this.props.store.get('profile')
     return (
       <Wrapper>
         <View style={styles.topContainer}>
-          <Title>{`${this.props.screenProps.data.name},\n Just one last thing...`}</Title>
+          <Title>{`${fullName},\n Just one last thing...`}</Title>
           <Description style={styles.description}>
             {"In order to give you a basic income we need to make sure it's really you"}
           </Description>

--- a/src/components/dashboard/Reason.js
+++ b/src/components/dashboard/Reason.js
@@ -46,4 +46,9 @@ SendReason.navigationOptions = {
   title: TITLE
 }
 
+SendReason.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return screenState.amount >= 0 && screenState.nextRoutes
+}
+
 export default SendReason

--- a/src/components/dashboard/ReceiveAmount.js
+++ b/src/components/dashboard/ReceiveAmount.js
@@ -48,4 +48,9 @@ ReceiveAmount.navigationOptions = {
   title: RECEIVE_TITLE
 }
 
+ReceiveAmount.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return !!screenState.nextRoutes && screenState.amount
+}
+
 export default ReceiveAmount

--- a/src/components/dashboard/SendConfirmation.js
+++ b/src/components/dashboard/SendConfirmation.js
@@ -40,13 +40,13 @@ const SendConfirmation = ({ screenProps, navigation }: ReceiveProps) => {
             <Text style={[styles.centered, styles.url]}>{sendLink}</Text>
           </View>
         </View>
-        <View style={styles.sectionBottom}>
-          <DoneButton screenProps={screenProps} style={{ flex: 1 }} />
-          <CustomButton onPress={copySendLink} style={{ flex: 2 }} mode="contained">
-            Copy Link to Clipboard
-          </CustomButton>
-        </View>
       </Section>
+      <View style={styles.sectionBottom}>
+        <CustomButton style={styles.buttonStyle} onPress={copySendLink} mode="contained">
+          Copy Link to Clipboard
+        </CustomButton>
+        <DoneButton style={styles.buttonStyle} screenProps={screenProps} />
+      </View>
     </Wrapper>
   )
 }
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
   },
   sectionBottom: {
     width: '100%',
-    flexDirection: 'row'
+    flexDirection: 'column'
   },
   qrCode: {
     marginTop: '2rem',
@@ -88,6 +88,9 @@ const styles = StyleSheet.create({
     maxWidth: '100%',
     paddingLeft: '1rem',
     paddingRight: '1rem'
+  },
+  buttonStyle: {
+    marginTop: '1em'
   }
 })
 

--- a/src/components/dashboard/SendConfirmation.js
+++ b/src/components/dashboard/SendConfirmation.js
@@ -99,4 +99,9 @@ SendConfirmation.navigationOptions = {
   backButtonHidden: true
 }
 
+SendConfirmation.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return !!screenState.sendLink
+}
+
 export default SendConfirmation

--- a/src/components/dashboard/SendConfirmation.js
+++ b/src/components/dashboard/SendConfirmation.js
@@ -6,7 +6,7 @@ import QRCode from 'qrcode.react'
 import logger from '../../lib/logger/pino-logger'
 import { Section, Wrapper, CustomButton, TopBar } from '../common'
 import { fontStyle } from '../common/styles'
-import { useScreenState } from '../appNavigation/stackNavigation'
+import { DoneButton, useScreenState } from '../appNavigation/stackNavigation'
 
 export type ReceiveProps = {
   screenProps: any,
@@ -41,7 +41,8 @@ const SendConfirmation = ({ screenProps, navigation }: ReceiveProps) => {
           </View>
         </View>
         <View style={styles.sectionBottom}>
-          <CustomButton onPress={copySendLink} mode="contained">
+          <DoneButton screenProps={screenProps} style={{ flex: 1 }} />
+          <CustomButton onPress={copySendLink} style={{ flex: 2 }} mode="contained">
             Copy Link to Clipboard
           </CustomButton>
         </View>
@@ -64,7 +65,8 @@ const styles = StyleSheet.create({
     alignItems: 'center'
   },
   sectionBottom: {
-    width: '100%'
+    width: '100%',
+    flexDirection: 'row'
   },
   qrCode: {
     marginTop: '2rem',
@@ -90,7 +92,8 @@ const styles = StyleSheet.create({
 })
 
 SendConfirmation.navigationOptions = {
-  title: SEND_TITLE
+  title: SEND_TITLE,
+  backButtonHidden: true
 }
 
 export default SendConfirmation

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -138,7 +138,7 @@ SendLinkSummary.navigationOptions = {
 
 SendLinkSummary.shouldNavigateToComponent = props => {
   const { screenState } = props.screenProps
-  return !!screenState.nextRoutes && screenState.amount
+  return (!!screenState.nextRoutes && screenState.amount) || !!screenState.sendLink
 }
 
 export default SendLinkSummary

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -136,4 +136,9 @@ SendLinkSummary.navigationOptions = {
   title: TITLE
 }
 
+SendLinkSummary.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return !!screenState.nextRoutes && screenState.amount
+}
+
 export default SendLinkSummary

--- a/src/components/dashboard/SendQRSummary.js
+++ b/src/components/dashboard/SendQRSummary.js
@@ -48,14 +48,14 @@ const SendQRSummary = (props: AmountProps) => {
           return hash
         }
       })
-      log.debug({ receipt })
+      log.debug({ receipt, screenProps })
       store.set('currentScreen')({
         dialogData: {
           visible: true,
           title: 'SUCCESS!',
           message: 'The GD was sent successfully',
           dismissText: 'Yay!',
-          onDismiss: screenProps.goToParent
+          onDismiss: screenProps.goToRoot
         }
       })
     } catch (e) {

--- a/src/components/dashboard/SendQRSummary.js
+++ b/src/components/dashboard/SendQRSummary.js
@@ -110,4 +110,9 @@ SendQRSummary.navigationOptions = {
   title: TITLE
 }
 
+SendQRSummary.shouldNavigateToComponent = props => {
+  const { screenState } = props.screenProps
+  return !!screenState.nextRoutes
+}
+
 export default SendQRSummary

--- a/src/components/dashboard/__tests__/__snapshots__/FaceRecognition.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/FaceRecognition.js.snap
@@ -140,7 +140,7 @@ exports[`FaceRecognition matches snapshot 1`] = `
               }
             }
           >
-            John,
+            undefined,
  Just one last thing...
           </div>
           <div

--- a/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
@@ -356,6 +356,11 @@ exports[`SendConfirmation matches snapshot 1`] = `
             className="css-view-1dbjc4n"
             style={
               Object {
+                "WebkitBoxDirection": "normal",
+                "WebkitBoxOrient": "horizontal",
+                "WebkitFlexDirection": "row",
+                "flexDirection": "row",
+                "msFlexDirection": "row",
                 "width": "100%",
               }
             }
@@ -364,7 +369,113 @@ exports[`SendConfirmation matches snapshot 1`] = `
               className="css-view-1dbjc4n"
               style={
                 Object {
+                  "WebkitBoxFlex": 1,
+                  "WebkitFlexBasis": "0%",
+                  "WebkitFlexGrow": 1,
+                  "WebkitFlexShrink": 1,
+                  "backgroundColor": "rgba(0,0,0,0.00)",
+                  "borderBottomColor": "rgba(0,0,0,0.00)",
+                  "borderBottomLeftRadius": "4px",
+                  "borderBottomRightRadius": "4px",
+                  "borderBottomStyle": "solid",
+                  "borderBottomWidth": "0px",
+                  "borderLeftColor": "rgba(0,0,0,0.00)",
+                  "borderLeftStyle": "solid",
+                  "borderLeftWidth": "0px",
+                  "borderRightColor": "rgba(0,0,0,0.00)",
+                  "borderRightStyle": "solid",
+                  "borderRightWidth": "0px",
+                  "borderTopColor": "rgba(0,0,0,0.00)",
+                  "borderTopLeftRadius": "4px",
+                  "borderTopRightRadius": "4px",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": "0px",
+                  "boxShadow": "0px 0px 0px rgba(0,0,0,0.24)",
+                  "flexBasis": "0%",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "minWidth": "64px",
+                  "msFlexNegative": 1,
+                  "msFlexPositive": 1,
+                  "msFlexPreferredSize": "0%",
+                }
+              }
+            >
+              <div
+                aria-disabled={true}
+                className="css-view-1dbjc4n"
+                disabled={true}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "borderBottomLeftRadius": "4px",
+                    "borderBottomRightRadius": "4px",
+                    "borderTopLeftRadius": "4px",
+                    "borderTopRightRadius": "4px",
+                    "overflowX": "hidden",
+                    "overflowY": "hidden",
+                    "position": "relative",
+                  }
+                }
+              >
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitAlignItems": "center",
+                      "WebkitBoxAlign": "center",
+                      "WebkitBoxDirection": "normal",
+                      "WebkitBoxOrient": "horizontal",
+                      "WebkitBoxPack": "center",
+                      "WebkitFlexDirection": "row",
+                      "WebkitJustifyContent": "center",
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "msFlexAlign": "center",
+                      "msFlexDirection": "row",
+                      "msFlexPack": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="css-text-76zvg2 css-textOneLine-bfa6kz"
+                    dir="auto"
+                    style={
+                      Object {
+                        "color": "rgba(87,87,87,1.00)",
+                        "direction": "ltr",
+                        "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                        "letterSpacing": "1px",
+                        "marginBottom": "9px",
+                        "marginLeft": "16px",
+                        "marginRight": "16px",
+                        "marginTop": "9px",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    DONE
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitBoxFlex": 2,
                   "WebkitBoxPack": "center",
+                  "WebkitFlexBasis": "0%",
+                  "WebkitFlexGrow": 2,
+                  "WebkitFlexShrink": 1,
                   "WebkitJustifyContent": "center",
                   "backgroundColor": "rgba(85,85,85,1.00)",
                   "borderBottomColor": "rgba(0,0,0,0.00)",
@@ -384,9 +495,15 @@ exports[`SendConfirmation matches snapshot 1`] = `
                   "borderTopStyle": "solid",
                   "borderTopWidth": "0px",
                   "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
+                  "flexBasis": "0%",
+                  "flexGrow": 2,
+                  "flexShrink": 1,
                   "justifyContent": "center",
                   "minWidth": "64px",
+                  "msFlexNegative": 1,
                   "msFlexPack": "center",
+                  "msFlexPositive": 2,
+                  "msFlexPreferredSize": "0%",
                 }
               }
             >

--- a/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
@@ -352,249 +352,254 @@ exports[`SendConfirmation matches snapshot 1`] = `
               />
             </div>
           </div>
+        </div>
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "WebkitBoxDirection": "normal",
+              "WebkitBoxOrient": "vertical",
+              "WebkitFlexDirection": "column",
+              "flexDirection": "column",
+              "msFlexDirection": "column",
+              "width": "100%",
+            }
+          }
+        >
           <div
             className="css-view-1dbjc4n"
             style={
               Object {
-                "WebkitBoxDirection": "normal",
-                "WebkitBoxOrient": "horizontal",
-                "WebkitFlexDirection": "row",
-                "flexDirection": "row",
-                "msFlexDirection": "row",
-                "width": "100%",
+                "WebkitBoxPack": "center",
+                "WebkitJustifyContent": "center",
+                "backgroundColor": "rgba(85,85,85,1.00)",
+                "borderBottomColor": "rgba(0,0,0,0.00)",
+                "borderBottomLeftRadius": "4px",
+                "borderBottomRightRadius": "4px",
+                "borderBottomStyle": "solid",
+                "borderBottomWidth": "0px",
+                "borderLeftColor": "rgba(0,0,0,0.00)",
+                "borderLeftStyle": "solid",
+                "borderLeftWidth": "0px",
+                "borderRightColor": "rgba(0,0,0,0.00)",
+                "borderRightStyle": "solid",
+                "borderRightWidth": "0px",
+                "borderTopColor": "rgba(0,0,0,0.00)",
+                "borderTopLeftRadius": "4px",
+                "borderTopRightRadius": "4px",
+                "borderTopStyle": "solid",
+                "borderTopWidth": "0px",
+                "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
+                "justifyContent": "center",
+                "marginTop": "1em",
+                "minWidth": "64px",
+                "msFlexPack": "center",
               }
             }
           >
             <div
-              className="css-view-1dbjc4n"
+              className="css-cursor-18t94o4 css-view-1dbjc4n"
+              data-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="button"
               style={
                 Object {
-                  "WebkitBoxFlex": 1,
-                  "WebkitFlexBasis": "0%",
-                  "WebkitFlexGrow": 1,
-                  "WebkitFlexShrink": 1,
-                  "backgroundColor": "rgba(0,0,0,0.00)",
-                  "borderBottomColor": "rgba(0,0,0,0.00)",
                   "borderBottomLeftRadius": "4px",
                   "borderBottomRightRadius": "4px",
-                  "borderBottomStyle": "solid",
-                  "borderBottomWidth": "0px",
-                  "borderLeftColor": "rgba(0,0,0,0.00)",
-                  "borderLeftStyle": "solid",
-                  "borderLeftWidth": "0px",
-                  "borderRightColor": "rgba(0,0,0,0.00)",
-                  "borderRightStyle": "solid",
-                  "borderRightWidth": "0px",
-                  "borderTopColor": "rgba(0,0,0,0.00)",
                   "borderTopLeftRadius": "4px",
                   "borderTopRightRadius": "4px",
-                  "borderTopStyle": "solid",
-                  "borderTopWidth": "0px",
-                  "boxShadow": "0px 0px 0px rgba(0,0,0,0.24)",
-                  "flexBasis": "0%",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "minWidth": "64px",
-                  "msFlexNegative": 1,
-                  "msFlexPositive": 1,
-                  "msFlexPreferredSize": "0%",
+                  "cursor": "pointer",
+                  "msTouchAction": "manipulation",
+                  "overflowX": "hidden",
+                  "overflowY": "hidden",
+                  "position": "relative",
+                  "touchAction": "manipulation",
                 }
               }
+              tabIndex="0"
             >
               <div
-                aria-disabled={true}
                 className="css-view-1dbjc4n"
-                disabled={true}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
                 style={
                   Object {
-                    "borderBottomLeftRadius": "4px",
-                    "borderBottomRightRadius": "4px",
-                    "borderTopLeftRadius": "4px",
-                    "borderTopRightRadius": "4px",
-                    "overflowX": "hidden",
-                    "overflowY": "hidden",
-                    "position": "relative",
+                    "WebkitAlignItems": "center",
+                    "WebkitBoxAlign": "center",
+                    "WebkitBoxDirection": "normal",
+                    "WebkitBoxOrient": "horizontal",
+                    "WebkitBoxPack": "center",
+                    "WebkitFlexDirection": "row",
+                    "WebkitJustifyContent": "center",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "msFlexAlign": "center",
+                    "msFlexDirection": "row",
+                    "msFlexPack": "center",
                   }
                 }
               >
                 <div
-                  className="css-view-1dbjc4n"
+                  className="css-text-76zvg2 css-textOneLine-bfa6kz"
+                  dir="auto"
                   style={
                     Object {
-                      "WebkitAlignItems": "center",
-                      "WebkitBoxAlign": "center",
-                      "WebkitBoxDirection": "normal",
-                      "WebkitBoxOrient": "horizontal",
-                      "WebkitBoxPack": "center",
-                      "WebkitFlexDirection": "row",
-                      "WebkitJustifyContent": "center",
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "msFlexAlign": "center",
-                      "msFlexDirection": "row",
-                      "msFlexPack": "center",
+                      "color": "rgba(255,255,255,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                      "letterSpacing": "1px",
+                      "marginBottom": "9px",
+                      "marginLeft": "16px",
+                      "marginRight": "16px",
+                      "marginTop": "9px",
+                      "textAlign": "center",
                     }
                   }
                 >
-                  <div
-                    className="css-text-76zvg2 css-textOneLine-bfa6kz"
+                  <span
+                    className="css-text-76zvg2 css-textHasAncestor-16my406"
                     dir="auto"
                     style={
                       Object {
-                        "color": "rgba(87,87,87,1.00)",
                         "direction": "ltr",
-                        "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
-                        "letterSpacing": "1px",
-                        "marginBottom": "9px",
-                        "marginLeft": "16px",
-                        "marginRight": "16px",
-                        "marginTop": "9px",
+                        "fontFamily": "Helvetica, \\"sans-serif\\"",
+                        "fontSize": "18px",
+                        "fontWeight": "bold",
+                        "paddingBottom": "5px",
+                        "paddingLeft": "5px",
+                        "paddingRight": "5px",
+                        "paddingTop": "5px",
                         "textAlign": "center",
+                        "textTransform": "uppercase",
                       }
                     }
                   >
-                    DONE
-                  </div>
+                    Copy Link to Clipboard
+                  </span>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "WebkitBoxPack": "center",
+                "WebkitJustifyContent": "center",
+                "backgroundColor": "rgba(0,0,0,0.00)",
+                "borderBottomColor": "rgba(0,0,0,0.29)",
+                "borderBottomLeftRadius": "4px",
+                "borderBottomRightRadius": "4px",
+                "borderBottomStyle": "solid",
+                "borderBottomWidth": "1px",
+                "borderLeftColor": "rgba(0,0,0,0.29)",
+                "borderLeftStyle": "solid",
+                "borderLeftWidth": "1px",
+                "borderRightColor": "rgba(0,0,0,0.29)",
+                "borderRightStyle": "solid",
+                "borderRightWidth": "1px",
+                "borderTopColor": "rgba(0,0,0,0.29)",
+                "borderTopLeftRadius": "4px",
+                "borderTopRightRadius": "4px",
+                "borderTopStyle": "solid",
+                "borderTopWidth": "1px",
+                "boxShadow": "0px 0px 0px rgba(0,0,0,0.24)",
+                "justifyContent": "center",
+                "marginTop": "1em",
+                "minWidth": "64px",
+                "msFlexPack": "center",
+              }
+            }
+          >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
+              disabled={true}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="button"
               style={
                 Object {
-                  "WebkitBoxFlex": 2,
-                  "WebkitBoxPack": "center",
-                  "WebkitFlexBasis": "0%",
-                  "WebkitFlexGrow": 2,
-                  "WebkitFlexShrink": 1,
-                  "WebkitJustifyContent": "center",
-                  "backgroundColor": "rgba(85,85,85,1.00)",
-                  "borderBottomColor": "rgba(0,0,0,0.00)",
                   "borderBottomLeftRadius": "4px",
                   "borderBottomRightRadius": "4px",
-                  "borderBottomStyle": "solid",
-                  "borderBottomWidth": "0px",
-                  "borderLeftColor": "rgba(0,0,0,0.00)",
-                  "borderLeftStyle": "solid",
-                  "borderLeftWidth": "0px",
-                  "borderRightColor": "rgba(0,0,0,0.00)",
-                  "borderRightStyle": "solid",
-                  "borderRightWidth": "0px",
-                  "borderTopColor": "rgba(0,0,0,0.00)",
                   "borderTopLeftRadius": "4px",
                   "borderTopRightRadius": "4px",
-                  "borderTopStyle": "solid",
-                  "borderTopWidth": "0px",
-                  "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
-                  "flexBasis": "0%",
-                  "flexGrow": 2,
-                  "flexShrink": 1,
-                  "justifyContent": "center",
-                  "minWidth": "64px",
-                  "msFlexNegative": 1,
-                  "msFlexPack": "center",
-                  "msFlexPositive": 2,
-                  "msFlexPreferredSize": "0%",
+                  "overflowX": "hidden",
+                  "overflowY": "hidden",
+                  "position": "relative",
                 }
               }
             >
               <div
-                className="css-cursor-18t94o4 css-view-1dbjc4n"
-                data-focusable={true}
-                disabled={false}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
+                className="css-view-1dbjc4n"
                 style={
                   Object {
-                    "borderBottomLeftRadius": "4px",
-                    "borderBottomRightRadius": "4px",
-                    "borderTopLeftRadius": "4px",
-                    "borderTopRightRadius": "4px",
-                    "cursor": "pointer",
-                    "msTouchAction": "manipulation",
-                    "overflowX": "hidden",
-                    "overflowY": "hidden",
-                    "position": "relative",
-                    "touchAction": "manipulation",
+                    "WebkitAlignItems": "center",
+                    "WebkitBoxAlign": "center",
+                    "WebkitBoxDirection": "normal",
+                    "WebkitBoxOrient": "horizontal",
+                    "WebkitBoxPack": "center",
+                    "WebkitFlexDirection": "row",
+                    "WebkitJustifyContent": "center",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "msFlexAlign": "center",
+                    "msFlexDirection": "row",
+                    "msFlexPack": "center",
                   }
                 }
-                tabIndex="0"
               >
                 <div
-                  className="css-view-1dbjc4n"
+                  className="css-text-76zvg2 css-textOneLine-bfa6kz"
+                  dir="auto"
                   style={
                     Object {
-                      "WebkitAlignItems": "center",
-                      "WebkitBoxAlign": "center",
-                      "WebkitBoxDirection": "normal",
-                      "WebkitBoxOrient": "horizontal",
-                      "WebkitBoxPack": "center",
-                      "WebkitFlexDirection": "row",
-                      "WebkitJustifyContent": "center",
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "msFlexAlign": "center",
-                      "msFlexDirection": "row",
-                      "msFlexPack": "center",
+                      "color": "rgba(87,87,87,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                      "letterSpacing": "1px",
+                      "marginBottom": "9px",
+                      "marginLeft": "16px",
+                      "marginRight": "16px",
+                      "marginTop": "9px",
+                      "textAlign": "center",
                     }
                   }
                 >
-                  <div
-                    className="css-text-76zvg2 css-textOneLine-bfa6kz"
+                  <span
+                    className="css-text-76zvg2 css-textHasAncestor-16my406"
                     dir="auto"
                     style={
                       Object {
-                        "color": "rgba(255,255,255,1.00)",
                         "direction": "ltr",
-                        "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
-                        "letterSpacing": "1px",
-                        "marginBottom": "9px",
-                        "marginLeft": "16px",
-                        "marginRight": "16px",
-                        "marginTop": "9px",
+                        "fontFamily": "Helvetica, \\"sans-serif\\"",
+                        "fontSize": "18px",
+                        "fontWeight": "bold",
+                        "paddingBottom": "5px",
+                        "paddingLeft": "5px",
+                        "paddingRight": "5px",
+                        "paddingTop": "5px",
                         "textAlign": "center",
+                        "textTransform": "uppercase",
                       }
                     }
                   >
-                    <span
-                      className="css-text-76zvg2 css-textHasAncestor-16my406"
-                      dir="auto"
-                      style={
-                        Object {
-                          "direction": "ltr",
-                          "fontFamily": "Helvetica, \\"sans-serif\\"",
-                          "fontSize": "18px",
-                          "fontWeight": "bold",
-                          "paddingBottom": "5px",
-                          "paddingLeft": "5px",
-                          "paddingRight": "5px",
-                          "paddingTop": "5px",
-                          "textAlign": "center",
-                          "textTransform": "uppercase",
-                        }
-                      }
-                    >
-                      Copy Link to Clipboard
-                    </span>
-                  </div>
+                    Done
+                  </span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This PR closes #165006138, by:
- Adding `hideBackButton` property to NavBar so we can hide this in certain screens. Can be setted as a statci property
- Updating backRouteName to 'Home'
```
const defaultNavigationConfig = {
     backRouteName: 'Home'
 }
```
- Adding `DoneButton` that redirects to backRouteName
- Fixing `CancelButton` to redirect toRoot 

- Adding `wrapNavigatedComponent` which prevents to load a screen if `shouldNavigateToComponent` function is present in component and returns false. 
This function can be written in every component that needs to prevent access if there is not in a correct navigation flow.
Example: doesn't make sense to navigate to Amount if there is no nextRoutes
```
Amount.shouldNavigateToComponent = props => {
  const { screenState } = props.screenProps
  return !!screenState.nextRoutes
}
```
**Considerations:**
`Done` button is under review by liav

### Slideshow

 
![sendflow](https://user-images.githubusercontent.com/1731297/55686768-af452e80-593b-11e9-88d2-e35f09f8908b.gif)


