### PR TITLE
(Big) User avatar should look clickable only when clickable

### DIFF
--- a/src/components/common/Avatar.js
+++ b/src/components/common/Avatar.js
@@ -11,10 +11,7 @@ export type AvatarProps = {
 }
 
 export default (props: AvatarProps) => (
-  <TouchableOpacity
-    onPress={props.onPress}
-    style={props.onPress ? [props.style, styles.clickable] : [props.style, styles.avatarView]}
-  >
+  <TouchableOpacity onPress={props.onPress} style={props.style} disabled={!props.onPress}>
     <Avatar.Image
       size={34}
       source={props.source ? { uri: props.source } : undefined}
@@ -29,12 +26,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     borderColor: '#707070',
     borderWidth: StyleSheet.hairlineWidth
-  },
-  avatarView: {
-    borderRadius: '50%'
-  },
-  clickable: {
-    borderRadius: '50%',
-    cursor: 'pointer'
   }
 })

--- a/src/components/common/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/components/common/__tests__/__snapshots__/Avatar.js.snap
@@ -2,8 +2,9 @@
 
 exports[`Avatar matches snapshot 1`] = `
 <div
+  aria-disabled={true}
   className="css-view-1dbjc4n"
-  data-focusable={true}
+  disabled={true}
   onKeyDown={[Function]}
   onKeyUp={[Function]}
   onResponderGrant={[Function]}
@@ -19,20 +20,12 @@ exports[`Avatar matches snapshot 1`] = `
       "WebkitTransitionDuration": "0.15s",
       "WebkitTransitionProperty": "opacity",
       "WebkitUserSelect": "none",
-      "borderBottomLeftRadius": "50%",
-      "borderBottomRightRadius": "50%",
-      "borderTopLeftRadius": "50%",
-      "borderTopRightRadius": "50%",
-      "cursor": "pointer",
-      "msTouchAction": "manipulation",
       "msUserSelect": "none",
-      "touchAction": "manipulation",
       "transitionDuration": "0.15s",
       "transitionProperty": "opacity",
       "userSelect": "none",
     }
   }
-  tabIndex="0"
 >
   <div
     className="css-view-1dbjc4n"

--- a/src/components/common/__tests__/__snapshots__/TopBar.js.snap
+++ b/src/components/common/__tests__/__snapshots__/TopBar.js.snap
@@ -39,8 +39,9 @@ exports[`TopBar matches snapshot with balance 1`] = `
     }
   >
     <div
+      aria-disabled={true}
       className="css-view-1dbjc4n"
-      data-focusable={true}
+      disabled={true}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onResponderGrant={[Function]}
@@ -56,20 +57,12 @@ exports[`TopBar matches snapshot with balance 1`] = `
           "WebkitTransitionDuration": "0.15s",
           "WebkitTransitionProperty": "opacity",
           "WebkitUserSelect": "none",
-          "borderBottomLeftRadius": "50%",
-          "borderBottomRightRadius": "50%",
-          "borderTopLeftRadius": "50%",
-          "borderTopRightRadius": "50%",
-          "cursor": "pointer",
-          "msTouchAction": "manipulation",
           "msUserSelect": "none",
-          "touchAction": "manipulation",
           "transitionDuration": "0.15s",
           "transitionProperty": "opacity",
           "userSelect": "none",
         }
       }
-      tabIndex="0"
     >
       <div
         className="css-view-1dbjc4n"
@@ -216,8 +209,9 @@ exports[`TopBar matches snapshot without balance 1`] = `
     }
   >
     <div
+      aria-disabled={true}
       className="css-view-1dbjc4n"
-      data-focusable={true}
+      disabled={true}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onResponderGrant={[Function]}
@@ -233,20 +227,12 @@ exports[`TopBar matches snapshot without balance 1`] = `
           "WebkitTransitionDuration": "0.15s",
           "WebkitTransitionProperty": "opacity",
           "WebkitUserSelect": "none",
-          "borderBottomLeftRadius": "50%",
-          "borderBottomRightRadius": "50%",
-          "borderTopLeftRadius": "50%",
-          "borderTopRightRadius": "50%",
-          "cursor": "pointer",
-          "msTouchAction": "manipulation",
           "msUserSelect": "none",
