### PR TITLE
(Feature) G$ Sign - '$' should be smaller from the 'G' by 0.5pt

### DIFF
--- a/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
@@ -655,38 +655,58 @@ exports[`AppNavigation matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(85,85,85,1.00)",
+                    "color": "rgba(66,69,74,1.00)",
                     "direction": "ltr",
-                    "fontFamily": "Roboto Slab",
-                    "fontSize": "18px",
-                    "fontWeight": "700",
-                    "lineHeight": "24px",
-                    "textAlign": "right",
+                    "fontFamily": "Roboto",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "lineHeight": "22px",
+                    "marginRight": "-20px",
+                    "textAlign": "center",
                     "textDecoration": "none",
                     "textTransform": "none",
                   }
                 }
-              />
-            </div>
-            <div
-              className="css-text-901oao"
-              dir="auto"
-              style={
-                Object {
-                  "color": "rgba(66,69,74,1.00)",
-                  "direction": "ltr",
-                  "fontFamily": "Roboto Slab",
-                  "fontSize": "18px",
-                  "fontWeight": "700",
-                  "lineHeight": "24px",
-                  "marginRight": "-20px",
-                  "textAlign": "center",
-                  "textDecoration": "none",
-                  "textTransform": "none",
-                }
-              }
-            >
-              G$
+              >
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(85,85,85,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "18px",
+                      "fontWeight": "700",
+                      "lineHeight": "24px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  G
+                </span>
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(85,85,85,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "17.5px",
+                      "fontWeight": "700",
+                      "lineHeight": "21px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  $
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/common/view/BigGoodDollar.js
+++ b/src/components/common/view/BigGoodDollar.js
@@ -2,8 +2,13 @@
 import React from 'react'
 import { weiToMask } from '../../../lib/wallet/utils'
 import BigNumber from './BigNumber'
+import Text from './Text'
 
 type Props = { number: any, props?: {} }
+
+const GOOD_SIGN_SIZE = 18
+const DIFF_FACTOR = 0.5
+const DOLLAR_SIGN_SIZE = GOOD_SIGN_SIZE - DIFF_FACTOR
 
 /**
  * Receives wei and shows as G$ using BigNumber component
@@ -11,8 +16,47 @@ type Props = { number: any, props?: {} }
  * @param {Number} params.number
  * @returns {React.Node}
  */
-const BigGoodDollar = ({ number, ...props }: Props) => (
-  <BigNumber number={number === undefined ? '-.--' : weiToMask(number)} unit={'G$'} {...props} />
-)
+const BigGoodDollar = ({ number, formatter, ...props }: Props) => {
+  const formattedNumber = formatter && formatter(number)
+  const maskedNumber = weiToMask(number)
+  number = number === undefined ? '-.--' : formattedNumber || maskedNumber
+
+  return (
+    <BigNumber number={number} {...props}>
+      {props.unit ? null : <GDUnits {...props} />}
+    </BigNumber>
+  )
+}
+
+const GDUnits = props => {
+  const { fontSize, ...bigNumberUnitProps } = props.bigNumberUnitProps || {}
+  const dollarSignFontSize = fontSize ? fontSize - DIFF_FACTOR : DOLLAR_SIGN_SIZE
+  const goodSignFontSize = fontSize || GOOD_SIGN_SIZE
+
+  return (
+    <Text style={props.bigNumberUnitStyles}>
+      <Text
+        color={props.color || 'gray'}
+        fontSize={goodSignFontSize}
+        fontFamily="slab"
+        fontWeight="bold"
+        textAlign="right"
+        {...bigNumberUnitProps}
+      >
+        G
+      </Text>
+      <Text
+        color={props.color || 'gray'}
+        fontSize={dollarSignFontSize}
+        fontFamily="slab"
+        fontWeight="bold"
+        textAlign="right"
+        {...bigNumberUnitProps}
+      >
+        $
+      </Text>
+    </Text>
+  )
+}
 
 export default BigGoodDollar

--- a/src/components/common/view/BigGoodDollar.js
+++ b/src/components/common/view/BigGoodDollar.js
@@ -17,9 +17,8 @@ const DOLLAR_SIGN_SIZE = GOOD_SIGN_SIZE - DIFF_FACTOR
  * @returns {React.Node}
  */
 const BigGoodDollar = ({ number, formatter, ...props }: Props) => {
-  const formattedNumber = formatter && formatter(number)
-  const maskedNumber = weiToMask(number)
-  number = number === undefined ? '-.--' : formattedNumber || maskedNumber
+  const numberFormatter = formatter || weiToMask
+  number = number === undefined ? '-.--' : numberFormatter(number)
 
   return (
     <BigNumber number={number} {...props}>

--- a/src/components/common/view/BigGoodDollar.js
+++ b/src/components/common/view/BigGoodDollar.js
@@ -30,8 +30,8 @@ const BigGoodDollar = ({ number, formatter, ...props }: Props) => {
 
 const GDUnits = props => {
   const { fontSize, ...bigNumberUnitProps } = props.bigNumberUnitProps || {}
-  const dollarSignFontSize = fontSize ? fontSize - DIFF_FACTOR : DOLLAR_SIGN_SIZE
   const goodSignFontSize = fontSize || GOOD_SIGN_SIZE
+  const dollarSignFontSize = fontSize ? fontSize - DIFF_FACTOR : DOLLAR_SIGN_SIZE
 
   return (
     <Text style={props.bigNumberUnitStyles}>

--- a/src/components/common/view/BigNumber.js
+++ b/src/components/common/view/BigNumber.js
@@ -15,7 +15,18 @@ import Text from './Text'
  */
 class BigNumber extends React.Component {
   render() {
-    const { bigNumberStyles, bigNumberUnitStyles, number, unit, style, color, styles } = this.props
+    const {
+      bigNumberStyles,
+      bigNumberUnitStyles,
+      bigNumberProps,
+      bigNumberUnitProps,
+      children,
+      number,
+      unit,
+      style,
+      color,
+      styles,
+    } = this.props
     return (
       <View style={[styles.bigNumberWrapper, style]}>
         <Text
@@ -24,20 +35,26 @@ class BigNumber extends React.Component {
           fontWeight="bold"
           textAlign="right"
           color={color || 'gray'}
+          {...bigNumberProps}
           style={[styles.bigNumber, bigNumberStyles]}
         >
           {number}
         </Text>
-        <Text
-          fontFamily="slab"
-          fontSize={18}
-          fontWeight="bold"
-          textAlign="right"
-          color={color || 'gray'}
-          style={bigNumberUnitStyles}
-        >
-          {unit}
-        </Text>
+        {unit ? (
+          <Text
+            fontFamily="slab"
+            fontSize={18}
+            fontWeight="bold"
+            textAlign="right"
+            color={color || 'gray'}
+            {...bigNumberUnitProps}
+            style={bigNumberUnitStyles}
+          >
+            {unit}
+          </Text>
+        ) : (
+          children
+        )}
       </View>
     )
   }

--- a/src/components/common/view/SummaryTable.js
+++ b/src/components/common/view/SummaryTable.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import normalize from '../../../lib/utils/normalizeText'
 import Section from '../layout/Section'
 import { withStyles } from '../../../lib/styles'
 import BigGoodDollar from './BigGoodDollar'
@@ -31,10 +30,10 @@ const AmountRow = props => {
         Amount:
       </Section.Text>
       <BigGoodDollar
-        bigNumberStyles={styles.bigGoodDollar}
-        bigNumberUnitStyles={styles.bigGoodDollarUnit}
         number={amount}
-        color={props.theme.colors.primary}
+        color="primary"
+        bigNumberProps={{ fontSize: 24 }}
+        bigNumberUnitProps={{ fontSize: 14 }}
       />
     </Section.Row>
   )
@@ -81,18 +80,6 @@ const getStylesFromProps = ({ theme }) => {
       alignItems: 'flex-end',
       paddingBottom: theme.sizes.defaultHalf,
       height: 40,
-    },
-
-    // TODO: all this properties can be removed once we merge Text component in
-    bigGoodDollar: {
-      color: theme.colors.primary,
-      fontSize: normalize(24),
-      fontFamily: theme.fonts.default,
-    },
-    bigGoodDollarUnit: {
-      color: theme.colors.primary,
-      fontSize: normalize(14),
-      fontFamily: theme.fonts.default,
     },
   }
 }

--- a/src/components/common/view/__tests__/__snapshots__/BigGoodDollar.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/BigGoodDollar.js.snap
@@ -60,19 +60,56 @@ exports[`BigGoodDollar matches snapshot 1`] = `
       dir="auto"
       style={
         Object {
-          "color": "rgba(85,85,85,1.00)",
+          "color": "rgba(66,69,74,1.00)",
           "direction": "ltr",
-          "fontFamily": "Roboto Slab",
-          "fontSize": "18px",
-          "fontWeight": "700",
-          "lineHeight": "24px",
-          "textAlign": "right",
+          "fontFamily": "Roboto",
+          "fontSize": "16px",
+          "fontWeight": "normal",
+          "lineHeight": "22px",
+          "textAlign": "center",
           "textDecoration": "none",
           "textTransform": "none",
         }
       }
     >
-      G$
+      <span
+        className="css-text-901oao css-textHasAncestor-16my406"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(85,85,85,1.00)",
+            "direction": "ltr",
+            "fontFamily": "Roboto Slab",
+            "fontSize": "18px",
+            "fontWeight": "700",
+            "lineHeight": "24px",
+            "textAlign": "right",
+            "textDecoration": "none",
+            "textTransform": "none",
+          }
+        }
+      >
+        G
+      </span>
+      <span
+        className="css-text-901oao css-textHasAncestor-16my406"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(85,85,85,1.00)",
+            "direction": "ltr",
+            "fontFamily": "Roboto Slab",
+            "fontSize": "17.5px",
+            "fontWeight": "700",
+            "lineHeight": "21px",
+            "textAlign": "right",
+            "textDecoration": "none",
+            "textTransform": "none",
+          }
+        }
+      >
+        $
+      </span>
     </div>
   </div>
 </div>

