### PR TITLE
(Bug) Showing Error Dialog on catch executeWithdraw

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -6,7 +6,7 @@ import normalize from '../../lib/utils/normalizeText'
 
 import GDStore from '../../lib/undux/GDStore'
 import SimpleStore from '../../lib/undux/SimpleStore'
-import { useDialog } from '../../lib/undux/utils/dialog'
+import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { getInitialFeed, getNextFeed, PAGE_SIZE } from '../../lib/undux/utils/feed'
 import { executeWithdraw } from '../../lib/undux/utils/withdraw'
 import { weiToMask } from '../../lib/wallet/utils'
@@ -57,6 +57,7 @@ const Dashboard = props => {
   const store = SimpleStore.useStore()
   const gdstore = GDStore.useStore()
   const [showDialog, hideDialog] = useDialog()
+  const [showErrorDialog] = useErrorDialog()
   const [state: DashboardState, setState] = useState({
     currentFeed: null,
     feeds: [],
@@ -119,7 +120,7 @@ const Dashboard = props => {
       await executeWithdraw(store, paymentCode, reason)
       hideDialog()
     } catch (e) {
-      showDialog({ title: 'Error', message: e.message })
+      showErrorDialog(e)
     }
   }
 

--- a/src/components/dashboard/ReceiveByQR.web.js
+++ b/src/components/dashboard/ReceiveByQR.web.js
@@ -7,6 +7,7 @@ import { extractQueryParams, readReceiveLink } from '../../lib/share'
 import SimpleStore from '../../lib/undux/SimpleStore'
 import { wrapFunction } from '../../lib/undux/utils/wrapper'
 import { executeWithdraw } from '../../lib/undux/utils/withdraw'
+import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 
@@ -18,6 +19,8 @@ const ReceiveByQR = ({ screenProps }) => {
   const [qrDelay, setQRDelay] = useState(QR_DEFAULT_DELAY)
   const [withdrawParams, setWithdrawParams] = useState({ receiveLink: '', reason: '' })
   const store = SimpleStore.useStore()
+  const [showDialog] = useDialog()
+  const [showErrorDialog] = useErrorDialog()
 
   const onDismissDialog = () => setQRDelay(QR_DEFAULT_DELAY)
 
@@ -31,25 +34,19 @@ const ReceiveByQR = ({ screenProps }) => {
         log.debug({ url })
 
         if (url === null) {
-          store.set('currentScreen')({
-            dialogData: {
-              visible: true,
-              title: 'Error',
-              message: 'Invalid QR Code. Probably this QR code is for sending GD',
-              dismissText: 'Ok',
-            },
+          showDialog({
+            title: 'Error',
+            message: 'Invalid QR Code. Probably this QR code is for sending GD',
+            dismissText: 'Ok',
           })
         } else {
           const { receiveLink, reason } = extractQueryParams(url)
 
           if (!receiveLink) {
-            store.set('currentScreen')({
-              dialogData: {
-                visible: true,
-                title: 'Error',
-                message: 'Invalid QR Code. Probably this QR code is for sending GD',
-                dismissText: 'Ok',
-              },
+            showDialog({
+              title: 'Error',
+              message: 'Invalid QR Code. Probably this QR code is for sending GD',
+              dismissText: 'Ok',
             })
           }
 
@@ -65,12 +62,16 @@ const ReceiveByQR = ({ screenProps }) => {
 
   const runWithdraw = async () => {
     if (withdrawParams.receiveLink) {
-      const receipt = await executeWithdraw(store, withdrawParams.receiveLink)
-      screenProps.navigateTo('Home', {
-        event: receipt.transactionHash,
-        receiveLink: undefined,
-        reason: undefined,
-      })
+      try {
+        const receipt = await executeWithdraw(store, withdrawParams.receiveLink)
+        screenProps.navigateTo('Home', {
+          event: receipt.transactionHash,
+          receiveLink: undefined,
+          reason: undefined,
+        })
+      } catch (e) {
+        showErrorDialog(e)
+      }
     }
   }
 

--- a/src/components/dashboard/ReceiveByQR.web.js
+++ b/src/components/dashboard/ReceiveByQR.web.js
@@ -7,7 +7,7 @@ import { extractQueryParams, readReceiveLink } from '../../lib/share'
 import SimpleStore from '../../lib/undux/SimpleStore'
 import { wrapFunction } from '../../lib/undux/utils/wrapper'
 import { executeWithdraw } from '../../lib/undux/utils/withdraw'
-import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
+import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import { Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 
@@ -19,7 +19,6 @@ const ReceiveByQR = ({ screenProps }) => {
   const [qrDelay, setQRDelay] = useState(QR_DEFAULT_DELAY)
   const [withdrawParams, setWithdrawParams] = useState({ receiveLink: '', reason: '' })
   const store = SimpleStore.useStore()
-  const [showDialog] = useDialog()
   const [showErrorDialog] = useErrorDialog()
 
   const onDismissDialog = () => setQRDelay(QR_DEFAULT_DELAY)
@@ -34,22 +33,12 @@ const ReceiveByQR = ({ screenProps }) => {
         log.debug({ url })
 
         if (url === null) {
-          showDialog({
-            title: 'Error',
-            message: 'Invalid QR Code. Probably this QR code is for sending GD',
-            dismissText: 'Ok',
-            type: 'error',
-          })
+          showErrorDialog('Invalid QR Code. Probably this QR code is for sending GD')
         } else {
           const { receiveLink, reason } = extractQueryParams(url)
 
           if (!receiveLink) {
-            showDialog({
-              title: 'Error',
-              message: 'Invalid QR Code. Probably this QR code is for sending GD',
-              dismissText: 'Ok',
-              type: 'error',
-            })
+            showErrorDialog('Invalid QR Code. Probably this QR code is for sending GD')
           }
 
           setWithdrawParams({ receiveLink, reason })

--- a/src/components/dashboard/ReceiveByQR.web.js
+++ b/src/components/dashboard/ReceiveByQR.web.js
@@ -38,6 +38,7 @@ const ReceiveByQR = ({ screenProps }) => {
             title: 'Error',
             message: 'Invalid QR Code. Probably this QR code is for sending GD',
             dismissText: 'Ok',
+            type: 'error',
           })
         } else {
           const { receiveLink, reason } = extractQueryParams(url)
@@ -47,6 +48,7 @@ const ReceiveByQR = ({ screenProps }) => {
               title: 'Error',
               message: 'Invalid QR Code. Probably this QR code is for sending GD',
               dismissText: 'Ok',
+              type: 'error',
             })
           }
 

--- a/src/lib/undux/utils/__tests__/dialog.js
+++ b/src/lib/undux/utils/__tests__/dialog.js
@@ -69,7 +69,13 @@ describe('Dialog', () => {
     }
     showDialogForError(store, 'human readable', error)
     expect(store.get('currentScreen')).toEqual({
-      dialogData: { visible: true, title: 'Error', message: `human readable\n${message}`, dismissText: 'OK' },
+      dialogData: {
+        visible: true,
+        title: 'Error',
+        message: `human readable\n${message}`,
+        dismissText: 'OK',
+        type: 'error',
+      },
     })
   })
 
@@ -81,7 +87,13 @@ describe('Dialog', () => {
     }
     showDialogForError(store, 'human readable', error)
     expect(store.get('currentScreen')).toEqual({
-      dialogData: { visible: true, title: 'Error', message: `human readable\n${err}`, dismissText: 'OK' },
+      dialogData: {
+        visible: true,
+        title: 'Error',
+        message: `human readable\n${err}`,
+        dismissText: 'OK',
+        type: 'error',
+      },
     })
   })
 
@@ -97,7 +109,13 @@ describe('Dialog', () => {
     }
     showDialogForError(store, 'human readable', error)
     expect(store.get('currentScreen')).toEqual({
-      dialogData: { visible: true, title: 'Error', message: `human readable\n${message}`, dismissText: 'OK' },
+      dialogData: {
+        visible: true,
+        title: 'Error',
+        message: `human readable\n${message}`,
+        dismissText: 'OK',
+        type: 'error',
+      },
     })
   })
 })

--- a/src/lib/undux/utils/dialog.js
+++ b/src/lib/undux/utils/dialog.js
@@ -26,7 +26,7 @@ export const showDialogForError = (store: Store, humanError: string, error: Erro
   }
 
   message = humanError ? humanError + '\n' + message : message
-  const dialogData = { visible: true, title: 'Error', message, dismissText: 'OK' }
+  const dialogData = { visible: true, title: 'Error', message, dismissText: 'OK', type: 'error' }
   showDialogWithData(store, dialogData)
 }
 


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167416858](https://www.pivotaltracker.com/story/show/167416858), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Adding `showErrorDialog` on catch executeWithdraw

** Extra **
The `ReceiveByQR` screen cannot be used since the send flow is not generating a QR code.
Didn't edit `ReceiveByQR.native` since we cannot test that file yet