### PR TITLE
(BUG) Adds some titles and test Helmet re rendering

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,4 +1,4 @@
-import { createNavigator, SwitchRouter } from '@react-navigation/core'
+import { createNavigator, SwitchRouter, getActiveChildNavigationOptions } from '@react-navigation/core'
 import { createBrowserApp } from '@react-navigation/web'
 import { Platform } from 'react-native'
 import Auth from './components/auth/Auth'
@@ -24,7 +24,12 @@ const AppNavigator = createNavigator(
       initialRouteName: 'Splash'
     }
   ),
-  {}
+  {
+    navigationOptions: ({ navigation, screenProps }) => {
+      const options = navigation ? getActiveChildNavigationOptions(navigation, screenProps) : {}
+      return { title: options.title }
+    }
+  }
 )
 let WebRouter
 if (Platform.OS === 'web') {

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,6 +1,7 @@
-import { createNavigator, SwitchRouter, getActiveChildNavigationOptions } from '@react-navigation/core'
+import { createNavigator, SwitchRouter } from '@react-navigation/core'
 import { createBrowserApp } from '@react-navigation/web'
 import { Platform } from 'react-native'
+import { navigationConfig } from './components/appNavigation/navigationConfig'
 import Auth from './components/auth/Auth'
 import Signup from './components/signup/SignupState'
 import SignIn from './components/signin/SignInState'
@@ -22,15 +23,12 @@ const AppNavigator = createNavigator(
     },
     {
       initialRouteName: 'Splash'
-    }
+    },
+    navigationConfig
   ),
-  {
-    navigationOptions: ({ navigation, screenProps }) => {
-      const options = navigation ? getActiveChildNavigationOptions(navigation, screenProps) : {}
-      return { title: options.title }
-    }
-  }
+  navigationConfig
 )
