### PR TITLE
(Bug) Payment request doesn't fill amount

### DIFF
--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -18,6 +18,7 @@ export const DEFAULT_PARAMS = {
   receiveLink: undefined,
   reason: undefined,
   code: undefined,
+  action: undefined,
 }
 
 const log = logger.child({ from: 'stackNavigation' })

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -26,7 +26,7 @@ export function generateCode(
 ) {
   const mnid = encode({ address, network: `0x${networkId.toString(16)}` })
 
-  return `${mnid}|${amount}|${reason}|${counterPartyDisplayName}`
+  return `${mnid}|${amount}|${reason || ''}|${counterPartyDisplayName || ''}`
 }
 
 /**
@@ -35,7 +35,7 @@ export function generateCode(
  * @returns {null|{amount: *, address, networkId: number, reason: string}}
  */
 export function readCode(code: string) {
-  const [mnid, value, reason] = code.split('|')
+  const [mnid, value, reason, counterPartyDisplayName] = code.split('|')
 
   if (!isMNID(mnid)) {
     return null
@@ -49,6 +49,7 @@ export function readCode(code: string) {
     address,
     amount: amount ? amount : undefined,
     reason,
+    counterPartyDisplayName,
   }
 }
 


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167798178](https://www.pivotaltracker.com/story/show/167798178), by:

* Fixing counterPlayDisplayName value when it is empty
* Added action with a default value in StackNavigator to clean up if it's necessary the url.

**Extra:**
@sirpy I couldn't reproduce the error because it is not possible to send amount with 0. The error in PT shows Send link is incorrect, with amount zero, but we have validations for that, and I tried multiple times from different browsers to reproduce that and I couldn't
