### PR TITLE
(Fix) `claim` feed event creation on Claim screen

### DIFF
--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -105,18 +105,8 @@ const Claim = ({ screenProps }: ClaimProps) => {
       dismissText: 'OK'
     })
 
-    const success = setTimeout(() => {
-      setLoading(false)
-
-      showDialog({
-        title: 'SUCCESS!',
-        message: `You've claimed your G$`,
-        dismissText: 'Yay!'
-      })
-    }, 3000)
-
     try {
-      await goodWallet.claim({
+      const receipt = await goodWallet.claim({
         onTransactionHash: async hash => {
           const entitlement = await wrappedGoodWallet.checkEntitlement()
           const transactionEvent: TransactionEvent = {
@@ -131,17 +121,30 @@ const Claim = ({ screenProps }: ClaimProps) => {
           userStorage.enqueueTX(transactionEvent)
         }
       })
+
+      if (receipt.status) {
+        showDialog({
+          title: 'SUCCESS!',
+          message: `You've claimed your G$`,
+          dismissText: 'Yay!'
+        })
+      } else {
+        showDialog({
+          title: 'Caliming Failed',
+          message: 'Something went wrong with the transaction.\nSee feed details for further information.',
+          dismissText: 'OK'
+        })
+      }
     } catch (e) {
       log.error('claiming failed', e)
-
-      clearTimeout(success)
-      setLoading(false)
 
       showDialog({
         title: 'Claiming Failed',
         message: `${e.message}.\nTry again later.`,
         dismissText: 'OK'
       })
+    } finally {
+      setLoading(false)
     }
   }
 

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from 'react'
 import { Image, StyleSheet } from 'react-native'
 import normalize from 'react-native-elements/src/helpers/normalizeText'
 import illustration from '../../assets/Claim/illustration.png'
+import userStorage, { type TransactionEvent } from '../../lib/gundb/UserStorage'
+import goodWallet from '../../lib/wallet/GoodWallet'
 import logger from '../../lib/logger/pino-logger'
 import GDStore from '../../lib/undux/GDStore'
 import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import wrapper from '../../lib/undux/utils/wrapper'
-import goodWallet from '../../lib/wallet/GoodWallet'
 import { weiToMask } from '../../lib/wallet/utils'
 import { CustomButton, Section, Text, TopBar, Wrapper } from '../common'
 import type { DashboardProps } from './Dashboard'
@@ -115,7 +116,21 @@ const Claim = ({ screenProps }: ClaimProps) => {
     }, 3000)
 
     try {
-      await goodWallet.claim()
+      await goodWallet.claim({
+        onTransactionHash: async hash => {
+          const entitlement = await wrappedGoodWallet.checkEntitlement()
+          const transactionEvent: TransactionEvent = {
+            id: hash,
+            date: new Date().toString(),
+            type: 'claim',
+            data: {
+              from: 'GoodDollar',
+              amount: entitlement
+            }
+          }
+          userStorage.enqueueTX(transactionEvent)
+        }
+      })
     } catch (e) {
       log.error('claiming failed', e)
 

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -3,13 +3,12 @@ import React, { useEffect, useState } from 'react'
 import { Image, StyleSheet } from 'react-native'
 import normalize from 'react-native-elements/src/helpers/normalizeText'
 import illustration from '../../assets/Claim/illustration.png'
-import userStorage, { type TransactionEvent } from '../../lib/gundb/UserStorage'
-import goodWallet from '../../lib/wallet/GoodWallet'
 import logger from '../../lib/logger/pino-logger'
 import GDStore from '../../lib/undux/GDStore'
 import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import wrapper from '../../lib/undux/utils/wrapper'
+import goodWallet from '../../lib/wallet/GoodWallet'
 import { weiToMask } from '../../lib/wallet/utils'
 import { CustomButton, Section, Text, TopBar, Wrapper } from '../common'
 import type { DashboardProps } from './Dashboard'
@@ -116,21 +115,7 @@ const Claim = ({ screenProps }: ClaimProps) => {
     }, 3000)
 
     try {
-      await goodWallet.claim({
-        onTransactionHash: async hash => {
-          const entitlement = await wrappedGoodWallet.checkEntitlement()
-          const transactionEvent: TransactionEvent = {
-            id: hash,
-            date: new Date().toString(),
-            type: 'claim',
-            data: {
-              from: 'GoodDollar',
-              amount: entitlement
-            }
-          }
-          userStorage.enqueueTX(transactionEvent)
-        }
-      })
+      await goodWallet.claim()
     } catch (e) {
       log.error('claiming failed', e)
 


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#166905157](https://www.pivotaltracker.com/story/show/166905157), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* ~Removing 'claim' feed event creation, on claiming.~ See comment: https://www.pivotaltracker.com/story/show/166905157/comments/204346394
* After further discussion with Hadar, the expected behavior is to wait for the Claim tx to finish before giving feedback to the user.
* Current flow:
  * Trigger claim.
  * If the call to claim fails, display error caught.
  * Wait for the call to claim promise response.
  * If `receipt.status` received from promise response is valid, display successful message.
  * If `receipt.status` received from promise response is invalid, display error message.

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
