### PR TITLE
(Bug) Adds label to Next button and uses from Reason page

### DIFF
--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -254,7 +254,8 @@ type NextButtonProps = {
   ...ButtonProps,
   values: {},
   screenProps: { push: (routeName: string, params: any) => void },
-  nextRoutes: [string]
+  nextRoutes: [string],
+  label?: string
 }
 /**
  * NextButton
@@ -262,7 +263,7 @@ type NextButtonProps = {
  * next screens for further Components. Is meant to be used inside a stackNavigator
  * @param {any} props
  */
-export const NextButton = ({ disabled, values, screenProps, nextRoutes: nextRoutesParam }: NextButtonProps) => {
+export const NextButton = ({ disabled, values, screenProps, nextRoutes: nextRoutesParam, label }: NextButtonProps) => {
   const [next, ...nextRoutes] = nextRoutesParam ? nextRoutesParam : []
   return (
     <PushButton
@@ -273,7 +274,7 @@ export const NextButton = ({ disabled, values, screenProps, nextRoutes: nextRout
       routeName={next}
       style={{ flex: 2 }}
     >
-      Next
+      {label || 'Next'}
     </PushButton>
   )
 }

--- a/src/components/dashboard/Reason.js
+++ b/src/components/dashboard/Reason.js
@@ -34,7 +34,12 @@ const SendReason = (props: AmountProps) => {
             <BackButton mode="text" screenProps={screenProps} style={{ flex: 1 }}>
               Cancel
             </BackButton>
-            <NextButton nextRoutes={screenState.nextRoutes} values={{ amount, reason, to }} {...props} />
+            <NextButton
+              nextRoutes={screenState.nextRoutes}
+              values={{ amount, reason, to }}
+              {...props}
+              label={reason ? 'Next' : 'Skip'}
+            />
           </View>
         </Section.Row>
       </Section>

--- a/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
@@ -611,7 +611,7 @@ exports[`Reason matches snapshot 1`] = `
                           }
                         }
                       >
-                        Next
+                        Skip
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
This PR closes #165529511, by:
- Adding different labels to Next button in Reason page according to input value

**Extra:**
- When reason is empty, it shows "SKIP" label
- When reason has a value, it shows "NEXT" label

**Without reason**
![image](https://user-images.githubusercontent.com/4523375/57168745-906e7680-6dd9-11e9-8c20-2dd115072f47.png)

**With reason**
![image](https://user-images.githubusercontent.com/4523375/57168758-995f4800-6dd9-11e9-9a33-667e65809474.png)