-          "touchAction": "manipulation",
           "transitionDuration": "0.15s",
           "transitionProperty": "opacity",
           "userSelect": "none",
         }
       }
-      tabIndex="0"
     >
       <div
         className="css-view-1dbjc4n"
@@ -354,8 +340,9 @@ exports[`TopBar should render the children component 1`] = `
     }
   >
     <div
+      aria-disabled={true}
       className="css-view-1dbjc4n"
-      data-focusable={true}
+      disabled={true}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onResponderGrant={[Function]}
@@ -371,20 +358,12 @@ exports[`TopBar should render the children component 1`] = `
           "WebkitTransitionDuration": "0.15s",
           "WebkitTransitionProperty": "opacity",
           "WebkitUserSelect": "none",
-          "borderBottomLeftRadius": "50%",
-          "borderBottomRightRadius": "50%",
-          "borderTopLeftRadius": "50%",
-          "borderTopRightRadius": "50%",
-          "cursor": "pointer",
-          "msTouchAction": "manipulation",
           "msUserSelect": "none",
-          "touchAction": "manipulation",
           "transitionDuration": "0.15s",
           "transitionProperty": "opacity",
           "userSelect": "none",
         }
       }
-      tabIndex="0"
     >
       <div
         className="css-view-1dbjc4n"

--- a/src/components/common/__tests__/__snapshots__/UserAvatar.js.snap
+++ b/src/components/common/__tests__/__snapshots__/UserAvatar.js.snap
@@ -41,8 +41,9 @@ exports[`UserAvatar matches snapshot 1`] = `
     }
   >
     <div
+      aria-disabled={true}
       className="css-view-1dbjc4n"
-      data-focusable={true}
+      disabled={true}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onResponderGrant={[Function]}
@@ -58,20 +59,12 @@ exports[`UserAvatar matches snapshot 1`] = `
           "WebkitTransitionDuration": "0.15s",
           "WebkitTransitionProperty": "opacity",
           "WebkitUserSelect": "none",
-          "borderBottomLeftRadius": "50%",
-          "borderBottomRightRadius": "50%",
-          "borderTopLeftRadius": "50%",
-          "borderTopRightRadius": "50%",
-          "cursor": "pointer",
-          "msTouchAction": "manipulation",
           "msUserSelect": "none",
-          "touchAction": "manipulation",
           "transitionDuration": "0.15s",
           "transitionProperty": "opacity",
           "userSelect": "none",
         }
       }
-      tabIndex="0"
     >
       <div
         className="css-view-1dbjc4n"

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
@@ -210,8 +210,9 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
         }
       >
         <div
+          aria-disabled={true}
           className="css-view-1dbjc4n"
-          data-focusable={true}
+          disabled={true}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onResponderGrant={[Function]}
@@ -228,20 +229,12 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
               "WebkitTransitionProperty": "opacity",
               "WebkitUserSelect": "none",
               "backgroundColor": "rgba(187,187,187,1.00)",
-              "borderBottomLeftRadius": "50%",
-              "borderBottomRightRadius": "50%",
-              "borderTopLeftRadius": "50%",
-              "borderTopRightRadius": "50%",
-              "cursor": "pointer",
-              "msTouchAction": "manipulation",
               "msUserSelect": "none",
-              "touchAction": "manipulation",
               "transitionDuration": "0.15s",
               "transitionProperty": "opacity",
               "userSelect": "none",
             }
           }
-          tabIndex="0"
         >
           <div
             className="css-view-1dbjc4n"
@@ -753,8 +746,9 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
         }
       >
         <div
+          aria-disabled={true}
           className="css-view-1dbjc4n"
-          data-focusable={true}
+          disabled={true}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
           onResponderGrant={[Function]}
@@ -771,20 +765,12 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
               "WebkitTransitionProperty": "opacity",
               "WebkitUserSelect": "none",
               "backgroundColor": "rgba(187,187,187,1.00)",
-              "borderBottomLeftRadius": "50%",
-              "borderBottomRightRadius": "50%",
-              "borderTopLeftRadius": "50%",
-              "borderTopRightRadius": "50%",
-              "cursor": "pointer",
-              "msTouchAction": "manipulation",
               "msUserSelect": "none",
