### PR TITLE
fix: remove unrequired init of wallet+storage and use await on ready

### DIFF
--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -70,12 +70,9 @@ const Mnemonics = ({ navigation, styles }) => {
       import('../../lib/gundb/UserStorageClass').then(_ => _.UserStorage),
     ])
     const wallet = new Wallet({ mnemonic: mnemonics })
-    await wallet.init()
+    await wallet.ready
     const userStorage = new UserStorage(wallet)
-
-    // reinstantiates wallet and userStorage with new mnemonics
-    await userStorage.init()
-
+    await userStorage.ready
     return userStorage.userAlreadyExist()
   }
 


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes #295 
<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* fixing duplicate call to init which is called on wallet+storage constructor


<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
