### PR TITLE
(Bug) Payment link should be encoded

### DIFF
--- a/src/lib/share/__tests__/generateShareLink.js
+++ b/src/lib/share/__tests__/generateShareLink.js
@@ -82,4 +82,16 @@ describe('generateShareLink', () => {
       `${Config.publicUrl}/AppNavigation/Dashboard/Home?key=value&key2=value2&key3=value3&key4=value4`
     )
   })
+
+  it.only(`should return link generated from send action, with encoded query param`, () => {
+    // Given
+    const action = 'send'
+    const params = { key: 'value with spaces' }
+
+    // When
+    const link = generateShareLink(action, params)
+
+    // Then
+    expect(link).toEqual(`${Config.publicUrl}/AppNavigation/Dashboard/Home?key=value%20with%20spaces`)
+  })
 })

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -191,5 +191,5 @@ export function generateShareLink(action: ActionType = 'receive', params: {} = {
     throw new Error(`Link couldn't be generated`)
   }
 
-  return `${Config.publicUrl}/AppNavigation/Dashboard/${destination}?${queryParams}`
+  return encodeURI(`${Config.publicUrl}/AppNavigation/Dashboard/${destination}?${queryParams}`)
 }


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167938535](https://www.pivotaltracker.com/story/show/167938535), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Adding `uriEncoded` function call on `generateShareLink`
* Adding unit test for this case