+
 let WebRouter
 if (Platform.OS === 'web') {
   WebRouter = createBrowserApp(AppNavigator)

--- a/src/components/appNavigation/AppNavigation.js
+++ b/src/components/appNavigation/AppNavigation.js
@@ -2,6 +2,7 @@
 import { createSwitchNavigator } from '@react-navigation/core'
 import React from 'react'
 import type { Store } from 'undux'
+import { navigationOptions } from './navigationConfig'
 
 // TODO: Should we do this diferently?
 import homeIcon from '../../assets/homeIcon.png'
@@ -49,5 +50,6 @@ class AppNavigation extends React.Component<AppNavigationProps, AppNavigationSta
 
 const appNavigation = GDStore.withStore(AppNavigation)
 appNavigation.router = AppNavigator.router
+appNavigation.navigationOptions = navigationOptions
 
 export default appNavigation

--- a/src/components/appNavigation/navigationConfig.js
+++ b/src/components/appNavigation/navigationConfig.js
@@ -1,0 +1,13 @@
+import { getActiveChildNavigationOptions } from '@react-navigation/core'
+
+export const navigationOptions = ({ navigation, screenProps }) => {
+  const options = getActiveChildNavigationOptions(navigation, screenProps)
+  const title = options.title
+    ? options.title.indexOf('Good Dollar') > -1
+      ? options.title
+      : `Good Dollar | ${options.title}`
+    : 'Good Dollar'
+  return { title }
+}
+
+export const navigationConfig = { navigationOptions }

--- a/src/components/appNavigation/navigationConfig.js
+++ b/src/components/appNavigation/navigationConfig.js
@@ -3,10 +3,10 @@ import { getActiveChildNavigationOptions } from '@react-navigation/core'
 export const navigationOptions = ({ navigation, screenProps }) => {
   const options = getActiveChildNavigationOptions(navigation, screenProps)
   const title = options.title
-    ? options.title.indexOf('Good Dollar') > -1
+    ? options.title.indexOf('GoodDollar') > -1
       ? options.title
-      : `Good Dollar | ${options.title}`
-    : 'Good Dollar'
+      : `GoodDollar | ${options.title}`
+    : 'GoodDollar'
   return { title }
 }
 

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -4,7 +4,7 @@ import { ScrollView, View } from 'react-native'
 import { Button } from 'react-native-paper'
 import SideMenu from 'react-native-side-menu'
 import { createNavigator, SwitchRouter, SceneView, Route } from '@react-navigation/core'
-import { Helmet } from 'react-helmet'
+import { navigationOptions } from './navigationConfig'
 import GDStore from '../../lib/undux/GDStore'
 import { toggleSidemenu } from '../../lib/undux/utils/sidemenu'
 import SideMenuPanel from '../sidemenu/SideMenuPanel'
@@ -41,7 +41,6 @@ type AppViewState = {
  * Params are passed as initial state for next screen.
  * This navigation actions are being passed via navigationConfig to children components
  */
-
 class AppView extends Component<AppViewProps, AppViewState> {
   state = {
     stack: [],
@@ -74,6 +73,7 @@ class AppView extends Component<AppViewProps, AppViewState> {
     }
     return Component
   }
+
   /**
    * Pops from stack
    * If there is no screen on the stack navigates to initial screen on stack (goToRoot)
@@ -206,9 +206,6 @@ class AppView extends Component<AppViewProps, AppViewState> {
     const menu = open ? <SideMenuPanel navigation={navigation} /> : null
     return (
       <React.Fragment>
-        <Helmet>
-          <title>{`GoodDollar | ${pageTitle}`}</title>
-        </Helmet>
         {!navigationBarHidden && <NavBar goBack={backButtonHidden ? undefined : this.pop} title={pageTitle} />}
         <View style={{ backgroundColor: '#fff', flex: 1 }}>
           <SideMenu menu={menu} menuPosition="right" isOpen={store.get('sidemenu').visible}>
@@ -235,7 +232,8 @@ export const createStackNavigator = (routes: any, navigationConfig: any) => {
 
   return createNavigator(GDStore.withStore(AppView), SwitchRouter(routes), {
     ...defaultNavigationConfig,
-    ...navigationConfig
+    ...navigationConfig,
+    navigationOptions
   })
 }
 
@@ -340,6 +338,7 @@ type NextButtonProps = {
   label?: string,
   canContinue?: Function
 }
+
 /**
  * NextButton
  * This button gets the nextRoutes param and creates a Push to the next screen and passes the rest of the array which are

--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -55,6 +55,7 @@ class AppView extends Component<AppViewProps, AppViewState> {
   shouldComponentUpdate() {
     return this.trans === false
   }
+
   /**
    * getComponent gets the component and props and returns the same component except when
    * shouldNavigateToComponent is present in component and not complaining
@@ -205,9 +206,9 @@ class AppView extends Component<AppViewProps, AppViewState> {
     const menu = open ? <SideMenuPanel navigation={navigation} /> : null
     return (
       <React.Fragment>
-        {/* <Helmet>
+        <Helmet>
           <title>{`GoodDollar | ${pageTitle}`}</title>
-        </Helmet> */}
+        </Helmet>
         {!navigationBarHidden && <NavBar goBack={backButtonHidden ? undefined : this.pop} title={pageTitle} />}
         <View style={{ backgroundColor: '#fff', flex: 1 }}>
           <SideMenu menu={menu} menuPosition="right" isOpen={store.get('sidemenu').visible}>

--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -3,7 +3,6 @@ import React from 'react'
 import { AsyncStorage } from 'react-native'
 import { SceneView } from '@react-navigation/core'
 import some from 'lodash/some'
-import { Helmet } from 'react-helmet'
 import logger from '../../lib/logger/pino-logger'
 import API from '../../lib/API/api'
 import GDStore from '../../lib/undux/GDStore'
@@ -120,10 +119,6 @@ class AppSwitch extends React.Component<LoadingProps, {}> {
     const { dialogData } = store.get('currentScreen')
     return (
       <React.Fragment>
-        {/* <Helmet>
-          <title>GoodDollar | UBI</title>
-        </Helmet> */}
-
         <CustomDialog
           {...dialogData}
           onDismiss={(...args) => {

--- a/src/components/auth/Auth.js
+++ b/src/components/auth/Auth.js
@@ -21,10 +21,6 @@ type Props = {
 const log = logger.child({ from: 'Auth' })
 
 class Auth extends React.Component<Props> {
-  static navigationOptions = {
-    navigationBarHidden: true
-  }
-
   handleSignUp = () => {
     this.props.navigation.navigate('Signup')
     //Hack to get keyboard up on mobile need focus from user event such as click
@@ -76,6 +72,11 @@ class Auth extends React.Component<Props> {
       </View>
     )
   }
+}
+
+Auth.navigationOptions = {
+  title: 'Auth',
+  navigationBarHidden: true
 }
 
 const styles = StyleSheet.create({

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -101,6 +101,8 @@ const styles = StyleSheet.create({
 })
 
 const claim = GDStore.withStore(Claim)
-claim.navigationOptions = { title: 'Claim G$' }
+claim.navigationOptions = {
+  title: 'Claim G$'
+}
 
 export default claim

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -267,7 +267,8 @@ const styles = StyleSheet.create({
 const dashboard = GDStore.withStore(Dashboard)
 
 dashboard.navigationOptions = {
-  navigationBarHidden: true
+  navigationBarHidden: true,
+  title: 'Home'
 }
 
 export default createStackNavigator({

--- a/src/components/dashboard/__tests__/__util__/index.js
+++ b/src/components/dashboard/__tests__/__util__/index.js
@@ -26,6 +26,7 @@ export const getWebRouterComponentWithRoutes = routes => {
   const AppNavigator = createSwitchNavigator(routes)
   class AppNavigation extends React.Component<AppNavigationProps, AppNavigationState> {
     static router = AppNavigator.router
+    static navigationOptions = AppNavigator.navigationOptions
 
     render() {
       return <AppNavigator navigation={this.props.navigation} screenProps={{ routes }} />

--- a/src/components/profile/EditProfile.web.js
+++ b/src/components/profile/EditProfile.web.js
@@ -7,7 +7,8 @@ import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
 import ProfileDataTable from './ProfileDataTable'
 
-const log = logger.child({ from: 'EditProfile' })
+const TITLE = 'Edit profile'
+const log = logger.child({ from: TITLE })
 
 const EditProfile = props => {
   const store = GDStore.useStore()
@@ -55,6 +56,10 @@ const EditProfile = props => {
       </Section>
     </Wrapper>
   )
+}
+
+EditProfile.navigationOptions = {
+  title: TITLE
 }
 
 const styles = StyleSheet.create({

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -8,7 +8,8 @@ import GDStore from '../../lib/undux/GDStore'
 import EditProfile from './EditProfile'
 import ProfileDataTable from './ProfileDataTable'
 
-const log = logger.child({ from: 'Profile' })
+const TITLE = 'Profile'
+const log = logger.child({ from: TITLE })
 
 const EditIcon = props => <IconButton {...props} wrapperStyle={styles.iconRight} name="edit" />
 const PrivateIcon = props => <IconButton {...props} wrapperStyle={styles.iconLeft} name="visibility" />
@@ -35,6 +36,11 @@ const Profile = props => {
     </Wrapper>
   )
 }
+
+Profile.navigationOptions = {
+  title: TITLE
+}
+
 const styles = StyleSheet.create({
   centered: {
     justifyContent: 'center',

--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -13,7 +13,8 @@ import logger from '../../lib/logger/pino-logger'
 import MnemonicInput from './MnemonicInput'
 import { CustomButton } from '../common'
 
-const log = logger.child({ from: 'Mnemonics' })
+const TITLE = 'Recover my wallet'
+const log = logger.child({ from: TITLE })
 
 const Mnemonics = props => {
   const [mnemonics, setMnemonics] = useState()
@@ -24,7 +25,6 @@ const Mnemonics = props => {
     setMnemonics(mnemonics.join(' '))
   }
   const recover = async () => {
-    log.info('Mnemonics', mnemonics)
     if (!mnemonics || !bip39.validateMnemonic(mnemonics)) {
       store.set('currentScreen')({
         dialogData: {
@@ -55,7 +55,6 @@ const Mnemonics = props => {
         <View style={styles.textContainer}>
           <Paragraph style={[styles.fontBase, styles.paragraph]}>Please enter your 12-word passphrase:</Paragraph>
         </View>
-
         <View style={styles.formContainer}>
           <MnemonicInput onChange={handleChange} />
         </View>
@@ -67,6 +66,10 @@ const Mnemonics = props => {
       </View>
     </View>
   )
+}
+
+Mnemonics.navigationOptions = {
+  title: TITLE
 }
 
 const styles = StyleSheet.create({

--- a/src/components/signup/NameForm.js
+++ b/src/components/signup/NameForm.js
@@ -80,4 +80,9 @@ class NameForm extends React.Component<Props, State> {
   }
 }
 
-export default GDStore.withStore(NameForm)
+const nameForm = GDStore.withStore(NameForm)
+nameForm.navigationOptions = {
+  title: 'Name'
+}
+
+export default nameForm

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -184,7 +184,12 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
     </View>
   )
 }
+
 Signup.router = SignupWizardNavigator.router
+Signup.navigationOptions = {
+  title: 'Sign up'
+}
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
   contentContainer: { justifyContent: 'center', flexDirection: 'row', flex: 1 }

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -11,6 +11,7 @@ import NavBar from '../appNavigation/NavBar'
 import { scrollableContainer } from '../common/styles'
 
 import { createSwitchNavigator } from '@react-navigation/core'
+import { navigationConfig } from '../appNavigation/navigationConfig'
 import logger from '../../lib/logger/pino-logger'
 
 import { useWrappedApi } from '../../lib/API/useWrappedApi'
@@ -24,14 +25,17 @@ const log = logger.child({ from: 'SignupState' })
 
 export type SignupState = UserModel & SMSRecord
 
-const SignupWizardNavigator = createSwitchNavigator({
-  Name: NameForm,
-  Phone: PhoneForm,
-  SMS: SmsForm,
-  Email: EmailForm,
-  EmailConfirmation,
-  SignupCompleted
-})
+const SignupWizardNavigator = createSwitchNavigator(
+  {
+    Name: NameForm,
+    Phone: PhoneForm,
+    SMS: SmsForm,
+    Email: EmailForm,
+    EmailConfirmation,
+    SignupCompleted
+  },
+  navigationConfig
+)
 
 declare var amplitude
 const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any }) => {
@@ -186,9 +190,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
 }
 
 Signup.router = SignupWizardNavigator.router
-Signup.navigationOptions = {
-  title: 'Sign up'
-}
+Signup.navigationOptions = SignupWizardNavigator.navigationOptions
 
 const styles = StyleSheet.create({
   container: { flex: 1 },

--- a/src/components/splash/Splash.js
+++ b/src/components/splash/Splash.js
@@ -17,6 +17,10 @@ class Splash extends Component {
   }
 }
 
+Splash.navigationOptions = {
+  title: 'Good Dollar | Welcome'
+}
+
 const styles = StyleSheet.create({
   logo: {
     minWidth: 212,

--- a/src/components/splash/Splash.js
+++ b/src/components/splash/Splash.js
@@ -18,7 +18,7 @@ class Splash extends Component {
 }
 
 Splash.navigationOptions = {
-  title: 'Good Dollar | Welcome'
+  title: 'GoodDollar | Welcome'
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
This PR closes #166067909, by:

• Adding title in some pages
• Adding react-helmet to set document title

Comments:
- Apparently there is something overriding the title, so it's necessary to use Helmet to show the title correctly. I couldn't find where is the component which set title with undefined...but I tried different options to set the title, and they didn't work.

1. I tried with 
```jsx
componentDidUpdate() {
    const { descriptors, navigation } = this.props
    const activeKey = navigation.state.routes[navigation.state.index].key
    const pageTitle = descriptors[activeKey].options.title || activeKey
    document.title = `GoodDollar | ${pageTitle}`
    log.info(pageTitle)
  }
```
and the logs show pageTitle is correct, but tab title is undefined on navigate.

2. Either I tried with react-document-title, and it has the same behaviour previous implementation.
3. Also I tried directly on render to set document.title and same problem.
4. I added on Router the navigationOptions proposed by react-navigation https://github.com/react-navigation/web-server-example/blob/master/src/App.js
```jsx
{
    navigationOptions: ({ navigation, screenProps }) => {
      const options = navigation ? getActiveChildNavigationOptions(navigation, screenProps) : {}
      return { title: options.title }
    }
  }
```
But it didn't work