### PR TITLE
(Bug) Update username validation

### DIFF
--- a/src/lib/gundb/UserModel.js
+++ b/src/lib/gundb/UserModel.js
@@ -66,7 +66,7 @@ const getUsernameErrorMessage = (username: string) => {
   if (username === '') {
     return 'Username cannot be empty'
   }
-  if (!isValidUsername(username)) {
+  if (!isNaN(username) || !isValidUsername(username)) {
     return 'Only letters, numbers and underscore'
   }
 


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167787387](https://www.pivotaltracker.com/story/show/167787387), by:

* Adding a validation to avoid username to be a number
I didn't replace the error message because I wasn't sure what should it say...

![image](https://user-images.githubusercontent.com/4523375/63604613-a3809e80-c5a2-11e9-9610-5271df56d280.png)

*CONSIDERATIONS*
Wait until @sirpy confirmation to merge this fix...
