### PR TITLE
Adding `redirect` to Recover Account Screen

### DIFF
--- a/src/components/dashboard/FaceRecognition/UnsupportedDevice.js
+++ b/src/components/dashboard/FaceRecognition/UnsupportedDevice.js
@@ -41,7 +41,9 @@ const UnsupportedDevice = props => {
 
   const generateQRCode = async () => {
     const mnemonic = await AsyncStorage.getItem('GD_USER_MNEMONIC')
-    const url = `${Config.publicUrl}/Auth/Recover/?mnemonic=${mnemonic}`
+    const url = `${Config.publicUrl}/Auth/Recover/?mnemonic=${mnemonic}&redirect=${encodeURI(
+      '/AppNavigation/Dashboard/FRIntro'
+    )}`
     const code = encodeURI(url)
     log.debug({ code })
     setCode(code)

--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -46,9 +46,10 @@ const Mnemonics = ({ navigation, styles }) => {
 
       if (profile) {
         await AsyncStorage.setItem('GOODDAPP_isLoggedIn', true)
+        const incomingRedirectUrl = get(navigation, 'state.params.redirect', '/')
 
         // There is no error and Profile exists. Reload screen to start with users mnemonics
-        window.location = '/'
+        window.location = incomingRedirectUrl
       } else {
         await saveMnemonics(prevMnemonics)
         showErrorDialog("Mnemonic doesn't match any existing account.")


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167608302](https://www.pivotaltracker.com/story/show/167608302), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Adding redirect parameter to link in `UnsuportedDevice` screen
* Handling recover url in `Recover` screen