### PR TITLE
(Bug) Removing isVerified check from recover account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14797,7 +14797,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -23942,6 +23943,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -23950,7 +23952,8 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -41,22 +41,6 @@ const Mnemonics = props => {
       // We need to try to get a new address using new mnenonics
       await saveMnemonics(mnemonics)
 
-      const wallet = await walletFactory.create(WalletType)
-      const isVerified = await goodWallet.isVerified(wallet.eth.defaultAccount)
-
-      if (!isVerified) {
-        saveMnemonics(prevMnemonics)
-        store.set('currentScreen')({
-          dialogData: {
-            visible: true,
-            title: 'ERROR',
-            message: 'User is not verified',
-            dismissText: 'OK'
-          }
-        })
-        return
-      }
-
       // There is no error. Reload screen to start with users mnemonics
       window.location = '/'
     } catch (err) {


### PR DESCRIPTION
This PR closes [#166222345](https://www.pivotaltracker.com/story/show/166222345), by:

* Removing `isVerified` check from recover account action. 

**Extra:**

Please note that there is no validation about that mnemonic creating any user. In fact, getting mnemonics from localStorage on first use and then use these mnemonics to recover an account (without creating that account) will allow recovering but will prompt the user to register since the mnemonics are valid but no account is founded.
A better approach could use something like this to validate that there is an account but right now is not easy to use since UserStorage creates the wallet on init so we would need a mechanism to reset and that wasn't the idea behind this PR.
```
 const [credsOrError, isCitizen]: any = await Promise.all([goodWalletLogin.auth(), goodWallet.isCitizen()])

 const isLoggedIn = credsOrError.jwt !== undefined && (await userStorage.getProfileField('registered'))

```

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
