### PR TITLE
(Bug) Fixes styles to make profile clickable

### DIFF
--- a/src/components/common/Avatar.js
+++ b/src/components/common/Avatar.js
@@ -13,7 +13,7 @@ export type AvatarProps = {
 export default (props: AvatarProps) => (
   <View
     onClick={props.onPress}
-    style={props.onPress ? { ...props.style, ...styles.clickable } : { ...props.style, ...styles.avatarView }}
+    style={props.onPress ? [props.style, styles.clickable] : [props.style, styles.avatarView]}
   >
     <Avatar.Image
       size={34}


### PR DESCRIPTION
This PR closes #165762259, by:
- Fixing styles in Dashboard profile content

**Extra:**
- It shows the cursor as clickable when you move mouse over profile image

![image](https://user-images.githubusercontent.com/4523375/57169286-2e634080-6ddc-11e9-87e7-c943d324e1cf.png)