-              "touchAction": "manipulation",
               "transitionDuration": "0.15s",
               "transitionProperty": "opacity",
               "userSelect": "none",
             }
           }
-          tabIndex="0"
         >
           <div
             className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -121,8 +121,9 @@ exports[`Amount matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -138,20 +139,12 @@ exports[`Amount matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -141,8 +141,9 @@ exports[`Claim matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -158,20 +159,12 @@ exports[`Claim matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
@@ -422,6 +422,7 @@ exports[`Dashboard matches snapshot 1`] = `
                     <div
                       className="css-view-1dbjc4n"
                       data-focusable={true}
+                      disabled={false}
                       onKeyDown={[Function]}
                       onKeyUp={[Function]}
                       onResponderGrant={[Function]}
@@ -437,10 +438,6 @@ exports[`Dashboard matches snapshot 1`] = `
                           "WebkitTransitionDuration": "0.15s",
                           "WebkitTransitionProperty": "opacity",
                           "WebkitUserSelect": "none",
-                          "borderBottomLeftRadius": "50%",
-                          "borderBottomRightRadius": "50%",
-                          "borderTopLeftRadius": "50%",
-                          "borderTopRightRadius": "50%",
                           "cursor": "pointer",
                           "msTouchAction": "manipulation",
                           "msUserSelect": "none",

--- a/src/components/dashboard/__tests__/__snapshots__/FeedList.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/FeedList.js.snap
@@ -357,8 +357,9 @@ exports[`FeedList Horizontal rendering With feed data matches snapshot 1`] = `
                   }
                 >
                   <div
+                    aria-disabled={true}
                     className="css-view-1dbjc4n"
-                    data-focusable={true}
+                    disabled={true}
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onResponderGrant={[Function]}
@@ -375,20 +376,12 @@ exports[`FeedList Horizontal rendering With feed data matches snapshot 1`] = `
                         "WebkitTransitionProperty": "opacity",
                         "WebkitUserSelect": "none",
                         "backgroundColor": "rgba(187,187,187,1.00)",
-                        "borderBottomLeftRadius": "50%",
-                        "borderBottomRightRadius": "50%",
-                        "borderTopLeftRadius": "50%",
-                        "borderTopRightRadius": "50%",
-                        "cursor": "pointer",
-                        "msTouchAction": "manipulation",
                         "msUserSelect": "none",
-                        "touchAction": "manipulation",
                         "transitionDuration": "0.15s",
                         "transitionProperty": "opacity",
                         "userSelect": "none",
                       }
                     }
-                    tabIndex="0"
                   >
                     <div
                       className="css-view-1dbjc4n"
@@ -920,8 +913,9 @@ exports[`FeedList Horizontal rendering With feed data matches snapshot 1`] = `
                   }
                 >
                   <div
+                    aria-disabled={true}
                     className="css-view-1dbjc4n"
-                    data-focusable={true}
+                    disabled={true}
                     onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onResponderGrant={[Function]}
@@ -938,20 +932,12 @@ exports[`FeedList Horizontal rendering With feed data matches snapshot 1`] = `
                         "WebkitTransitionProperty": "opacity",
                         "WebkitUserSelect": "none",
                         "backgroundColor": "rgba(187,187,187,1.00)",
-                        "borderBottomLeftRadius": "50%",
-                        "borderBottomRightRadius": "50%",
-                        "borderTopLeftRadius": "50%",
-                        "borderTopRightRadius": "50%",
-                        "cursor": "pointer",
-                        "msTouchAction": "manipulation",
                         "msUserSelect": "none",
-                        "touchAction": "manipulation",
                         "transitionDuration": "0.15s",
                         "transitionProperty": "opacity",
                         "userSelect": "none",
                       }
                     }
-                    tabIndex="0"
                   >
                     <div
                       className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
