### PR TITLE
Delete feed item should have trash icon like in design

### DIFF
--- a/src/components/dashboard/FeedActions.js
+++ b/src/components/dashboard/FeedActions.js
@@ -12,13 +12,13 @@ import type { FeedEventProps } from './FeedItems/EventProps'
  * @param {FeedEventProps} feedItem - Contains the feed item
  * @returns React element with actions
  */
-const FeedActions = ({ actionActive, hasAction, children, onPress, styles, theme }: FeedEventProps) => {
+const FeedActions = ({ actionActive, hasAction, children, actionIcon, onPress, styles, theme }: FeedEventProps) => {
   const backgroundColor = hasAction ? theme.colors.red : 'transparent'
 
   const content =
     actionActive === undefined ? (
       <>
-        <Icon name="close" color={theme.colors.surface} />
+        <Icon name={actionIcon} color={theme.colors.surface} size={22} />
         <Text style={styles.action} fontSize={14} fontWeight="medium" color="surface">
           {children}
         </Text>
@@ -47,10 +47,12 @@ const getStylesFromProps = ({ theme }) => ({
     borderTopRightRadius: theme.feedItems.borderRadius,
     height: theme.feedItems.height,
     marginTop: theme.sizes.default,
+    paddingRight: 0,
+    paddingLeft: 24,
     marginRight: theme.sizes.default,
     maxHeight: theme.feedItems.height,
     padding: theme.sizes.default,
-    width: 122,
+    width: 140,
   },
   actionsContainerInner: {
     display: 'flex',

--- a/src/components/dashboard/FeedList.js
+++ b/src/components/dashboard/FeedList.js
@@ -117,6 +117,7 @@ const FeedList = ({ data, handleFeedSelection, initialNumToRender, onEndReached,
       <FeedActions
         onPress={hasAction && (() => handleFeedActionPress(item, actions))}
         actionActive={activeItems[item.id]}
+        actionIcon={actionIcon(actions)}
         {...props}
       >
         {actionLabel(actions)}
@@ -172,6 +173,18 @@ const actionLabel = ({ canDelete, canCancel }) => {
   }
 
   return ''
+}
+
+const actionIcon = ({ canDelete, canCancel }) => {
+  if (canCancel) {
+    return 'close'
+  }
+
+  if (canDelete) {
+    return 'trash'
+  }
+
+  return null
 }
 
 export default GDStore.withStore(withStyles(getStylesFromProps)(FeedList))

--- a/src/components/dashboard/__tests__/__snapshots__/FeedActions.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/FeedActions.js.snap
@@ -42,10 +42,10 @@ exports[`FeedActions matches snapshot 1`] = `
         "msFlexItemAlign": "end",
         "msFlexPack": "center",
         "paddingBottom": "8px",
-        "paddingLeft": "8px",
-        "paddingRight": "8px",
+        "paddingLeft": "24px",
+        "paddingRight": "0px",
         "paddingTop": "8px",
-        "width": "122px",
+        "width": "140px",
       }
     }
   />


### PR DESCRIPTION
<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
This PR closes [#167867608](https://www.pivotaltracker.com/story/show/167867608), by:

<!-- If you're linking a repository issue, use the following line instead:
This PR closes #x, by:
-->

* Updating FeedActions to take which icon should use
* Updating FeedList to pass the icon to FeedActions
* Adding `actionIcon` function that returns the icons name depending on the actions as in `actionLabel` 

**Extra:**

![Screenshot from 2019-08-23 17-19-54](https://user-images.githubusercontent.com/1731297/63621432-4a2c6580-c5ca-11e9-8d96-f1056067147f.png)
![Screenshot from 2019-08-23 17-19-45](https://user-images.githubusercontent.com/1731297/63621433-4ac4fc00-c5ca-11e9-9517-89791437e8cc.png)
![Screenshot from 2019-08-23 17-18-59](https://user-images.githubusercontent.com/1731297/63621435-4ac4fc00-c5ca-11e9-8846-d5fc21f35f22.png)


<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
