### PR TITLE
(Fix) CSSStyleDeclaration error

### DIFF
--- a/src/components/common/Section.js
+++ b/src/components/common/Section.js
@@ -15,7 +15,7 @@ const Title = (props: any) => (
   </Text>
 )
 const SectionText = (props: any) => <Text {...props} style={[styles.text, props.style]} />
-const Separator = (props: any) => <hr {...props} style={[styles.separator, props.style]} />
+const Separator = () => <hr style={{ width: '100%' }} />
 
 export default class Section extends Component<any> {
   static Row = Row
@@ -48,8 +48,5 @@ const styles = StyleSheet.create({
   text: {
     ...fontStyle,
     fontSize: normalize(14)
-  },
-  separator: {
-    width: '100%'
   }
 })

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -488,12 +488,9 @@ exports[`Claim matches snapshot 1`] = `
           </div>
           <hr
             style={
-              Array [
-                Object {
-                  "width": "100%",
-                },
-                undefined,
-              ]
+              Object {
+                "width": "100%",
+              }
             }
           />
           <div


### PR DESCRIPTION
This is an error that we have in `master`, for some reason the app is failing to render `<hr />` element with styleSheet object.

Error: `react-dom.production.min.js:4408 TypeError: Failed to set an indexed property on 'CSSStyleDeclaration': Index property setter is not supported.`

This can be checked by creating a new account and trying to claim GDs.

Just simplified it to make it work.