### PR TITLE
(Fix) Payment link domain is incorrect

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,7 +1,7 @@
 const Config = {
     "env": process.env.REACT_ENV || "development",
     "serverUrl": process.env.REACT_APP_SERVER_URL || "http://localhost:3003",
-    "publicUrl": process.env.REACT_APP_PUBLIC_URL || "http://localhost:3000",
+    "publicUrl": process.env.REACT_APP_PUBLIC_URL || window && window.location && window.location.origin,
     "infuraKey": process.env.REACT_APP_INFURA_KEY,
     "networkId": process.env.REACT_APP_NETWORK_ID || 42,
     "recaptcha": "6LeOaJIUAAAAAKB3DlmijMPfX2CBYsve3T2MwlTd",


### PR DESCRIPTION
This PR closes [#165496096](https://www.pivotaltracker.com/story/show/165496096), by:
- Removing hardcoded app location and extract it from `window.location` object
  - this will only work on the web. For platform-specific builds, env variable is a must
