### PR TITLE
#167700483 load profile details if empty

### DIFF
--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -32,6 +32,17 @@ const EditProfile = ({ screenProps, theme, styles }) => {
     setProfile(storedProfile)
   }, [isEqual(profile, {}) && storedProfile])
 
+  const updateProfile = async () => {
+    const profile = await userStorage.getProfile()
+    store.set('privateProfile')(profile)
+  }
+
+  useEffect(() => {
+    if (isEqual(storedProfile, {})) {
+      updateProfile()
+    }
+  }, [])
+
   const validate = useCallback(
     debounce(async (profile, storedProfile, setIsPristine, setErrors, setIsValid) => {
       if (profile && profile.validate) {

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -1,9 +1,11 @@
 // @flow
-import React from 'react'
+import React, { useEffect } from 'react'
+import isEqual from 'lodash/isEqual'
 import GDStore from '../../lib/undux/GDStore'
 import { createStackNavigator } from '../appNavigation/stackNavigation'
 import { Section, UserAvatar, Wrapper } from '../common'
 import { withStyles } from '../../lib/styles'
+import userStorage from '../../lib/gundb/UserStorage'
 import EditAvatar from './EditAvatar'
 import EditProfile from './EditProfile'
 import ProfileDataTable from './ProfileDataTable'
@@ -14,7 +16,8 @@ import CircleButtonWrapper from './CircleButtonWrapper'
 const TITLE = 'Profile'
 
 const ProfileWrapper = props => {
-  const profile = GDStore.useStore().get('profile')
+  const store = GDStore.useStore()
+  const profile = store.get('profile')
   const { screenProps, styles } = props
 
   const handleAvatarPress = event => {
@@ -22,6 +25,16 @@ const ProfileWrapper = props => {
     event.stopPropagation()
     screenProps.push(`${profile.avatar ? 'View' : 'Edit'}Avatar`)
   }
+
+  const updateProfile = async () => {
+    const publicProfile = await userStorage.getPublicProfile()
+    store.set('profile')(publicProfile)
+  }
+  useEffect(() => {
+    if (isEqual(profile, {})) {
+      updateProfile()
+    }
+  }, [])
 
   return (
     <Wrapper>

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -1146,6 +1146,10 @@ export class UserStorage {
 
   async getProfile(): Promise<any> {
     const encryptedProfile = await this.loadGunField(this.profile)
+    if (encryptedProfile === undefined) {
+      logger.error('getProfile: profile node undefined')
+      return {}
+    }
     const fullProfile = this.getPrivateProfile(encryptedProfile)
     return fullProfile
   }
@@ -1166,6 +1170,10 @@ export class UserStorage {
 
   async getPublicProfile(): Promise<any> {
     const encryptedProfile = await this.loadGunField(this.profile)
+    if (encryptedProfile === undefined) {
+      logger.error('getPublicProfile: profile node undefined')
+      return {}
+    }
     const fullProfile = this.getDisplayProfile(encryptedProfile)
     return fullProfile
   }

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -578,7 +578,7 @@ export class UserStorage {
         .filter(key => profile[key])
         .map(async field => {
           return this.setProfileField(field, profile[field], await getPrivacy(field)).catch(e => {
-            logger.error('setProfile field failed:', field)
+            logger.error('setProfile field failed:', field, e.message, e)
             return { err: `failed saving field ${field}` }
           })
         })
@@ -1160,8 +1160,14 @@ export class UserStorage {
     })
   }
 
-  getFullProfile(profileNode): Promise<> {
+  getEncryptedProfile(profileNode): Promise<> {
     return this.loadGunField(profileNode)
+  }
+
+  async getPublicProfile(): Promise<any> {
+    const encryptedProfile = await this.loadGunField(this.profile)
+    const fullProfile = this.getDisplayProfile(encryptedProfile)
+    return fullProfile
   }
 
   /**


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
I think the bug is caused by the store registering to profile updates only after isLoggedIn is set to true in signup. while the profile is updated before this flag is set, so the store isn't updated with the initial value.

This PR closes [#167700483](https://www.pivotaltracker.com/story/show/x), by:
checking in profile screen + profile edit that store is not empty
if it is then it sets the store data with current profile from userstorage


<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
