### PR TITLE
add: restore helmet after navigation chages. check if no crashes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the
@@ -36,13 +36,13 @@
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
     <meta name="theme-color" content="#ffffff" />
-    <title>Good Dollar</title>
+    <title>GoodDollar | UBI</title>
   </head>
   <body>
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    
+
     <div id="root"></div>
     <!--
       This HTML file is a template.
@@ -55,5 +55,4 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>
-  
 </html>

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -205,9 +205,9 @@ class AppView extends Component<AppViewProps, AppViewState> {
     const menu = open ? <SideMenuPanel navigation={navigation} /> : null
     return (
       <React.Fragment>
-        {/* <Helmet>
-          <title>{`Good Dollar | ${pageTitle}`}</title>
-        </Helmet> */}
+        <Helmet>
+          <title>{`GoodDollar | ${pageTitle}`}</title>
+        </Helmet>
         {!navigationBarHidden && <NavBar goBack={backButtonHidden ? undefined : this.pop} title={pageTitle} />}
         <View style={{ backgroundColor: '#fff', flex: 1 }}>
           <SideMenu menu={menu} menuPosition="right" isOpen={store.get('sidemenu').visible}>

--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -116,9 +116,9 @@ class AppSwitch extends React.Component<LoadingProps, {}> {
     const { dialogData } = store.get('currentScreen')
     return (
       <React.Fragment>
-        {/* <Helmet>
-          <title>Good Dollar</title>
-        </Helmet> */}
+        <Helmet>
+          <title>GoodDollar | UBI</title>
+        </Helmet>
 
         <CustomDialog
           {...dialogData}


### PR DESCRIPTION
* Adding .<helmet> to change title
**Extra:**
* It used to crash the app, usually when navigating back or after making transactions/creating payment link.
* some optimizations have been made to the stacknavigator to prevending constant rerendering, it seems to be ok now.

## Please test different scenarios that no crash happens

