### PR TITLE
(Bug) Receive: When user sending a link, message should not include how much G$.

### DIFF
--- a/src/lib/share/__tests__/generateReceiveShareObject.js
+++ b/src/lib/share/__tests__/generateReceiveShareObject.js
@@ -1,0 +1,63 @@
+import { generateReceiveShareObject } from '../'
+
+describe('generateReceiveShareObject', () => {
+  it(`should return an object for receipt with code, amount, to and from`, () => {
+    // Given
+    const title = 'Sending G$ via GoodDollar App'
+    const text = "Joe Bloggs, You've got a request from John Doe for 1 G$. To Transfer open:"
+    const isReceiveLink = /^http.+\/AppNavigation\/Dashboard\/Send\?code=123$/
+
+    // When
+    const shareObject = generateReceiveShareObject('123', 100, 'Joe Bloggs', 'John Doe')
+
+    // Then
+    expect(shareObject.title).toBe(title)
+    expect(shareObject.text).toBe(text)
+    expect(shareObject.url).toMatch(isReceiveLink)
+  })
+
+  it(`should return an object for receipt with code, to and from`, () => {
+    // Given
+    const title = 'Sending G$ via GoodDollar App'
+    const text = "Joe Bloggs, You've got a request from John Doe. To Transfer open:"
+    const isReceiveLink = /^http.+\/AppNavigation\/Dashboard\/Send\?code=123$/
+
+    // When
+    const shareObject = generateReceiveShareObject('123', 0, 'Joe Bloggs', 'John Doe')
+
+    // Then
+    expect(shareObject.title).toBe(title)
+    expect(shareObject.text).toBe(text)
+    expect(shareObject.url).toMatch(isReceiveLink)
+  })
+
+  it(`should return an object for receipt with code, amount and from`, () => {
+    // Given
+    const title = 'Sending G$ via GoodDollar App'
+    const text = "You've got a request from John Doe for 1 G$. To Transfer open:"
+    const isReceiveLink = /^http.+\/AppNavigation\/Dashboard\/Send\?code=123$/
+
+    // When
+    const shareObject = generateReceiveShareObject('123', 100, '', 'John Doe')
+
+    // Then
+    expect(shareObject.title).toBe(title)
+    expect(shareObject.text).toBe(text)
+    expect(shareObject.url).toMatch(isReceiveLink)
+  })
+
+  it(`should return an object for receipt with code and from`, () => {
+    // Given
+    const title = 'Sending G$ via GoodDollar App'
+    const text = "You've got a request from John Doe. To Transfer open:"
+    const isReceiveLink = /^http.+\/AppNavigation\/Dashboard\/Send\?code=123$/
+
+    // When
+    const shareObject = generateReceiveShareObject('123', 0, '', 'John Doe')
+
+    // Then
+    expect(shareObject.title).toBe(title)
+    expect(shareObject.text).toBe(text)
+    expect(shareObject.url).toMatch(isReceiveLink)
+  })
+})

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -99,7 +99,9 @@ type ShareObject = {
 
 /**
  * Generates the standard object required for `navigator.share` method to trigger Share menu on mobile devices
- * @param url - Link
+ * @param {string} title
+ * @param {string} text
+ * @param {string} url - Link
  * @returns {ShareObject}
  */
 export function generateShareObject(title: string, text: string, url: string): ShareObject {
@@ -122,18 +124,22 @@ export function generateSendShareObject(url: string, amount: number, to: string,
 
 /**
  * Generates URL link to share/receive GDs
- * @param code - code returned by `generateCode`
+ * @param {string} code - code returned by `generateCode`
+ * @param {number } amount - amount expressed in Wei
+ * @param {string} to - recipient name
+ * @param {string} from - current user's fullName
  * @returns {string} - URL to use to share/receive GDs
  */
 export function generateReceiveShareObject(code: string, amount: number, to: string, from: string): ShareObject {
   const url = generateShareLink('receive', { code })
-  return generateShareObject(
-    'Sending G$ via GoodDollar App',
-    to
-      ? `${to}, You've got a request from ${from} for ${weiToGd(amount)} G$. To transfer open:`
-      : `You've got a request from ${from} for ${weiToGd(amount)} G$. To transfer open:`,
-    url
-  )
+  const text = [
+    to ? `${to}, ` : '',
+    `You've got a request from ${from}`,
+    amount > 0 ? ` for ${weiToGd(amount)} G$` : '',
+    `. To Transfer open:`,
+  ].join('')
+
+  return generateShareObject('Sending G$ via GoodDollar App', text, url)
 }
 
 type HrefLinkProps = {


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167894110](https://www.pivotaltracker.com/story/show/167894110), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Updating `generateReceiveShareObject`, with conditional amount
* Adding tests for `generateReceiveShareObject`

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
