### PR TITLE
#407 - Profile details should be private by default

### DIFF
--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -634,8 +634,8 @@ export class UserStorage {
 
     const profileSettings = {
       fullName: { defaultPrivacy: 'public' },
-      email: { defaultPrivacy: 'public' },
-      mobile: { defaultPrivacy: 'public' },
+      email: { defaultPrivacy: 'private' },
+      mobile: { defaultPrivacy: 'private' },
       avatar: { defaultPrivacy: 'public' },
       walletAddress: { defaultPrivacy: 'public' },
       username: { defaultPrivacy: 'public' },


### PR DESCRIPTION
This PR closes #407 

* Change mobilePhone and email display type to private by default