### PR TITLE
(Bug) Send GD - Error - Balance check should be done earlier

### DIFF
--- a/src/components/appNavigation/__tests__/__snapshots__/stackNavigation.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/stackNavigation.js.snap
@@ -1,0 +1,254 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NextButton matches snapshot 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitBoxFlex": 2,
+      "WebkitBoxPack": "center",
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexGrow": 2,
+      "WebkitFlexShrink": 1,
+      "WebkitJustifyContent": "center",
+      "backgroundColor": "rgba(0,0,0,0.12)",
+      "borderBottomColor": "rgba(0,0,0,0.00)",
+      "borderBottomLeftRadius": "4px",
+      "borderBottomRightRadius": "4px",
+      "borderBottomStyle": "solid",
+      "borderBottomWidth": "0px",
+      "borderLeftColor": "rgba(0,0,0,0.00)",
+      "borderLeftStyle": "solid",
+      "borderLeftWidth": "0px",
+      "borderRightColor": "rgba(0,0,0,0.00)",
+      "borderRightStyle": "solid",
+      "borderRightWidth": "0px",
+      "borderTopColor": "rgba(0,0,0,0.00)",
+      "borderTopLeftRadius": "4px",
+      "borderTopRightRadius": "4px",
+      "borderTopStyle": "solid",
+      "borderTopWidth": "0px",
+      "flexBasis": "0%",
+      "flexGrow": 2,
+      "flexShrink": 1,
+      "justifyContent": "center",
+      "minWidth": "64px",
+      "msFlexNegative": 1,
+      "msFlexPack": "center",
+      "msFlexPositive": 2,
+      "msFlexPreferredSize": "0%",
+    }
+  }
+>
+  <div
+    aria-disabled={true}
+    className="css-view-1dbjc4n"
+    disabled={true}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      Object {
+        "borderBottomLeftRadius": "4px",
+        "borderBottomRightRadius": "4px",
+        "borderTopLeftRadius": "4px",
+        "borderTopRightRadius": "4px",
+        "overflowX": "hidden",
+        "overflowY": "hidden",
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+      style={
+        Object {
+          "WebkitAlignItems": "center",
+          "WebkitBoxAlign": "center",
+          "WebkitBoxDirection": "normal",
+          "WebkitBoxOrient": "horizontal",
+          "WebkitBoxPack": "center",
+          "WebkitFlexDirection": "row",
+          "WebkitJustifyContent": "center",
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "msFlexAlign": "center",
+          "msFlexDirection": "row",
+          "msFlexPack": "center",
+        }
+      }
+    >
+      <div
+        className="css-text-76zvg2 css-textOneLine-bfa6kz"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(0,0,0,0.32)",
+            "direction": "ltr",
+            "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+            "letterSpacing": "1px",
+            "marginBottom": "9px",
+            "marginLeft": "16px",
+            "marginRight": "16px",
+            "marginTop": "9px",
+            "textAlign": "center",
+          }
+        }
+      >
+        <span
+          className="css-text-76zvg2 css-textHasAncestor-16my406"
+          dir="auto"
+          style={
+            Object {
+              "color": "rgba(255,255,255,1.00)",
+              "direction": "ltr",
+              "fontFamily": "Helvetica, \\"sans-serif\\"",
+              "fontSize": "18px",
+              "fontWeight": "bold",
+              "paddingBottom": "5px",
+              "paddingLeft": "5px",
+              "paddingRight": "5px",
+              "paddingTop": "5px",
+              "textAlign": "center",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Next
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PushButton matches snapshot 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitBoxPack": "center",
+      "WebkitJustifyContent": "center",
+      "backgroundColor": "rgba(85,85,85,1.00)",
+      "borderBottomColor": "rgba(0,0,0,0.00)",
+      "borderBottomLeftRadius": "4px",
+      "borderBottomRightRadius": "4px",
+      "borderBottomStyle": "solid",
+      "borderBottomWidth": "0px",
+      "borderLeftColor": "rgba(0,0,0,0.00)",
+      "borderLeftStyle": "solid",
+      "borderLeftWidth": "0px",
+      "borderRightColor": "rgba(0,0,0,0.00)",
+      "borderRightStyle": "solid",
+      "borderRightWidth": "0px",
+      "borderTopColor": "rgba(0,0,0,0.00)",
+      "borderTopLeftRadius": "4px",
+      "borderTopRightRadius": "4px",
+      "borderTopStyle": "solid",
+      "borderTopWidth": "0px",
+      "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
+      "justifyContent": "center",
+      "minWidth": "64px",
+      "msFlexPack": "center",
+    }
+  }
+>
+  <div
+    className="css-cursor-18t94o4 css-view-1dbjc4n"
+    data-focusable={true}
+    disabled={false}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      Object {
+        "borderBottomLeftRadius": "4px",
+        "borderBottomRightRadius": "4px",
+        "borderTopLeftRadius": "4px",
+        "borderTopRightRadius": "4px",
+        "cursor": "pointer",
+        "msTouchAction": "manipulation",
+        "overflowX": "hidden",
+        "overflowY": "hidden",
+        "position": "relative",
+        "touchAction": "manipulation",
+      }
+    }
+    tabIndex="0"
+  >
+    <div
+      className="css-view-1dbjc4n"
+      style={
+        Object {
+          "WebkitAlignItems": "center",
+          "WebkitBoxAlign": "center",
+          "WebkitBoxDirection": "normal",
+          "WebkitBoxOrient": "horizontal",
+          "WebkitBoxPack": "center",
+          "WebkitFlexDirection": "row",
+          "WebkitJustifyContent": "center",
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "msFlexAlign": "center",
+          "msFlexDirection": "row",
+          "msFlexPack": "center",
+        }
+      }
+    >
+      <div
+        className="css-text-76zvg2 css-textOneLine-bfa6kz"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(255,255,255,1.00)",
+            "direction": "ltr",
+            "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+            "letterSpacing": "1px",
+            "marginBottom": "9px",
+            "marginLeft": "16px",
+            "marginRight": "16px",
+            "marginTop": "9px",
+            "textAlign": "center",
+          }
+        }
+      >
+        <span
+          className="css-text-76zvg2 css-textHasAncestor-16my406"
+          dir="auto"
+          style={
+            Object {
+              "color": "rgba(255,255,255,1.00)",
+              "direction": "ltr",
+              "fontFamily": "Helvetica, \\"sans-serif\\"",
+              "fontSize": "18px",
+              "fontWeight": "bold",
+              "paddingBottom": "5px",
+              "paddingLeft": "5px",
+              "paddingRight": "5px",
+              "paddingTop": "5px",
+              "textAlign": "center",
+              "textTransform": "uppercase",
+            }
+          }
+        >
+          Push
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/appNavigation/__tests__/stackNavigation.js
+++ b/src/components/appNavigation/__tests__/stackNavigation.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { PushButton, NextButton } from '../stackNavigation'
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer'
+
+describe('PushButton', () => {
+  it('renders without errors', () => {
+    const tree = renderer.create(<PushButton>Push</PushButton>)
+    expect(tree.toJSON()).toBeTruthy()
+  })
+
+  it('matches snapshot', () => {
+    const component = renderer.create(<PushButton>Push</PushButton>)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('NextButton', () => {
+  it('renders without errors', () => {
+    const tree = renderer.create(<NextButton />)
+    expect(tree.toJSON()).toBeTruthy()
+  })
+
+  it('matches snapshot', () => {
+    const component = renderer.create(<NextButton />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -174,7 +174,8 @@ type PushButtonProps = {
   ...ButtonProps,
   routeName: Route,
   params?: any,
-  screenProps: { push: (routeName: string, params: any) => void }
+  screenProps: { push: (routeName: string, params: any) => void },
+  canContinue?: Function
 }
 
 /**
@@ -185,13 +186,26 @@ type PushButtonProps = {
  * @param params
  * @param {ButtonProps} props
  */
-export const PushButton = ({ routeName, screenProps, params, ...props }: PushButtonProps) => {
-  return <CustomButton {...props} onPress={() => screenProps && screenProps.push(routeName, params)} />
+export const PushButton = ({ routeName, screenProps, canContinue, params, ...props }: PushButtonProps) => {
+  const shouldContinue = async () => {
+    if (canContinue === undefined) return true
+
+    const result = await canContinue()
+    return result
+  }
+
+  return (
+    <CustomButton
+      {...props}
+      onPress={async () => screenProps && (await shouldContinue()) && screenProps.push(routeName, params)}
+    />
+  )
 }
 
 PushButton.defaultProps = {
   mode: 'contained',
-  dark: true
+  dark: true,
+  canContinue: () => true
 }
 
 type BackButtonProps = {
@@ -253,7 +267,8 @@ type NextButtonProps = {
   values: {},
   screenProps: { push: (routeName: string, params: any) => void },
   nextRoutes: [string],
-  label?: string
+  label?: string,
+  canContinue?: Function
 }
 /**
  * NextButton
@@ -261,7 +276,14 @@ type NextButtonProps = {
  * next screens for further Components. Is meant to be used inside a stackNavigator
  * @param {any} props
  */
-export const NextButton = ({ disabled, values, screenProps, nextRoutes: nextRoutesParam, label }: NextButtonProps) => {
+export const NextButton = ({
+  disabled,
+  values,
+  screenProps,
+  nextRoutes: nextRoutesParam,
+  label,
+  canContinue
+}: NextButtonProps) => {
   const [next, ...nextRoutes] = nextRoutesParam ? nextRoutesParam : []
   return (
     <PushButton
@@ -271,6 +293,7 @@ export const NextButton = ({ disabled, values, screenProps, nextRoutes: nextRout
       params={{ ...values, nextRoutes }}
       routeName={next}
       style={{ flex: 2 }}
+      canContinue={canContinue}
     >
       {label || 'Next'}
     </PushButton>

--- a/src/components/common/InputGoodDollar.js
+++ b/src/components/common/InputGoodDollar.js
@@ -10,12 +10,13 @@ type Props = {
 }
 
 const InputGoodDollar = (props: Props) => {
+  const { onChangeWei, ...rest } = props
   return (
     <TextInput
-      {...props}
+      {...rest}
       value={weiToMask(props.wei)}
       onChangeText={text => {
-        props.onChangeWei(maskToWei(text))
+        onChangeWei(maskToWei(text))
       }}
     />
   )

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -386,7 +386,6 @@ exports[`Amount matches snapshot 1`] = `
                       focus="true"
                       onBlur={[Function]}
                       onChange={[Function]}
-                      onChangeWei={[Function]}
                       onFocus={[Function]}
                       onKeyDown={[Function]}
                       onKeyPress={[Function]}

--- a/src/lib/undux/utils/dialog.js
+++ b/src/lib/undux/utils/dialog.js
@@ -1,0 +1,32 @@
+// @flow
+import type { Store } from 'undux'
+import GDStore from '../GDStore'
+import pino from '../../logger/pino-logger'
+const log = pino.child({ from: 'dialogs' })
+
+export const showDialogWithData = (store: Store, dialogData: {}) => {
+  log.debug('showDialogWithData', { dialogData })
+  store.set('currentScreen')({
+    ...store.get('currentScreen'),
+    dialogData: {
+      ...dialogData,
+      visible: true
+    }
+  })
+}
+
+export const hideDialog = (store: Store) => {
+  log.debug('hideDialog')
+
+  store.set('currentScreen')({
+    ...store.get('currentScreen'),
+    dialogData: {
+      visible: false
+    }
+  })
+}
+
+export const useDialog = () => {
+  const store = GDStore.useStore()
+  return [showDialogWithData.bind(null, store), hideDialog.bind(null, store)]
+}

--- a/src/lib/wallet/GoodWallet.js
+++ b/src/lib/wallet/GoodWallet.js
@@ -374,7 +374,7 @@ export class GoodWallet {
 
   async canSend(amount: number): Promise<boolean> {
     const balance = await this.balanceOf()
-    return amount < balance
+    return amount <= balance
   }
 
   async generateLink(amount: number, reason: string = '', events: PromitEvents) {


### PR DESCRIPTION
This PR closes [#165493860](https://www.pivotaltracker.com/story/show/165493860), by:
- Adding a `canSend` check in the `Amount` component
- Adding an error dialog if `canSend` returns false
- Adding `canContinue` function to NextButton and PushButton so it's evaluated before pushing

**Extra:**
- Adding `useDialog` hook to easily show and hide dialogs
- Solved a warning with the `input` field in Amount screen
- Solved a bug that didn't let the user send the exact amount that owns in balance

**Slideshow:**
![amountScreen](https://user-images.githubusercontent.com/1731297/57386271-68409800-718a-11e9-883f-afc2a23673ac.gif)
