### PR TITLE
(Bug) Handling user using different browser on confirm email

### DIFF
--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -82,18 +82,17 @@ class AppSwitch extends React.Component<LoadingProps, {}> {
         return AsyncStorage.removeItem('destinationPath')
       } else this.props.navigation.navigate('AppNavigation')
     } else {
+      if (destDetails && destDetails.params.validation) {
+        log.debug('destinationPath redirecting to email validation')
+        this.props.navigation.navigate(destDetails)
+        return
+      }
       const { jwt } = credsOrError
       if (jwt) {
         log.debug('New account, not verified, or did not finish signup', jwt)
         //for new accounts check if link is email validation if so
         //redirect to continue signup flow
         if (destDetails) {
-          log.debug('destinationPath details found', destDetails)
-          if (destDetails.params.validation) {
-            log.debug('destinationPath redirecting to email validation')
-            this.props.navigation.navigate(destDetails)
-            return
-          }
           log.debug('destinationPath saving details')
           //for non loggedin users, store non email validation params to the destinationPath for later
           //to be used once signed in

--- a/src/components/signup/EmailConfirmationError.js
+++ b/src/components/signup/EmailConfirmationError.js
@@ -1,0 +1,64 @@
+// @flow
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import normalize from 'react-native-elements/src/helpers/normalizeText'
+import logger from '../../lib/logger/pino-logger'
+import { Description, Title, Wrapper } from './components'
+import { isMobileSafari } from 'mobile-device-detect'
+
+type Props = {
+  screenProps: any,
+  navigation: any
+}
+
+const log = logger.child({ from: 'EmailConfirmationError' })
+
+const getBrowserData = () => {
+  const standalone = window.navigator.standalone,
+    userAgent = window.navigator.userAgent.toLowerCase(),
+    safari = /safari/.test(userAgent),
+    ios = /iphone|ipod|ipad/.test(userAgent)
+  return {
+    standalone,
+    safari,
+    ios
+  }
+}
+
+const BrowserSpecificMessage = () => {
+  if (isMobileSafari)
+    return <Description>You can open this link in safari using safari icon on the bottom right</Description>
+  return null
+}
+
+const EmailConfirmationError = ({ navigation, screenProps }: Props) => {
+  return (
+    <>
+      <Wrapper footerComponent={props => null}>
+        <Title style={styles.wrapper}>Email Confirmation Fail</Title>
+        <Description>
+          {
+            'In order to be able to continue with the signup process please open this link in the same browser you start the registration process'
+          }
+        </Description>
+        <BrowserSpecificMessage />
+      </Wrapper>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginTop: normalize(50)
+  },
+  description: {
+    marginBottom: normalize(20),
+    fontSize: normalize(24)
+  },
+  link: {
+    fontSize: normalize(15),
+    opacity: '0.6'
+  }
+})
+
+export default EmailConfirmationError

--- a/src/components/signup/EmailConfirmationError.js
+++ b/src/components/signup/EmailConfirmationError.js
@@ -35,7 +35,7 @@ const EmailConfirmationError = ({ navigation, screenProps }: Props) => {
   return (
     <>
       <Wrapper footerComponent={props => null}>
-        <Title style={styles.wrapper}>Email Confirmation Fail</Title>
+        <Title style={styles.title}>Email Confirmation Fail</Title>
         <Description>
           {
             'In order to be able to continue with the signup process please open this link in the same browser you start the registration process'
@@ -48,16 +48,8 @@ const EmailConfirmationError = ({ navigation, screenProps }: Props) => {
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
+  title: {
     marginTop: normalize(50)
-  },
-  description: {
-    marginBottom: normalize(20),
-    fontSize: normalize(24)
-  },
-  link: {
-    fontSize: normalize(15),
-    opacity: '0.6'
   }
 })
 

--- a/src/components/signup/__tests__/EmailConfirmationError.js
+++ b/src/components/signup/__tests__/EmailConfirmationError.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import EmailConfirmationError from '../EmailConfirmationError'
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer'
+
+describe('Address', () => {
+  it('renders without errors', () => {
+    const tree = renderer.create(<EmailConfirmationError />)
+    expect(tree.toJSON()).toBeTruthy()
+  })
+
+  it('matches snapshot', () => {
+    const component = renderer.create(<EmailConfirmationError />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/signup/__tests__/__snapshots__/EmailConfirmationError.js.snap
+++ b/src/components/signup/__tests__/__snapshots__/EmailConfirmationError.js.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Address matches snapshot 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitAlignItems": "stretch",
+      "WebkitBoxAlign": "stretch",
+      "WebkitBoxDirection": "normal",
+      "WebkitBoxFlex": 1,
+      "WebkitBoxOrient": "vertical",
+      "WebkitBoxPack": "justify",
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexDirection": "column",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "WebkitJustifyContent": "space-between",
+      "alignItems": "stretch",
+      "display": "flex",
+      "flexBasis": "0%",
+      "flexDirection": "column",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "justifyContent": "space-between",
+      "maxWidth": "500px",
+      "msFlexAlign": "stretch",
+      "msFlexDirection": "column",
+      "msFlexNegative": 1,
+      "msFlexPack": "justify",
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
+      "paddingBottom": "20px",
+      "paddingLeft": "20px",
+      "paddingRight": "20px",
+      "paddingTop": "20px",
+    }
+  }
+>
+  <div
+    className="css-view-1dbjc4n"
+    style={
+      Object {
+        "WebkitBoxFlex": 1,
+        "WebkitBoxPack": "space-evenly",
+        "WebkitFlexBasis": "0%",
+        "WebkitFlexGrow": 1,
+        "WebkitFlexShrink": 1,
+        "WebkitJustifyContent": "space-evenly",
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "justifyContent": "space-evenly",
+        "msFlexNegative": 1,
+        "msFlexPack": "space-evenly",
+        "msFlexPositive": 1,
+        "msFlexPreferredSize": "0%",
+        "paddingTop": "30px",
+      }
+    }
+  >
+    <div
+      className="css-text-76zvg2"
+      dir="auto"
+      style={
+        Object {
+          "color": "rgba(85,85,85,1.00)",
+          "direction": "ltr",
+          "fontFamily": "Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+          "fontSize": "24px",
+          "marginBottom": "30px",
+          "marginTop": "50px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Email Confirmation Fail
+    </div>
+    <div
+      className="css-text-76zvg2"
+      dir="auto"
+      style={
+        Object {
+          "color": "rgba(85,85,85,1.00)",
+          "direction": "ltr",
+          "fontFamily": "Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+          "fontSize": "18px",
+          "marginTop": "30px",
+          "textAlign": "center",
+        }
+      }
+    >
+      In order to be able to continue with the signup process please open this link in the same browser you start the registration process
+    </div>
+  </div>
+  <div
+    className="css-view-1dbjc4n"
+    style={
+      Object {
+        "WebkitBoxFlex": 1,
+        "WebkitBoxPack": "end",
+        "WebkitFlexBasis": "0%",
+        "WebkitFlexGrow": 1,
+        "WebkitFlexShrink": 1,
+        "WebkitJustifyContent": "flex-end",
+        "display": "flex",
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "justifyContent": "flex-end",
+        "msFlexNegative": 1,
+        "msFlexPack": "end",
+        "msFlexPositive": 1,
+        "msFlexPreferredSize": "0%",
+        "paddingTop": "20px",
+      }
+    }
+  />
+</div>
+`;

--- a/src/lib/gundb/UserStorage.js
+++ b/src/lib/gundb/UserStorage.js
@@ -835,7 +835,11 @@ export class UserStorage {
   }
 
   getProfile(): Promise<any> {
-    return new Promise(res => {
+    return new Promise(async (res, rej) => {
+      const profile = await this.profile.then()
+      if (!profile) {
+        return rej('User profile not found')
+      }
       this.profile.load(async profile => res(await this.getPrivateProfile(profile)), { wait: 99 })
     })
   }


### PR DESCRIPTION
This PR closes [#166246865](https://www.pivotaltracker.com/story/show/166246865), by:

* Adding an `EmailConfirmationError` component that handles user not opening the confirmation link in the same browser that the process started
* Changing `AppSwitch` navigation flow conditions to avoid redirecting to auth in this case
* Adding `BrowserSpecificMessage`. When opened in safari iOS it shows a more specific message. Seems like user agent for safari being opened on Gmail app and in the actual safari app are the same.
The condition assumes that if we are in iOS safari and users data is not there needs to show this extra message.

**Extra:**

![Screenshot from 2019-05-24 17-09-15](https://user-images.githubusercontent.com/1731297/58355548-16b33100-7e4b-11e9-8f13-fc55985e59ea.png)
![Screenshot from 2019-05-24 17-08-55](https://user-images.githubusercontent.com/1731297/58355549-16b33100-7e4b-11e9-9123-d0d8fa2438d3.png)
![IMG_2682 (1)](https://user-images.githubusercontent.com/1731297/58355580-321e3c00-7e4b-11e9-9a9f-ae11979fcb54.PNG)


<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
