### PR TITLE
Edit Profile Should Refresh Errors onChange

### DIFF
--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { useEffect, useState } from 'react'
+import debounce from 'lodash/debounce'
 import { useWrappedUserStorage } from '../../lib/gundb/useWrappedStorage'
 import logger from '../../lib/logger/pino-logger'
 import GDStore from '../../lib/undux/GDStore'
@@ -27,7 +28,7 @@ const EditProfile = ({ screenProps, theme, styles }) => {
     setProfile(storedProfile)
   }, [storedProfile])
 
-  const validate = async () => {
+  const validate = debounce(async () => {
     log.info({ validate: profile })
     if (profile && profile.validate) {
       const { isValid, errors } = profile.validate()
@@ -37,7 +38,7 @@ const EditProfile = ({ screenProps, theme, styles }) => {
       return isValid && indexIsValid
     }
     return false
-  }
+  }, 500)
 
   const handleProfileChange = newProfile => {
     if (saving) {


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167246391](https://www.pivotaltracker.com/story/show/167246391), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Adding `debounce` to `validate` function

**Extra:**
There is no different behavior but now there are fewer calls to validate function and is consistent with how Signup flow works

**Video:**

![profileErrors](https://user-images.githubusercontent.com/1731297/61957868-96b65e00-af96-11e9-83a6-f5b83af2be0b.gif)


<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
