### PR TITLE
Coveralls Task Should Always Return True

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - CI=false
 script:
   - npm run coverage
-  - npm run coveralls
+  - npm run coveralls || true
   - npm run build
 
 after_success:


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR is a hotfix for the coveralls maintenance error.

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Adding default true as return value in `npm run coveralls`
