### PR TITLE
Fixing default url gunserver

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -2,7 +2,7 @@ const Config = {
   env: process.env.REACT_ENV || 'development',
   logLevel: process.env.REACT_APP_LOG_LEVEL || 'debug',
   serverUrl: process.env.REACT_APP_SERVER_URL || 'http://localhost:3003',
-  gunPublicUrl: process.env.REACT_APP_GUN_PUBLIC_URL || 'http://localhost:3003',
+  gunPublicUrl: process.env.REACT_APP_GUN_PUBLIC_URL || 'http://localhost:3003/gun',
   publicUrl: process.env.REACT_APP_PUBLIC_URL || (window && window.location && window.location.origin),
   infuraKey: process.env.REACT_APP_INFURA_KEY,
   network: process.env.REACT_APP_NETWORK || 'fuse',


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#166445617](https://www.pivotaltracker.com/story/show/166445617), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Fixing `.env.dev` file gun server config 
