### PR TITLE
add: make email+mobile public to allow inapp sending in alpha

### DIFF
--- a/src/lib/gundb/UserStorage.js
+++ b/src/lib/gundb/UserStorage.js
@@ -428,8 +428,8 @@ export class UserStorage {
 
     const profileSettings = {
       fullName: { defaultPrivacy: 'public' },
-      email: { defaultPrivacy: 'masked' },
-      mobile: { defaultPrivacy: 'masked' },
+      email: { defaultPrivacy: 'public' },
+      mobile: { defaultPrivacy: 'public' },
       avatar: { defaultPrivacy: 'public' },
       walletAddress: { defaultPrivacy: 'public' },
       username: { defaultPrivacy: 'public' }


### PR DESCRIPTION
This PR closes #x, by:

* updating defaults of mobile+email to public

**Extra:**

allow for simpler inapp sending of money for alpha

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
