### PR TITLE
(Bug) Adds scroll when phone is too small or keyboard is opened

### DIFF
--- a/src/components/sidemenu/SideMenuPanel.js
+++ b/src/components/sidemenu/SideMenuPanel.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import SideMenuItem from './SideMenuItem'
-import { View, StyleSheet, TouchableOpacity } from 'react-native'
+import { ScrollView, StyleSheet, TouchableOpacity } from 'react-native'
 import { Icon, normalize } from 'react-native-elements'
 import { useSidemenu } from '../../lib/undux/utils/sidemenu'
 import { useWrappedApi } from '../../lib/API/useWrappedApi'
@@ -60,14 +60,14 @@ const SideMenuPanel = ({ navigation }: SideMenuPanelProps) => {
   const [toggleSidemenu, hideSidemenu] = useSidemenu()
   const MENU_ITEMS = getMenuItems({ API, hideSidemenu, navigation })
   return (
-    <View>
+    <ScrollView>
       <TouchableOpacity style={styles.closeIconRow} onPress={toggleSidemenu}>
         <Icon name="close" />
       </TouchableOpacity>
       {MENU_ITEMS.map(item => (
         <SideMenuItem key={item.name} {...item} />
       ))}
-    </View>
+    </ScrollView>
   )
 }
 


### PR DESCRIPTION
# PULL\_REQUEST\_TEMPLATE

This PR closes \#166115171, by:
* Adding ScrollView in Side panel, so if you open with visible keyboard, or a really small mobile, you can scroll across the menu items.

![image](https://user-images.githubusercontent.com/4523375/58122545-401c5480-7be0-11e9-9813-d5baba2c66a8.png)

![image](https://user-images.githubusercontent.com/4523375/58122472-22e78600-7be0-11e9-962d-4164d1afd669.png)

