### PR TITLE
(Bug) Fixes back action on Profile privacy page when opening from side menu

### DIFF
--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -84,6 +84,15 @@ class AppView extends Component<AppViewProps, AppViewState> {
   pop = (params?: any) => {
     const { navigation } = this.props
 
+    const currentParams = navigation.state.routes[navigation.state.index].params
+    if (currentParams && currentParams.backPage) {
+      this.setState({ currentState: {}, stack: [] }, () => {
+        navigation.navigate(currentParams.backPage, currentParams.navigationParams)
+        this.trans = false
+      })
+      return
+    }
+
     const nextRoute = this.state.stack.pop()
     if (nextRoute) {
       this.trans = true

--- a/src/components/sidemenu/SideMenuPanel.js
+++ b/src/components/sidemenu/SideMenuPanel.js
@@ -46,6 +46,9 @@ const getMenuItems = ({ API, hideSidemenu, showDialog, hideDialog, navigation, s
       navigation.navigate({
         routeName: 'ProfilePrivacy',
         type: 'Navigation/NAVIGATE',
+        params: {
+          backPage: 'Dashboard',
+        },
       })
       hideSidemenu()
     },


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167276594](https://www.pivotaltracker.com/story/show/167276594), by:

* Adding params to the url to specify where should navigate back if it's necessary