@@ -121,8 +121,9 @@ exports[`Reason matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -138,20 +139,12 @@ exports[`Reason matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Send.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Send.js.snap
@@ -141,8 +141,9 @@ exports[`Send matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -158,20 +159,12 @@ exports[`Send matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendConfirmation.js.snap
@@ -141,8 +141,9 @@ exports[`SendConfirmation matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -158,20 +159,12 @@ exports[`SendConfirmation matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
@@ -121,8 +121,9 @@ exports[`SendLinkSummary matches snapshot 1`] = `
             }
           >
             <div
+              aria-disabled={true}
               className="css-view-1dbjc4n"
-              data-focusable={true}
+              disabled={true}
               onKeyDown={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
@@ -138,20 +139,12 @@ exports[`SendLinkSummary matches snapshot 1`] = `
                   "WebkitTransitionDuration": "0.15s",
                   "WebkitTransitionProperty": "opacity",
                   "WebkitUserSelect": "none",
-                  "borderBottomLeftRadius": "50%",
-                  "borderBottomRightRadius": "50%",
-                  "borderTopLeftRadius": "50%",
-                  "borderTopRightRadius": "50%",
-                  "cursor": "pointer",
-                  "msTouchAction": "manipulation",
                   "msUserSelect": "none",
-                  "touchAction": "manipulation",
                   "transitionDuration": "0.15s",
                   "transitionProperty": "opacity",
                   "userSelect": "none",
                 }
               }
-              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"
@@ -332,8 +325,9 @@ exports[`SendLinkSummary matches snapshot 1`] = `
               }
             >
               <div
+                aria-disabled={true}
                 className="css-view-1dbjc4n"
-                data-focusable={true}
+                disabled={true}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 onResponderGrant={[Function]}
@@ -350,27 +344,19 @@ exports[`SendLinkSummary matches snapshot 1`] = `
                     "WebkitTransitionProperty": "opacity",
                     "WebkitUserSelect": "none",
                     "borderBottomColor": "rgba(112,112,112,1.00)",
-                    "borderBottomLeftRadius": "50%",
-                    "borderBottomRightRadius": "50%",
                     "borderBottomWidth": "1px",
                     "borderLeftColor": "rgba(112,112,112,1.00)",
                     "borderLeftWidth": "1px",
                     "borderRightColor": "rgba(112,112,112,1.00)",
                     "borderRightWidth": "1px",
                     "borderTopColor": "rgba(112,112,112,1.00)",
-                    "borderTopLeftRadius": "50%",
-                    "borderTopRightRadius": "50%",
                     "borderTopWidth": "1px",
-                    "cursor": "pointer",
-                    "msTouchAction": "manipulation",
                     "msUserSelect": "none",
-                    "touchAction": "manipulation",
                     "transitionDuration": "0.15s",
                     "transitionProperty": "opacity",
                     "userSelect": "none",
                   }
                 }
-                tabIndex="0"
               >
                 <div
                   className="css-view-1dbjc4n"

--- a/src/components/profile/__tests__/__snapshots__/Profile.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/Profile.js.snap
@@ -407,8 +407,9 @@ Array [
                         }
                       >
                         <div
+                          aria-disabled={true}
                           className="css-view-1dbjc4n"
-                          data-focusable={true}
+                          disabled={true}
                           onKeyDown={[Function]}
                           onKeyUp={[Function]}
                           onResponderGrant={[Function]}
@@ -424,20 +425,12 @@ Array [
                               "WebkitTransitionDuration": "0.15s",
                               "WebkitTransitionProperty": "opacity",
                               "WebkitUserSelect": "none",
-                              "borderBottomLeftRadius": "50%",
-                              "borderBottomRightRadius": "50%",
-                              "borderTopLeftRadius": "50%",
-                              "borderTopRightRadius": "50%",
-                              "cursor": "pointer",
-                              "msTouchAction": "manipulation",
                               "msUserSelect": "none",
-                              "touchAction": "manipulation",
                               "transitionDuration": "0.15s",
                               "transitionProperty": "opacity",
                               "userSelect": "none",
                             }
                           }
-                          tabIndex="0"
                         >
                           <div
                             className="css-view-1dbjc4n"


### PR DESCRIPTION
This PR closes [#166091728](https://www.pivotaltracker.com/story/show/166091728), by:

* Adding disabled property to TouchableOpacity id there is no onPress prop.
* Removing unused styles
* Updating snapshots

Slideshow
---

![avatar](https://user-images.githubusercontent.com/1731297/58039658-bc903400-7b09-11e9-8d2b-7317ef4825c7.gif)