--- a/src/components/common/view/__tests__/__snapshots__/SummaryTable.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/SummaryTable.js.snap
@@ -176,7 +176,7 @@ exports[`SummaryTable matches snapshot 1`] = `
             Object {
               "color": "rgba(0,175,255,1.00)",
               "direction": "ltr",
-              "fontFamily": "Roboto",
+              "fontFamily": "Roboto Slab",
               "fontSize": "24px",
               "fontWeight": "700",
               "lineHeight": "30px",
@@ -194,19 +194,56 @@ exports[`SummaryTable matches snapshot 1`] = `
           dir="auto"
           style={
             Object {
-              "color": "rgba(0,175,255,1.00)",
+              "color": "rgba(66,69,74,1.00)",
               "direction": "ltr",
               "fontFamily": "Roboto",
-              "fontSize": "14px",
-              "fontWeight": "700",
-              "lineHeight": "24px",
-              "textAlign": "right",
+              "fontSize": "16px",
+              "fontWeight": "normal",
+              "lineHeight": "22px",
+              "textAlign": "center",
               "textDecoration": "none",
               "textTransform": "none",
             }
           }
         >
-          G$
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(0,175,255,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "14px",
+                "fontWeight": "700",
+                "lineHeight": "20px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            G
+          </span>
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(0,175,255,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "13.5px",
+                "fontWeight": "700",
+                "lineHeight": "16.2px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            $
+          </span>
         </div>
       </div>
     </div>
@@ -390,7 +427,7 @@ exports[`SummaryTable matches snapshot with minimal properties 1`] = `
             Object {
               "color": "rgba(0,175,255,1.00)",
               "direction": "ltr",
-              "fontFamily": "Roboto",
+              "fontFamily": "Roboto Slab",
               "fontSize": "24px",
               "fontWeight": "700",
               "lineHeight": "30px",
@@ -408,19 +445,56 @@ exports[`SummaryTable matches snapshot with minimal properties 1`] = `
           dir="auto"
           style={
             Object {
-              "color": "rgba(0,175,255,1.00)",
+              "color": "rgba(66,69,74,1.00)",
               "direction": "ltr",
               "fontFamily": "Roboto",
-              "fontSize": "14px",
-              "fontWeight": "700",
-              "lineHeight": "24px",
-              "textAlign": "right",
+              "fontSize": "16px",
+              "fontWeight": "normal",
+              "lineHeight": "22px",
+              "textAlign": "center",
               "textDecoration": "none",
               "textTransform": "none",
             }
           }
         >
-          G$
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(0,175,255,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "14px",
+                "fontWeight": "700",
+                "lineHeight": "20px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            G
+          </span>
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(0,175,255,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "13.5px",
+                "fontWeight": "700",
+                "lineHeight": "16.2px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            $
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/common/view/__tests__/__snapshots__/TopBar.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/TopBar.js.snap
@@ -200,19 +200,56 @@ exports[`TopBar matches snapshot with balance 1`] = `
           dir="auto"
           style={
             Object {
-              "color": "rgba(85,85,85,1.00)",
+              "color": "rgba(66,69,74,1.00)",
               "direction": "ltr",
-              "fontFamily": "Roboto Slab",
-              "fontSize": "18px",
-              "fontWeight": "700",
-              "lineHeight": "24px",
-              "textAlign": "right",
+              "fontFamily": "Roboto",
+              "fontSize": "16px",
+              "fontWeight": "normal",
+              "lineHeight": "22px",
+              "textAlign": "center",
               "textDecoration": "none",
               "textTransform": "none",
             }
           }
         >
-          G$
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(85,85,85,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "18px",
+                "fontWeight": "700",
+                "lineHeight": "24px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            G
+          </span>
+          <span
+            className="css-text-901oao css-textHasAncestor-16my406"
+            dir="auto"
+            style={
+              Object {
+                "color": "rgba(85,85,85,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "17.5px",
+                "fontWeight": "700",
+                "lineHeight": "21px",
+                "textAlign": "right",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            $
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -5,13 +5,13 @@ import numeral from 'numeral'
 import userStorage, { type TransactionEvent } from '../../lib/gundb/UserStorage'
 import goodWallet from '../../lib/wallet/GoodWallet'
 import logger from '../../lib/logger/pino-logger'
-import normalize from '../../lib/utils/normalizeText'
 import GDStore from '../../lib/undux/GDStore'
 import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import wrapper from '../../lib/undux/utils/wrapper'
 import { weiToGd } from '../../lib/wallet/utils'
 import { CustomButton, Wrapper } from '../common'
+import BigGoodDollar from '../common/view/BigGoodDollar'
 import Text from '../common/view/Text'
 import TopBar from '../common/view/TopBar'
 import LoadingIcon from '../common/modal/LoadingIcon'
@@ -178,11 +178,15 @@ const Claim = props => {
       }}
     >
       <Text color="surface" fontWeight="medium">
-        {`CLAIM YOUR SHARE - ${weiToGd(entitlement)}`}
-        <Text fontSize={10} color="surface" fontWeight="medium" style={styles.goodDollarUnit}>
-          G$
-        </Text>
+        {`CLAIM YOUR SHARE - `}
       </Text>
+      <BigGoodDollar
+        number={entitlement}
+        formatter={number => weiToGd(number)}
+        bigNumberProps={{ fontSize: 16, color: 'surface', fontWeight: 'medium' }}
+        bigNumberUnitProps={{ fontSize: 10, color: 'surface', fontWeight: 'medium' }}
+        style={styles.inline}
+      />
     </CustomButton>
   )
 
@@ -195,12 +199,13 @@ const Claim = props => {
             GoodDollar allows you to collect
           </Section.Text>
           <Section.Text style={styles.mainTextBigMarginBottom}>
-            <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36}>
-              1
-            </Section.Text>
-            <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={20}>
-              {' G$'}
-            </Section.Text>
+            <BigGoodDollar
+              number={1}
+              formatter={number => number}
+              bigNumberProps={{ color: 'surface' }}
+              bigNumberUnitProps={{ color: 'surface', fontSize: 20 }}
+              style={styles.inline}
+            />
             <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36}>
               {' Free'}
             </Section.Text>
@@ -214,10 +219,12 @@ const Claim = props => {
           <Section.Row style={styles.extraInfoStats}>
             <Section.Text fontWeight="bold">{numeral(claimedToday.people).format('0a')} </Section.Text>
             <Section.Text>People Claimed </Section.Text>
-            <Section.Text fontWeight="bold">{numeral(claimedToday.amount).format('0a')}</Section.Text>
-            <Section.Text fontWeight="bold" fontSize={10} style={styles.goodDollarUnit}>
-              G${' '}
-            </Section.Text>
+            <BigGoodDollar
+              number={claimedToday.amount}
+              formatter={number => numeral(number).format('0a')}
+              bigNumberProps={{ fontSize: 16 }}
+              bigNumberUnitProps={{ fontSize: 10 }}
+            />
             <Section.Text>Today!</Section.Text>
           </Section.Row>
           <Section.Stack style={styles.extraInfoCountdown}>
@@ -305,8 +312,8 @@ const getStylesFromProps = ({ theme }) => {
     extraInfoCountdownTitle: {
       marginBottom: theme.sizes.default,
     },
-    goodDollarUnit: {
-      paddingTop: normalize(4),
+    inline: {
+      display: 'inline',
     },
   }
 }

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -182,7 +182,7 @@ const Claim = props => {
       </Text>
       <BigGoodDollar
         number={entitlement}
-        formatter={number => weiToGd(number)}
+        formatter={weiToGd}
         bigNumberProps={{ fontSize: 16, color: 'surface', fontWeight: 'medium' }}
         bigNumberUnitProps={{ fontSize: 10, color: 'surface', fontWeight: 'medium' }}
         style={styles.inline}

--- a/src/components/dashboard/Confirmation.js
+++ b/src/components/dashboard/Confirmation.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { useMemo } from 'react'
 import { isMobile } from 'mobile-device-detect'
-import normalize from '../../lib/utils/normalizeText'
 import GDStore from '../../lib/undux/GDStore'
 import { generateReceiveShareObject, generateSendShareObject } from '../../lib/share'
 import { BigGoodDollar, CopyButton, CustomButton, QRCode, Section, Wrapper } from '../common'
@@ -60,10 +59,10 @@ const ReceiveConfirmation = ({ screenProps, styles, ...props }: ReceiveProps) =>
           )}
           {amount && (
             <BigGoodDollar
-              bigNumberStyles={styles.bigGoodDollar}
-              bigNumberUnitStyles={styles.bigGoodDollarUnit}
               number={amount}
-              color={props.theme.colors.primary}
+              color="primary"
+              bigNumberProps={{ fontSize: 24 }}
+              bigNumberUnitProps={{ fontSize: 14 }}
             />
           )}
           <Section.Text style={styles.textRow}>{reason}</Section.Text>
@@ -99,16 +98,6 @@ const getStylesFromProps = ({ theme }) => {
     },
     doneButton: {
       marginTop: theme.paddings.defaultMargin,
-    },
-    bigGoodDollar: {
-      fontFamily: theme.fonts.default,
-      fontSize: normalize(24),
-      fontWeight: '700',
-    },
-    bigGoodDollarUnit: {
-      fontFamily: theme.fonts.default,
-      fontSize: normalize(14),
-      fontWeight: '700',
     },
   }
 }

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -131,10 +131,11 @@ const Dashboard = props => {
               {fullName || ' '}
             </Section.Text>
             <Section.Row style={styles.bigNumberWrapper}>
-              <BigGoodDollar bigNumberStyles={styles.bigNumberVerticalStyles} number={balance} unit={undefined} />
-              <Section.Text fontSize={18} fontWeight="bold" fontFamily="slab" style={styles.bigNumberUnitStyles}>
-                G$
-              </Section.Text>
+              <BigGoodDollar
+                number={balance}
+                bigNumberProps={{ fontSize: 42, fontWeight: 'semibold' }}
+                bigNumberUnitStyles={styles.bigNumberUnitStyles}
+              />
             </Section.Row>
           </Section.Stack>
         ) : (
@@ -145,7 +146,7 @@ const Dashboard = props => {
               source={avatar}
               style={[styles.avatarSmall]}
             />
-            <BigGoodDollar bigNumberStyles={styles.bigNumberStyles} number={balance} />
+            <BigGoodDollar number={balance} />
           </Section>
         )}
         <Section.Row style={styles.buttonsRow}>
@@ -300,19 +301,9 @@ const getStylesFromProps = ({ theme }) => ({
   rightButtonText: {
     marginLeft: 16,
   },
-  bigNumberVerticalStyles: {
-    fontFamily: theme.fonts.slab,
-    fontSize: normalize(42),
-    fontWeight: '600',
-  },
   bigNumberWrapper: {
     marginVertical: theme.sizes.defaultDouble,
     alignItems: 'baseline',
-  },
-  bigNumberStyles: {
-    fontFamily: theme.fonts.slab,
-    fontSize: normalize(36),
-    fontWeight: '700',
   },
   bigNumberUnitStyles: {
     marginRight: normalize(-20),

--- a/src/components/dashboard/FeedItems/FeedModalItem.js
+++ b/src/components/dashboard/FeedItems/FeedModalItem.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react'
 import { View } from 'react-native'
-import normalize from '../../../lib/utils/normalizeText'
 import Avatar from '../../common/view/Avatar'
 import BigGoodDollar from '../../common/view/BigGoodDollar'
 import Text from '../../common/view/Text'
@@ -51,10 +50,11 @@ const FeedModalItem = (props: FeedEventProps) => {
                     </Text>
                   )}
                   <BigGoodDollar
-                    bigNumberStyles={styles.bigNumberStyles}
-                    bigNumberUnitStyles={styles.bigNumberUnitStyles}
-                    color={mainColor}
                     number={item.data.amount}
+                    color={mainColor}
+                    bigNumberProps={{ fontSize: 22 }}
+                    bigNumberStyles={styles.bigNumberStyles}
+                    bigNumberUnitProps={{ fontSize: 12 }}
                   />
                 </React.Fragment>
               )}
@@ -105,11 +105,7 @@ const getStylesFromProps = ({ theme }) => {
       paddingRight: 4,
     },
     bigNumberStyles: {
-      fontSize: normalize(22),
       marginRight: 4,
-    },
-    bigNumberUnitStyles: {
-      fontSize: normalize(12),
     },
     transactionDetails: {
       alignItems: 'center',

--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -48,10 +48,12 @@ const ListEvent = ({ item: feed, theme, styles }: FeedEventProps) => {
                 </Text>
               )}
               <BigGoodDollar
-                bigNumberStyles={styles.bigNumberStyles}
-                bigNumberUnitStyles={styles.bigNumberUnitStyles}
-                color={mainColor}
                 number={feed.data.amount}
+                color={mainColor}
+                bigNumberProps={{ fontSize: 15, lineHeight: 18 }}
+                bigNumberStyles={styles.bigNumberStyles}
+                bigNumberUnitProps={{ fontSize: 10, lineHeight: 11 }}
+                bigNumberUnitStyles={styles.bigNumberUnitStyles}
               />
             </React.Fragment>
           )}
@@ -138,14 +140,10 @@ const getStylesFromProps = ({ theme }) => ({
     marginLeft: 'auto',
   },
   bigNumberStyles: {
-    fontSize: normalize(15),
-    lineHeight: normalize(18),
     marginRight: theme.sizes.defaultHalf,
   },
   bigNumberUnitStyles: {
-    fontSize: normalize(10),
-    lineHeight: normalize(11),
-    marginTop: 6,
+    lineHeight: normalize(16),
   },
   transferInfo: {
     display: 'flex',

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedListItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedListItem.js.snap
@@ -363,20 +363,56 @@ exports[`FeedListItem - Send matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(250,108,119,1.00)",
+                    "color": "rgba(66,69,74,1.00)",
                     "direction": "ltr",
-                    "fontFamily": "Roboto Slab",
-                    "fontSize": "10px",
-                    "fontWeight": "700",
-                    "lineHeight": "11px",
-                    "marginTop": "6px",
-                    "textAlign": "right",
+                    "fontFamily": "Roboto",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "lineHeight": "16px",
+                    "textAlign": "center",
                     "textDecoration": "none",
                     "textTransform": "none",
                   }
                 }
               >
-                G$
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(250,108,119,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "10px",
+                      "fontWeight": "700",
+                      "lineHeight": "11px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  G
+                </span>
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(250,108,119,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "9.5px",
+                      "fontWeight": "700",
+                      "lineHeight": "11px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  $
+                </span>
               </div>
             </div>
           </div>
@@ -911,20 +947,56 @@ exports[`FeedListItem - Withdraw matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(0,195,174,1.00)",
+                    "color": "rgba(66,69,74,1.00)",
                     "direction": "ltr",
-                    "fontFamily": "Roboto Slab",
-                    "fontSize": "10px",
-                    "fontWeight": "700",
-                    "lineHeight": "11px",
-                    "marginTop": "6px",
-                    "textAlign": "right",
+                    "fontFamily": "Roboto",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "lineHeight": "16px",
+                    "textAlign": "center",
                     "textDecoration": "none",
                     "textTransform": "none",
                   }
                 }
               >
-                G$
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(0,195,174,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "10px",
+                      "fontWeight": "700",
+                      "lineHeight": "11px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  G
+                </span>
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(0,195,174,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "9.5px",
+                      "fontWeight": "700",
+                      "lineHeight": "11px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  $
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
@@ -1989,19 +1989,56 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
                       dir="auto"
                       style={
                         Object {
-                          "color": "rgba(250,108,119,1.00)",
+                          "color": "rgba(66,69,74,1.00)",
                           "direction": "ltr",
-                          "fontFamily": "Roboto Slab",
-                          "fontSize": "12px",
-                          "fontWeight": "700",
-                          "lineHeight": "24px",
-                          "textAlign": "right",
+                          "fontFamily": "Roboto",
+                          "fontSize": "16px",
+                          "fontWeight": "normal",
+                          "lineHeight": "22px",
+                          "textAlign": "center",
                           "textDecoration": "none",
                           "textTransform": "none",
                         }
                       }
                     >
-                      G$
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "color": "rgba(250,108,119,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto Slab",
+                            "fontSize": "12px",
+                            "fontWeight": "700",
+                            "lineHeight": "16px",
+                            "textAlign": "right",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        G
+                      </span>
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "color": "rgba(250,108,119,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto Slab",
+                            "fontSize": "11.5px",
+                            "fontWeight": "700",
+                            "lineHeight": "13.799999999999999px",
+                            "textAlign": "right",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        $
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -2848,19 +2885,56 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
                       dir="auto"
                       style={
                         Object {
-                          "color": "rgba(0,195,174,1.00)",
+                          "color": "rgba(66,69,74,1.00)",
                           "direction": "ltr",
-                          "fontFamily": "Roboto Slab",
-                          "fontSize": "12px",
-                          "fontWeight": "700",
-                          "lineHeight": "24px",
-                          "textAlign": "right",
+                          "fontFamily": "Roboto",
+                          "fontSize": "16px",
+                          "fontWeight": "normal",
+                          "lineHeight": "22px",
+                          "textAlign": "center",
                           "textDecoration": "none",
                           "textTransform": "none",
                         }
                       }
                     >
-                      G$
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "color": "rgba(0,195,174,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto Slab",
+                            "fontSize": "12px",
+                            "fontWeight": "700",
+                            "lineHeight": "16px",
+                            "textAlign": "right",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        G
+                      </span>
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "color": "rgba(0,195,174,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto Slab",
+                            "fontSize": "11.5px",
+                            "fontWeight": "700",
+                            "lineHeight": "13.799999999999999px",
+                            "textAlign": "right",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        $
+                      </span>
                     </div>
                   </div>
                 </div>

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
@@ -277,20 +277,56 @@ exports[`ListEventItem receive matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(0,187,165,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "10px",
-                "fontWeight": "700",
-                "lineHeight": "11px",
-                "marginTop": "6px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "16px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(0,187,165,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "10px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(0,187,165,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "9.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>
@@ -737,20 +773,56 @@ exports[`ListEventItem send matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(250,108,119,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "10px",
-                "fontWeight": "700",
-                "lineHeight": "11px",
-                "marginTop": "6px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "16px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(250,108,119,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "10px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(250,108,119,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "9.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>
@@ -1197,20 +1269,56 @@ exports[`ListEventItem withdraw matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(0,195,174,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "10px",
-                "fontWeight": "700",
-                "lineHeight": "11px",
-                "marginTop": "6px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "16px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(0,195,174,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "10px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(0,195,174,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "9.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "11px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -225,19 +225,56 @@ exports[`Amount matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(85,85,85,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "18px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "22px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "18px",
+                  "fontWeight": "700",
+                  "lineHeight": "24px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "17.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "21px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -225,19 +225,56 @@ exports[`Claim matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(85,85,85,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "18px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "22px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "18px",
+                  "fontWeight": "700",
+                  "lineHeight": "24px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "17.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "21px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>
@@ -322,44 +359,100 @@ exports[`Claim matches snapshot 1`] = `
             }
           }
         >
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406"
-            dir="auto"
+          <div
+            className="css-view-1dbjc4n"
             style={
               Object {
-                "color": "rgba(255,255,255,1.00)",
-                "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "36px",
-                "fontWeight": "700",
-                "lineHeight": "30px",
-                "textAlign": "center",
-                "textDecoration": "none",
-                "textTransform": "none",
+                "WebkitAlignItems": "baseline",
+                "WebkitBoxAlign": "baseline",
+                "WebkitBoxDirection": "normal",
+                "WebkitBoxOrient": "horizontal",
+                "WebkitFlexDirection": "row",
+                "alignItems": "baseline",
+                "display": "inline",
+                "flexDirection": "row",
+                "msFlexAlign": "baseline",
+                "msFlexDirection": "row",
               }
             }
           >
-            1
-          </span>
-          <span
-            className="css-text-901oao css-textHasAncestor-16my406"
-            dir="auto"
-            style={
-              Object {
-                "color": "rgba(255,255,255,1.00)",
-                "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "20px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "center",
-                "textDecoration": "none",
-                "textTransform": "none",
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(255,255,255,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "36px",
+                  "fontWeight": "700",
+                  "lineHeight": "30px",
+                  "marginRight": "2px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
               }
-            }
-          >
-             G$
-          </span>
+            >
+              1
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(66,69,74,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto",
+                  "fontSize": "16px",
+                  "fontWeight": "normal",
+                  "lineHeight": "22px",
+                  "textAlign": "center",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(255,255,255,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto Slab",
+                    "fontSize": "20px",
+                    "fontWeight": "700",
+                    "lineHeight": "24px",
+                    "textAlign": "right",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                G
+              </span>
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(255,255,255,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto Slab",
+                    "fontSize": "19.5px",
+                    "fontWeight": "700",
+                    "lineHeight": "23.4px",
+                    "textAlign": "right",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                $
+              </span>
+            </span>
+          </div>
           <span
             className="css-text-901oao css-textHasAncestor-16my406"
             dir="auto"
@@ -563,44 +656,98 @@ exports[`Claim matches snapshot 1`] = `
             People Claimed 
           </div>
           <div
-            className="css-text-901oao"
-            dir="auto"
+            className="css-view-1dbjc4n"
             style={
               Object {
-                "color": "rgba(66,69,74,1.00)",
-                "direction": "ltr",
-                "fontFamily": "Roboto",
-                "fontSize": "16px",
-                "fontWeight": "700",
-                "lineHeight": "22px",
-                "textAlign": "center",
-                "textDecoration": "none",
-                "textTransform": "none",
+                "WebkitAlignItems": "baseline",
+                "WebkitBoxAlign": "baseline",
+                "WebkitBoxDirection": "normal",
+                "WebkitBoxOrient": "horizontal",
+                "WebkitFlexDirection": "row",
+                "alignItems": "baseline",
+                "display": "flex",
+                "flexDirection": "row",
+                "msFlexAlign": "baseline",
+                "msFlexDirection": "row",
               }
             }
           >
-            0
-          </div>
-          <div
-            className="css-text-901oao"
-            dir="auto"
-            style={
-              Object {
-                "color": "rgba(66,69,74,1.00)",
-                "direction": "ltr",
-                "fontFamily": "Roboto",
-                "fontSize": "10px",
-                "fontWeight": "700",
-                "lineHeight": "14px",
-                "paddingTop": "4px",
-                "textAlign": "center",
-                "textDecoration": "none",
-                "textTransform": "none",
+            <div
+              className="css-text-901oao"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "16px",
+                  "fontWeight": "700",
+                  "lineHeight": "22px",
+                  "marginRight": "2px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
               }
-            }
-          >
-            G$
-             
+            >
+              0
+            </div>
+            <div
+              className="css-text-901oao"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(66,69,74,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto",
+                  "fontSize": "16px",
+                  "fontWeight": "normal",
+                  "lineHeight": "22px",
+                  "textAlign": "center",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(85,85,85,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto Slab",
+                    "fontSize": "10px",
+                    "fontWeight": "700",
+                    "lineHeight": "14px",
+                    "textAlign": "right",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                G
+              </span>
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(85,85,85,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto Slab",
+                    "fontSize": "9.5px",
+                    "fontWeight": "700",
+                    "lineHeight": "11.4px",
+                    "textAlign": "right",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                $
+              </span>
+            </div>
           </div>
           <div
             className="css-text-901oao"
@@ -817,7 +964,25 @@ exports[`Claim matches snapshot 1`] = `
                     }
                   }
                 >
-                  CLAIM YOUR SHARE - NaN
+                  CLAIM YOUR SHARE - 
+                </span>
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitAlignItems": "baseline",
+                      "WebkitBoxAlign": "baseline",
+                      "WebkitBoxDirection": "normal",
+                      "WebkitBoxOrient": "horizontal",
+                      "WebkitFlexDirection": "row",
+                      "alignItems": "baseline",
+                      "display": "inline",
+                      "flexDirection": "row",
+                      "msFlexAlign": "baseline",
+                      "msFlexDirection": "row",
+                    }
+                  }
+                >
                   <span
                     className="css-text-901oao css-textHasAncestor-16my406"
                     dir="auto"
@@ -825,20 +990,76 @@ exports[`Claim matches snapshot 1`] = `
                       Object {
                         "color": "rgba(255,255,255,1.00)",
                         "direction": "ltr",
-                        "fontFamily": "Roboto",
-                        "fontSize": "10px",
+                        "fontFamily": "Roboto Slab",
+                        "fontSize": "16px",
                         "fontWeight": "500",
-                        "lineHeight": "14px",
-                        "paddingTop": "4px",
+                        "lineHeight": "22px",
+                        "marginRight": "2px",
+                        "textAlign": "right",
+                        "textDecoration": "none",
+                        "textTransform": "none",
+                      }
+                    }
+                  >
+                    -.--
+                  </span>
+                  <span
+                    className="css-text-901oao css-textHasAncestor-16my406"
+                    dir="auto"
+                    style={
+                      Object {
+                        "color": "rgba(66,69,74,1.00)",
+                        "direction": "ltr",
+                        "fontFamily": "Roboto",
+                        "fontSize": "16px",
+                        "fontWeight": "normal",
+                        "lineHeight": "22px",
                         "textAlign": "center",
                         "textDecoration": "none",
                         "textTransform": "none",
                       }
                     }
                   >
-                    G$
+                    <span
+                      className="css-text-901oao css-textHasAncestor-16my406"
+                      dir="auto"
+                      style={
+                        Object {
+                          "color": "rgba(255,255,255,1.00)",
+                          "direction": "ltr",
+                          "fontFamily": "Roboto Slab",
+                          "fontSize": "10px",
+                          "fontWeight": "500",
+                          "lineHeight": "14px",
+                          "textAlign": "right",
+                          "textDecoration": "none",
+                          "textTransform": "none",
+                        }
+                      }
+                    >
+                      G
+                    </span>
+                    <span
+                      className="css-text-901oao css-textHasAncestor-16my406"
+                      dir="auto"
+                      style={
+                        Object {
+                          "color": "rgba(255,255,255,1.00)",
+                          "direction": "ltr",
+                          "fontFamily": "Roboto Slab",
+                          "fontSize": "9.5px",
+                          "fontWeight": "500",
+                          "lineHeight": "11.4px",
+                          "textAlign": "right",
+                          "textDecoration": "none",
+                          "textTransform": "none",
+                        }
+                      }
+                    >
+                      $
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
@@ -655,38 +655,58 @@ exports[`Dashboard matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(85,85,85,1.00)",
+                    "color": "rgba(66,69,74,1.00)",
                     "direction": "ltr",
-                    "fontFamily": "Roboto Slab",
-                    "fontSize": "18px",
-                    "fontWeight": "700",
-                    "lineHeight": "24px",
-                    "textAlign": "right",
+                    "fontFamily": "Roboto",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "lineHeight": "22px",
+                    "marginRight": "-20px",
+                    "textAlign": "center",
                     "textDecoration": "none",
                     "textTransform": "none",
                   }
                 }
-              />
-            </div>
-            <div
-              className="css-text-901oao"
-              dir="auto"
-              style={
-                Object {
-                  "color": "rgba(66,69,74,1.00)",
-                  "direction": "ltr",
-                  "fontFamily": "Roboto Slab",
-                  "fontSize": "18px",
-                  "fontWeight": "700",
-                  "lineHeight": "24px",
-                  "marginRight": "-20px",
-                  "textAlign": "center",
-                  "textDecoration": "none",
-                  "textTransform": "none",
-                }
-              }
-            >
-              G$
+              >
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(85,85,85,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "18px",
+                      "fontWeight": "700",
+                      "lineHeight": "24px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  G
+                </span>
+                <span
+                  className="css-text-901oao css-textHasAncestor-16my406"
+                  dir="auto"
+                  style={
+                    Object {
+                      "color": "rgba(85,85,85,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto Slab",
+                      "fontSize": "17.5px",
+                      "fontWeight": "700",
+                      "lineHeight": "21px",
+                      "textAlign": "right",
+                      "textDecoration": "none",
+                      "textTransform": "none",
+                    }
+                  }
+                >
+                  $
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/dashboard/__tests__/__snapshots__/FeedList.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/FeedList.js.snap
@@ -924,20 +924,56 @@ exports[`FeedList Vertical rendering With feed data matches snapshot 1`] = `
                           dir="auto"
                           style={
                             Object {
-                              "color": "rgba(0,195,174,1.00)",
+                              "color": "rgba(66,69,74,1.00)",
                               "direction": "ltr",
-                              "fontFamily": "Roboto Slab",
-                              "fontSize": "10px",
-                              "fontWeight": "700",
-                              "lineHeight": "11px",
-                              "marginTop": "6px",
-                              "textAlign": "right",
+                              "fontFamily": "Roboto",
+                              "fontSize": "16px",
+                              "fontWeight": "normal",
+                              "lineHeight": "16px",
+                              "textAlign": "center",
                               "textDecoration": "none",
                               "textTransform": "none",
                             }
                           }
                         >
-                          G$
+                          <span
+                            className="css-text-901oao css-textHasAncestor-16my406"
+                            dir="auto"
+                            style={
+                              Object {
+                                "color": "rgba(0,195,174,1.00)",
+                                "direction": "ltr",
+                                "fontFamily": "Roboto Slab",
+                                "fontSize": "10px",
+                                "fontWeight": "700",
+                                "lineHeight": "11px",
+                                "textAlign": "right",
+                                "textDecoration": "none",
+                                "textTransform": "none",
+                              }
+                            }
+                          >
+                            G
+                          </span>
+                          <span
+                            className="css-text-901oao css-textHasAncestor-16my406"
+                            dir="auto"
+                            style={
+                              Object {
+                                "color": "rgba(0,195,174,1.00)",
+                                "direction": "ltr",
+                                "fontFamily": "Roboto Slab",
+                                "fontSize": "9.5px",
+                                "fontWeight": "700",
+                                "lineHeight": "11px",
+                                "textAlign": "right",
+                                "textDecoration": "none",
+                                "textTransform": "none",
+                              }
+                            }
+                          >
+                            $
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -1481,20 +1517,56 @@ exports[`FeedList Vertical rendering With feed data matches snapshot 1`] = `
                           dir="auto"
                           style={
                             Object {
-                              "color": "rgba(250,108,119,1.00)",
+                              "color": "rgba(66,69,74,1.00)",
                               "direction": "ltr",
-                              "fontFamily": "Roboto Slab",
-                              "fontSize": "10px",
-                              "fontWeight": "700",
-                              "lineHeight": "11px",
-                              "marginTop": "6px",
-                              "textAlign": "right",
+                              "fontFamily": "Roboto",
+                              "fontSize": "16px",
+                              "fontWeight": "normal",
+                              "lineHeight": "16px",
+                              "textAlign": "center",
                               "textDecoration": "none",
                               "textTransform": "none",
                             }
                           }
                         >
-                          G$
+                          <span
+                            className="css-text-901oao css-textHasAncestor-16my406"
+                            dir="auto"
+                            style={
+                              Object {
+                                "color": "rgba(250,108,119,1.00)",
+                                "direction": "ltr",
+                                "fontFamily": "Roboto Slab",
+                                "fontSize": "10px",
+                                "fontWeight": "700",
+                                "lineHeight": "11px",
+                                "textAlign": "right",
+                                "textDecoration": "none",
+                                "textTransform": "none",
+                              }
+                            }
+                          >
+                            G
+                          </span>
+                          <span
+                            className="css-text-901oao css-textHasAncestor-16my406"
+                            dir="auto"
+                            style={
+                              Object {
+                                "color": "rgba(250,108,119,1.00)",
+                                "direction": "ltr",
+                                "fontFamily": "Roboto Slab",
+                                "fontSize": "9.5px",
+                                "fontWeight": "700",
+                                "lineHeight": "11px",
+                                "textAlign": "right",
+                                "textDecoration": "none",
+                                "textTransform": "none",
+                              }
+                            }
+                          >
+                            $
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
@@ -225,19 +225,56 @@ exports[`Reason matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(85,85,85,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "18px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "22px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "18px",
+                  "fontWeight": "700",
+                  "lineHeight": "24px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "17.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "21px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/__tests__/__snapshots__/Send.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Send.js.snap
@@ -225,19 +225,56 @@ exports[`Send matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(85,85,85,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "18px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "22px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "18px",
+                  "fontWeight": "700",
+                  "lineHeight": "24px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "17.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "21px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
@@ -225,19 +225,56 @@ exports[`SendLinkSummary matches snapshot 1`] = `
             dir="auto"
             style={
               Object {
-                "color": "rgba(85,85,85,1.00)",
+                "color": "rgba(66,69,74,1.00)",
                 "direction": "ltr",
-                "fontFamily": "Roboto Slab",
-                "fontSize": "18px",
-                "fontWeight": "700",
-                "lineHeight": "24px",
-                "textAlign": "right",
+                "fontFamily": "Roboto",
+                "fontSize": "16px",
+                "fontWeight": "normal",
+                "lineHeight": "22px",
+                "textAlign": "center",
                 "textDecoration": "none",
                 "textTransform": "none",
               }
             }
           >
-            G$
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "18px",
+                  "fontWeight": "700",
+                  "lineHeight": "24px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              G
+            </span>
+            <span
+              className="css-text-901oao css-textHasAncestor-16my406"
+              dir="auto"
+              style={
+                Object {
+                  "color": "rgba(85,85,85,1.00)",
+                  "direction": "ltr",
+                  "fontFamily": "Roboto Slab",
+                  "fontSize": "17.5px",
+                  "fontWeight": "700",
+                  "lineHeight": "21px",
+                  "textAlign": "right",
+                  "textDecoration": "none",
+                  "textTransform": "none",
+                }
+              }
+            >
+              $
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167846000](https://www.pivotaltracker.com/story/show/167846000), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Refactoring `BigGoodDollar` and `BigNumber`
* Adding a `formatter` prop, which will receive a function to format the `number` instead of using the default `weiToMask`
* Adding `GDUnit` as a default value if no `unit` is specified for `BigGoodDollar`
* Updating `BigNumber` and `BigGoodDollar` props, now support `bigNumberProps` and `bigNumberUnitProps` that can be used to replace the `Text` props for those values within the updated components.
* Updating the usage of `bigNumberUnitStyles` apply styles to `GDUnit` as a whole, or the specified `unit` within `BigNumber`
* Updating `Claim` to display `G$` values using `BigGoodDollar` component

**Extra:**
* `Summary` looks as no-longer used, is it safe to delete it?

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
