### PR TITLE
(Feature) Non-mobile user should see a pre splash screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,12 +22,8 @@ const App = () => {
     setUseDesktop(true)
   }
 
-  const Splash =
-    !isMobile && !useDesktop ? (
-      <SplashDesktop onContinue={continueWithDesktop} />
-    ) : (
-      <RouterSelector usingDesktop={useDesktop} />
-    )
+  const Splash = !isMobile && !useDesktop ? <SplashDesktop onContinue={continueWithDesktop} /> : <RouterSelector />
+
   return (
     <PaperProvider theme={theme}>
       <SafeAreaView style={styles.safeAreaView}>

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,34 @@
 // @flow
-import React from 'react'
-import { Platform, SafeAreaView, StyleSheet } from 'react-native'
+import { isMobile } from 'mobile-device-detect'
+import React, { useEffect, useState } from 'react'
+import { AsyncStorage, Platform, SafeAreaView, StyleSheet } from 'react-native'
 import PaperProvider from 'react-native-paper/src/core/Provider'
 import { theme } from './components/theme/styles'
+import { USE_DESKTOP } from './lib/constants/localStorage'
 import SimpleStore from './lib/undux/SimpleStore'
 import RouterSelector from './RouterSelector'
 import { SimpleStoreDialog } from './components/common/dialogs/CustomDialog'
 import LoadingIndicator from './components/common/view/LoadingIndicator'
+import SplashDesktop from './components/splash/SplashDesktop'
 
 const App = () => {
   // onRecaptcha = (token: string) => {
   //   userStorage.setProfileField('recaptcha', token, 'private')
   // }
+  const [useDesktop, setUseDesktop] = useState()
+
+  const continueWithDesktop = () => {
+    AsyncStorage.setItem(USE_DESKTOP, true)
+    setUseDesktop(true)
+  }
+
+  useEffect(() => {
+    const getDesktopFlag = async () => {
+      const desktopFlag = JSON.parse(await AsyncStorage.getItem(USE_DESKTOP))
+      setUseDesktop(desktopFlag)
+    }
+    getDesktopFlag()
+  }, [])
 
   return (
     <SimpleStore.Container>
@@ -21,7 +38,11 @@ const App = () => {
             <SimpleStoreDialog />
             <LoadingIndicator />
             {/* <ReCaptcha sitekey={Config.recaptcha} action="auth" verifyCallback={this.onRecaptcha} /> */}
-            <RouterSelector />
+            {!isMobile && !useDesktop ? (
+              <SplashDesktop onContinue={continueWithDesktop} />
+            ) : (
+              <RouterSelector usingDesktop={useDesktop} />
+            )}
           </React.Fragment>
         </SafeAreaView>
       </PaperProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,9 @@
 // @flow
 import { isMobile } from 'mobile-device-detect'
-import React, { useEffect, useState } from 'react'
-import { AsyncStorage, Platform, SafeAreaView, StyleSheet } from 'react-native'
+import React, { useState } from 'react'
+import { Platform, SafeAreaView, StyleSheet } from 'react-native'
 import PaperProvider from 'react-native-paper/src/core/Provider'
 import { theme } from './components/theme/styles'
-import { USE_DESKTOP } from './lib/constants/localStorage'
 import SimpleStore from './lib/undux/SimpleStore'
 import RouterSelector from './RouterSelector'
 import { SimpleStoreDialog } from './components/common/dialogs/CustomDialog'
@@ -12,41 +11,34 @@ import LoadingIndicator from './components/common/view/LoadingIndicator'
 import SplashDesktop from './components/splash/SplashDesktop'
 
 const App = () => {
+  const store = SimpleStore.useStore()
+
   // onRecaptcha = (token: string) => {
   //   userStorage.setProfileField('recaptcha', token, 'private')
   // }
-  const [useDesktop, setUseDesktop] = useState()
+  const [useDesktop, setUseDesktop] = useState(store.get('isLoggedIn') === true)
 
   const continueWithDesktop = () => {
-    AsyncStorage.setItem(USE_DESKTOP, true)
     setUseDesktop(true)
   }
 
-  useEffect(() => {
-    const getDesktopFlag = async () => {
-      const desktopFlag = JSON.parse(await AsyncStorage.getItem(USE_DESKTOP))
-      setUseDesktop(desktopFlag)
-    }
-    getDesktopFlag()
-  }, [])
-
+  const Splash =
+    !isMobile && !useDesktop ? (
+      <SplashDesktop onContinue={continueWithDesktop} />
+    ) : (
+      <RouterSelector usingDesktop={useDesktop} />
+    )
   return (
-    <SimpleStore.Container>
-      <PaperProvider theme={theme}>
-        <SafeAreaView style={styles.safeAreaView}>
-          <React.Fragment>
-            <SimpleStoreDialog />
-            <LoadingIndicator />
-            {/* <ReCaptcha sitekey={Config.recaptcha} action="auth" verifyCallback={this.onRecaptcha} /> */}
-            {!isMobile && !useDesktop ? (
-              <SplashDesktop onContinue={continueWithDesktop} />
-            ) : (
-              <RouterSelector usingDesktop={useDesktop} />
-            )}
-          </React.Fragment>
-        </SafeAreaView>
-      </PaperProvider>
-    </SimpleStore.Container>
+    <PaperProvider theme={theme}>
+      <SafeAreaView style={styles.safeAreaView}>
+        <React.Fragment>
+          <SimpleStoreDialog />
+          <LoadingIndicator />
+          {/* <ReCaptcha sitekey={Config.recaptcha} action="auth" verifyCallback={this.onRecaptcha} /> */}
+          {Splash}
+        </React.Fragment>
+      </SafeAreaView>
+    </PaperProvider>
   )
 }
 

--- a/src/RouterSelector.js
+++ b/src/RouterSelector.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { AsyncStorage } from 'react-native'
-import { USE_DESKTOP } from './lib/constants/localStorage'
+import { DESTINATION_PATH, USE_DESKTOP } from './lib/constants/localStorage'
 import SimpleStore from './lib/undux/SimpleStore'
 import Splash from './components/splash/Splash'
 import { delay } from './lib/utils/async'
@@ -33,7 +33,7 @@ const RouterSelector = () => {
   const store = SimpleStore.useStore()
 
   //we use global state for signup process to signal user has registered
-  const isLoggedIn = store.get('isLoggedIn') //Promise.resolve( || AsyncStorage.getItem('GOODDAPP_isLoggedIn'))
+  const isLoggedIn = store.get('isLoggedIn') //Promise.resolve( || AsyncStorage.getItem(IS_LOGGED_IN))
 
   log.debug('RouterSelector Rendered', { isLoggedIn })
   const Router = isLoggedIn ? AppRouter : SignupRouter
@@ -47,7 +47,7 @@ const RouterSelector = () => {
     if (params && Object.keys(params).length > 0) {
       const dest = { path: window.location.pathname.slice(1), params }
       log.debug('Saving destination url', dest)
-      AsyncStorage.setItem('destinationPath', JSON.stringify(dest))
+      AsyncStorage.setItem(DESTINATION_PATH, JSON.stringify(dest))
     }
   }, [])
   return (

--- a/src/RouterSelector.js
+++ b/src/RouterSelector.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { AsyncStorage } from 'react-native'
-import { DESTINATION_PATH, USE_DESKTOP } from './lib/constants/localStorage'
+import { DESTINATION_PATH } from './lib/constants/localStorage'
 import SimpleStore from './lib/undux/SimpleStore'
 import Splash from './components/splash/Splash'
 import { delay } from './lib/utils/async'
@@ -10,13 +10,8 @@ import logger from './lib/logger/pino-logger'
 const log = logger.child({ from: 'RouterSelector' })
 
 // import Router from './SignupRouter'
-let SignupRouter = React.lazy(async () => {
-  const useDesktop = JSON.parse(await AsyncStorage.getItem(USE_DESKTOP))
-  const delayTime = useDesktop ? 0 : 2000
-
-  return Promise.all([delay(delayTime), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(
-    r => r[1]
-  )
+let SignupRouter = React.lazy(() => {
+  return Promise.all([delay(2000), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(r => r[1])
 })
 let AppRouter = React.lazy(() => {
   log.debug('initializing storage and wallet...')

--- a/src/RouterSelector.js
+++ b/src/RouterSelector.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { AsyncStorage } from 'react-native'
+import { USE_DESKTOP } from './lib/constants/localStorage'
 import SimpleStore from './lib/undux/SimpleStore'
 import Splash from './components/splash/Splash'
 import { delay } from './lib/utils/async'
@@ -9,9 +10,14 @@ import logger from './lib/logger/pino-logger'
 const log = logger.child({ from: 'RouterSelector' })
 
 // import Router from './SignupRouter'
-let SignupRouter = React.lazy(() =>
-  Promise.all([delay(2000), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(r => r[1])
-)
+let SignupRouter = React.lazy(async () => {
+  const useDesktop = JSON.parse(await AsyncStorage.getItem(USE_DESKTOP))
+  const delayTime = useDesktop ? 0 : 2000
+
+  return Promise.all([delay(delayTime), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(
+    r => r[1]
+  )
+})
 let AppRouter = React.lazy(() => {
   log.debug('initializing storage and wallet...')
   let walletAndStorageReady = import(/* webpackChunkName: "init" */ './init')

--- a/src/RouterSelector.js
+++ b/src/RouterSelector.js
@@ -10,9 +10,9 @@ import logger from './lib/logger/pino-logger'
 const log = logger.child({ from: 'RouterSelector' })
 
 // import Router from './SignupRouter'
-let SignupRouter = React.lazy(() => {
-  return Promise.all([delay(2000), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(r => r[1])
-})
+let SignupRouter = React.lazy(() =>
+  Promise.all([delay(2000), import(/* webpackChunkName: "signuprouter" */ './SignupRouter')]).then(r => r[1])
+)
 let AppRouter = React.lazy(() => {
   log.debug('initializing storage and wallet...')
   let walletAndStorageReady = import(/* webpackChunkName: "init" */ './init')

--- a/src/__tests__/App.js
+++ b/src/__tests__/App.js
@@ -3,10 +3,17 @@ import React from 'react'
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer'
 import App from '../App'
+import SimpleStore from '../lib/undux/SimpleStore'
+
+const { Container } = SimpleStore
 
 describe('App', () => {
   it('renders without errors', () => {
-    const tree = renderer.create(<App />)
+    const tree = renderer.create(
+      <Container>
+        <App />
+      </Container>
+    )
     expect(tree.toJSON()).toBeTruthy()
   })
 })

--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import { AsyncStorage } from 'react-native'
 import { SceneView } from '@react-navigation/core'
 import some from 'lodash/some'
+import { DESTINATION_PATH } from '../../lib/constants/localStorage'
 import logger from '../../lib/logger/pino-logger'
 import API from '../../lib/API/api'
 import SimpleStore from '../../lib/undux/SimpleStore'
@@ -31,8 +32,8 @@ const AppSwitch = (props: LoadingProps) => {
     const { router, state } = props.navigation
 
     // const navInfo = router.getPathAndParamsForState(state)
-    const destinationPath = await AsyncStorage.getItem('destinationPath').then(JSON.parse)
-    AsyncStorage.removeItem('destinationPath')
+    const destinationPath = await AsyncStorage.getItem(DESTINATION_PATH).then(JSON.parse)
+    AsyncStorage.removeItem(DESTINATION_PATH)
     log.debug('getParams', { destinationPath, router, state })
     if (destinationPath) {
       const app = router.getActionForPathAndParams(destinationPath.path)
@@ -76,7 +77,7 @@ const AppSwitch = (props: LoadingProps) => {
     // if (isLoggedIn) {
     //   if (destDetails) {
     //     props.navigation.navigate(destDetails)
-    //     return AsyncStorage.removeItem('destinationPath')
+    //     return AsyncStorage.removeItem(DESTINATION_PATH)
     //   } else props.navigation.navigate('AppNavigation')
     // } else {
     //   const { jwt } = credsOrError
@@ -95,7 +96,7 @@ const AppSwitch = (props: LoadingProps) => {
     //       //for non loggedin users, store non email validation params to the destinationPath for later
     //       //to be used once signed in
     //       const destinationPath = JSON.stringify(destDetails)
-    //       AsyncStorage.setItem('destinationPath', destinationPath)
+    //       AsyncStorage.setItem(DESTINATION_PATH, destinationPath)
     //     }
     //     props.navigation.navigate('Auth')
     //   } else {

--- a/src/components/common/view/QRCode.js
+++ b/src/components/common/view/QRCode.js
@@ -4,10 +4,10 @@ import QRCodeReact from 'qrcode.react'
 import { View } from 'react-native'
 import { withStyles } from '../../../lib/styles'
 
-const QRCode = ({ styles, ...props }: any) => {
+const QRCode = ({ qrStyles = {}, styles, ...props }: any) => {
   return (
     <View style={styles.qrWrapper}>
-      <View style={styles.qrCode}>
+      <View style={[styles.qrCode, qrStyles]}>
         <QRCodeReact {...props} />
       </View>
     </View>

--- a/src/components/dashboard/FaceRecognition/UnsupportedDevice.js
+++ b/src/components/dashboard/FaceRecognition/UnsupportedDevice.js
@@ -4,6 +4,7 @@ import { isIOS, isMobile } from 'mobile-device-detect'
 
 import get from 'lodash/get'
 import QRCode from 'qrcode.react'
+import { GD_USER_MNEMONIC } from '../../../lib/constants/localStorage'
 import { getFirstWord } from '../../../lib/utils/getFirstWord'
 import Config from '../../../config/config'
 import { CopyButton, Section, Wrapper } from '../../common'
@@ -41,7 +42,7 @@ const UnsupportedDevice = props => {
   }
 
   const generateQRCode = async () => {
-    const mnemonic = await AsyncStorage.getItem('GD_USER_MNEMONIC')
+    const mnemonic = await AsyncStorage.getItem(GD_USER_MNEMONIC)
     const url = `${Config.publicUrl}/Auth/Recover/?mnemonic=${mnemonic}&redirect=${encodeURI(
       '/AppNavigation/Dashboard/FRIntro'
     )}`

--- a/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
@@ -630,7 +630,7 @@ a few seconds to complete
                 "WebkitBoxPack": "center",
                 "WebkitJustifyContent": "center",
                 "alignItems": "stretch",
-                "backgroundColor": "rgba(0,0,0,0.12)",
+                "backgroundColor": "rgba(0,175,255,1.00)",
                 "borderBottomColor": "rgba(0,175,255,1.00)",
                 "borderBottomLeftRadius": "50px",
                 "borderBottomRightRadius": "50px",
@@ -647,6 +647,7 @@ a few seconds to complete
                 "borderTopRightRadius": "50px",
                 "borderTopStyle": "solid",
                 "borderTopWidth": "0px",
+                "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
                 "display": "flex",
                 "justifyContent": "center",
                 "marginBottom": "0px",
@@ -665,13 +666,15 @@ a few seconds to complete
             }
           >
             <div
-              aria-disabled={true}
-              className="css-view-1dbjc4n"
-              disabled={true}
+              className="css-cursor-18t94o4 css-view-1dbjc4n"
+              data-focusable={true}
+              disabled={false}
               onKeyDown={[Function]}
+              onKeyPress={[Function]}
               onKeyUp={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
+              onResponderRelease={[Function]}
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
@@ -682,11 +685,15 @@ a few seconds to complete
                   "borderBottomRightRadius": "50px",
                   "borderTopLeftRadius": "50px",
                   "borderTopRightRadius": "50px",
+                  "cursor": "pointer",
+                  "msTouchAction": "manipulation",
                   "overflowX": "hidden",
                   "overflowY": "hidden",
                   "position": "relative",
+                  "touchAction": "manipulation",
                 }
               }
+              tabIndex="0"
             >
               <div
                 className="css-view-1dbjc4n"
@@ -714,7 +721,7 @@ a few seconds to complete
                   dir="auto"
                   style={
                     Object {
-                      "color": "rgba(0,0,0,0.32)",
+                      "color": "rgba(255,255,255,1.00)",
                       "direction": "ltr",
                       "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
                       "letterSpacing": "1px",

--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -4,6 +4,7 @@ import bip39 from 'bip39-light'
 import get from 'lodash/get'
 import React, { useEffect, useState } from 'react'
 import { AsyncStorage } from 'react-native'
+import { IS_LOGGED_IN } from '../../lib/constants/localStorage'
 import logger from '../../lib/logger/pino-logger'
 import { withStyles } from '../../lib/styles'
 import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
@@ -69,7 +70,7 @@ const Mnemonics = ({ screenProps, navigation, styles }) => {
       const [profile, fullName] = await profileExist()
 
       if (profile) {
-        await AsyncStorage.setItem('GOODDAPP_isLoggedIn', true)
+        await AsyncStorage.setItem(IS_LOGGED_IN, true)
         const incomingRedirectUrl = get(navigation, 'state.params.redirect', '/')
         const firstName = getFirstWord(fullName)
         showDialog({

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { AsyncStorage, ScrollView, StyleSheet, View } from 'react-native'
 import { createSwitchNavigator } from '@react-navigation/core'
 import { isMobileSafari } from 'mobile-device-detect'
+import { GD_USER_MNEMONIC, IS_LOGGED_IN } from '../../lib/constants/localStorage'
 
 import NavBar from '../appNavigation/NavBar'
 import { navigationConfig } from '../appNavigation/navigationConfig'
@@ -145,8 +146,8 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
       ])
 
       //need to wait for API.addUser but we dont need to wait for it to finish
-      AsyncStorage.getItem('GD_USER_MNEMONIC').then(mnemonic => API.sendRecoveryInstructionByEmail(mnemonic)),
-        await AsyncStorage.setItem('GOODDAPP_isLoggedIn', true)
+      AsyncStorage.getItem(GD_USER_MNEMONIC).then(mnemonic => API.sendRecoveryInstructionByEmail(mnemonic)),
+        await AsyncStorage.setItem(IS_LOGGED_IN, true)
       log.debug('New user created')
       return true
     } catch (e) {

--- a/src/components/splash/SplashDesktop.js
+++ b/src/components/splash/SplashDesktop.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Image, StyleSheet } from 'react-native'
+import goodDollarImage from '../../assets/Splash/goodDollar.svg'
+import wavePattern from '../../assets/wave50.svg'
+import { getDesignRelativeHeight } from '../../lib/utils/sizes'
+import CustomButton from '../common/buttons/CustomButton'
+import Wrapper from '../common/layout/Wrapper'
+import Section from '../common/layout/Section'
+import Config from '../../config/config'
+import QRCode from '../common/view/QRCode'
+
+//minimize delay <Image> has over web <img>
+Image.prefetch(goodDollarImage)
+Image.prefetch(wavePattern)
+
+const SplashDesktop = ({ onContinue }) => (
+  <Wrapper style={styles.wrapper}>
+    <Section style={styles.container}>
+      <Section.Stack style={styles.content} grow justifyContent="space-between">
+        <Section.Text fontSize={22} color="darkBlue">
+          {`For Best Experience\nplease scan and continue\non your mobile device.`}
+        </Section.Text>
+        <QRCode value={Config.publicUrl} size={150} qrStyles={styles.qrStyles} />
+        <Image source={goodDollarImage} style={styles.goodDollar} resizeMode="contain" />
+        <Section.Text fontSize={22} color="darkBlue">
+          {`V${Config.version}`}
+        </Section.Text>
+        <CustomButton mode="outlined" color="white" style={styles.buttonContinue} onPress={onContinue}>
+          Continue on Web
+        </CustomButton>
+      </Section.Stack>
+    </Section>
+  </Wrapper>
+)
+
+SplashDesktop.navigationOptions = {
+  title: 'GoodDollar | Welcome',
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    padding: 0,
+  },
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundImage: `url(${wavePattern})`,
+    backgroundRepeat: 'repeat-y',
+    backgroundColor: 'transparent',
+    backgroundSize: 'cover',
+    transform: [{ rotateY: '180deg' }],
+    flex: 1,
+  },
+  content: {
+    transform: [{ rotateY: '180deg' }],
+    marginTop: getDesignRelativeHeight(30),
+    width: '100%',
+  },
+  goodDollar: {
+    maxWidth: '100%',
+    minHeight: 30,
+    minWidth: 212,
+  },
+  buttonContinue: {
+    borderColor: 'white',
+  },
+  qrStyles: {
+    backgroundColor: 'white',
+    transform: [{ rotateY: '180deg' }],
+    borderWidth: 2,
+  },
+})
+
+export default SplashDesktop

--- a/src/components/splash/__tests__/SplashDesktop.js
+++ b/src/components/splash/__tests__/SplashDesktop.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { withThemeProvider } from '../../../__tests__/__util__'
+import ImportedSplash from '../SplashDesktop'
+
+const SplashDesktop = withThemeProvider(ImportedSplash)
+
+describe('SplashDesktop', () => {
+  it('renders without errors', () => {
+    const tree = renderer.create(<SplashDesktop />)
+    expect(tree.toJSON()).toBeTruthy()
+  })
+
+  it('matches snapshot', () => {
+    const component = renderer.create(<SplashDesktop />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
+++ b/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
@@ -1,0 +1,502 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplashDesktop matches snapshot 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitBoxFlex": 1,
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
+    }
+  }
+>
+  <div
+    className="css-view-1dbjc4n"
+    data-name="viewWrapper"
+    style={
+      Object {
+        "WebkitBoxDirection": "normal",
+        "WebkitBoxFlex": 0,
+        "WebkitBoxOrient": "vertical",
+        "WebkitFlexDirection": "column",
+        "WebkitFlexGrow": 0,
+        "backgroundImage": "linear-gradient(to bottom, #00AFFF, #2DC0F7, #28C0EF, #23C0E7, #1EC1DF, #19C1D7, #14C1CF, #0FC2C7, #0FC2C7, #0AC2BF, #05C2B7, #00C3AF)",
+        "display": "flex",
+        "flexDirection": "column",
+        "flexGrow": 0,
+        "msFlexDirection": "column",
+        "msFlexPositive": 0,
+        "paddingBottom": "0px",
+        "paddingLeft": "0px",
+        "paddingRight": "0px",
+        "paddingTop": "0px",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+      style={
+        Object {
+          "WebkitAlignItems": "center",
+          "WebkitBoxAlign": "center",
+          "WebkitBoxFlex": 1,
+          "WebkitBoxPack": "center",
+          "WebkitFlexBasis": "0%",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "WebkitJustifyContent": "center",
+          "WebkitTransform": "rotateY(180deg)",
+          "alignItems": "center",
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "backgroundImage": "url(wave50.svg)",
+          "backgroundRepeat": "repeat-y",
+          "backgroundSize": "cover",
+          "borderBottomLeftRadius": "5px",
+          "borderBottomRightRadius": "5px",
+          "borderTopLeftRadius": "5px",
+          "borderTopRightRadius": "5px",
+          "flexBasis": "0%",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "justifyContent": "center",
+          "msFlexAlign": "center",
+          "msFlexNegative": 1,
+          "msFlexPack": "center",
+          "msFlexPositive": 1,
+          "msFlexPreferredSize": "0%",
+          "paddingBottom": "16px",
+          "paddingLeft": "12px",
+          "paddingRight": "12px",
+          "paddingTop": "16px",
+          "transform": "rotateY(180deg)",
+        }
+      }
+    >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "WebkitAlignItems": "stretch",
+            "WebkitBoxAlign": "stretch",
+            "WebkitBoxDirection": "normal",
+            "WebkitBoxFlex": 1,
+            "WebkitBoxOrient": "vertical",
+            "WebkitBoxPack": "justify",
+            "WebkitFlexDirection": "column",
+            "WebkitFlexGrow": 1,
+            "WebkitJustifyContent": "space-between",
+            "WebkitTransform": "rotateY(180deg)",
+            "alignItems": "stretch",
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "justifyContent": "space-between",
+            "marginTop": "0px",
+            "msFlexAlign": "stretch",
+            "msFlexDirection": "column",
+            "msFlexPack": "justify",
+            "msFlexPositive": 1,
+            "transform": "rotateY(180deg)",
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="css-text-901oao"
+          dir="auto"
+          style={
+            Object {
+              "color": "rgba(12,38,61,1.00)",
+              "direction": "ltr",
+              "fontFamily": "Roboto",
+              "fontSize": "22px",
+              "fontWeight": "normal",
+              "lineHeight": "30px",
+              "textAlign": "center",
+              "textDecoration": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          For Best Experience
+please scan and continue
+on your mobile device.
+        </div>
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "WebkitAlignItems": "center",
+              "WebkitBoxAlign": "center",
+              "WebkitBoxPack": "center",
+              "WebkitJustifyContent": "center",
+              "alignItems": "center",
+              "justifyContent": "center",
+              "msFlexAlign": "center",
+              "msFlexPack": "center",
+            }
+          }
+        >
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "WebkitTransform": "rotateY(180deg)",
+                "backgroundColor": "rgba(255,255,255,1.00)",
+                "borderBottomColor": "rgba(0,175,255,1.00)",
+                "borderBottomLeftRadius": "5px",
+                "borderBottomRightRadius": "5px",
+                "borderBottomWidth": "2px",
+                "borderLeftColor": "rgba(0,175,255,1.00)",
+                "borderLeftWidth": "2px",
+                "borderRightColor": "rgba(0,175,255,1.00)",
+                "borderRightWidth": "2px",
+                "borderTopColor": "rgba(0,175,255,1.00)",
+                "borderTopLeftRadius": "5px",
+                "borderTopRightRadius": "5px",
+                "borderTopWidth": "2px",
+                "paddingBottom": "16px",
+                "paddingLeft": "16px",
+                "paddingRight": "16px",
+                "paddingTop": "16px",
+                "transform": "rotateY(180deg)",
+              }
+            }
+          >
+            <canvas
+              height={150}
+              style={
+                Object {
+                  "height": 150,
+                  "width": 150,
+                }
+              }
+              theme={
+                Object {
+                  "backdrop": Object {
+                    "backgroundColor": "rgba(255, 0, 0, 0.8)",
+                  },
+                  "borders": Object {
+                    "defaultBorderColor": "#c9c8c9",
+                  },
+                  "colors": Object {
+                    "accent": "#03dac4",
+                    "backdrop": "rgba(0, 0, 0, 0.5)",
+                    "background": "#f6f6f6",
+                    "blue": "#006EA0",
+                    "darkBlue": "#0C263D",
+                    "darkGray": "#42454A",
+                    "disabled": "rgba(0, 0, 0, 0.26)",
+                    "error": "#FA6C77",
+                    "gray": "#555",
+                    "gray50Percent": "#CBCBCB",
+                    "gray80Percent": "#A3A3A3",
+                    "green": "#00C3AE",
+                    "lightGray": "#EEE",
+                    "lightGreen": "#00BBA5",
+                    "lighterGray": "#A3A3A3",
+                    "notification": "#f50057",
+                    "orange": "#F8AF40",
+                    "placeholder": "#CBCBCB",
+                    "primary": "#00AFFF",
+                    "purple": "#9F6A9D",
+                    "red": "#FA6C77",
+                    "surface": "#ffffff",
+                    "text": "#222",
+                  },
+                  "dark": false,
+                  "feedItems": Object {
+                    "borderRadius": 8,
+                    "height": 84,
+                    "itemBackgroundColor": "#fff",
+                  },
+                  "fontStyle": Object {
+                    "color": "#555",
+                    "fontSize": 18,
+                    "textAlign": "center",
+                  },
+                  "fonts": Object {
+                    "default": "Roboto",
+                    "light": "Roboto-Light, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                    "medium": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                    "regular": "Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                    "slab": "Roboto Slab",
+                    "thin": "Roboto-Thin, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                  },
+                  "modals": Object {
+                    "activityIndicatorBackgroundColor": "rgba(255, 255, 255, 0.8)",
+                    "backgroundColor": "#fff",
+                    "borderLeftWidth": 10,
+                    "borderRadius": 5,
+                    "contentPadding": 16,
+                    "jaggedEdgeSize": 16,
+                    "overlayBackgroundColor": "transparent",
+                    "overlayHorizontalPadding": 20,
+                    "overlayVerticalPadding": 65,
+                  },
+                  "paddings": Object {
+                    "defaultMargin": 8,
+                    "mainContainerPadding": 8,
+                  },
+                  "roundness": 4,
+                  "sizes": Object {
+                    "borderRadius": 5,
+                    "default": 8,
+                    "defaultDouble": 16,
+                    "defaultHalf": 4,
+                    "defaultQuadruple": 32,
+                  },
+                }
+              }
+              width={150}
+            />
+          </div>
+        </div>
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "WebkitFlexBasis": "auto",
+              "flexBasis": "auto",
+              "maxWidth": "100%",
+              "minHeight": "30px",
+              "minWidth": "212px",
+              "msFlexPreferredSize": "auto",
+              "overflowX": "hidden",
+              "overflowY": "hidden",
+              "zIndex": 0,
+            }
+          }
+        >
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "backgroundColor": "rgba(0,0,0,0.00)",
+                "backgroundImage": "url(\\"goodDollar.svg\\")",
+                "backgroundPosition": "center",
+                "backgroundRepeat": "no-repeat",
+                "backgroundSize": "contain",
+                "bottom": "0px",
+                "height": "100%",
+                "left": "0px",
+                "position": "absolute",
+                "right": "0px",
+                "top": "0px",
+                "width": "100%",
+                "zIndex": -1,
+              }
+            }
+          />
+          <img
+            alt=""
+            className="css-accessibilityImage-9pa8cd"
+            draggable={false}
+            src="goodDollar.svg"
+          />
+        </div>
+        <div
+          className="css-text-901oao"
+          dir="auto"
+          style={
+            Object {
+              "color": "rgba(12,38,61,1.00)",
+              "direction": "ltr",
+              "fontFamily": "Roboto",
+              "fontSize": "22px",
+              "fontWeight": "normal",
+              "lineHeight": "30px",
+              "textAlign": "center",
+              "textDecoration": "none",
+              "textTransform": "none",
+            }
+          }
+        >
+          Vv0
+        </div>
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "WebkitAlignItems": "stretch",
+              "WebkitBoxAlign": "stretch",
+              "WebkitBoxPack": "center",
+              "WebkitJustifyContent": "center",
+              "alignItems": "stretch",
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "borderBottomColor": "rgba(255,255,255,1.00)",
+              "borderBottomLeftRadius": "50px",
+              "borderBottomRightRadius": "50px",
+              "borderBottomStyle": "solid",
+              "borderBottomWidth": "1px",
+              "borderLeftColor": "rgba(255,255,255,1.00)",
+              "borderLeftStyle": "solid",
+              "borderLeftWidth": "1px",
+              "borderRightColor": "rgba(255,255,255,1.00)",
+              "borderRightStyle": "solid",
+              "borderRightWidth": "1px",
+              "borderTopColor": "rgba(255,255,255,1.00)",
+              "borderTopLeftRadius": "50px",
+              "borderTopRightRadius": "50px",
+              "borderTopStyle": "solid",
+              "borderTopWidth": "1px",
+              "display": "flex",
+              "justifyContent": "center",
+              "marginBottom": "0px",
+              "marginLeft": "0px",
+              "marginRight": "0px",
+              "marginTop": "0px",
+              "minHeight": "44px",
+              "minWidth": "64px",
+              "msFlexAlign": "stretch",
+              "msFlexPack": "center",
+              "paddingBottom": "0px",
+              "paddingLeft": "0px",
+              "paddingRight": "0px",
+              "paddingTop": "0px",
+            }
+          }
+        >
+          <div
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            role="button"
+            style={
+              Object {
+                "borderBottomLeftRadius": "50px",
+                "borderBottomRightRadius": "50px",
+                "borderTopLeftRadius": "50px",
+                "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
+                "overflowX": "hidden",
+                "overflowY": "hidden",
+                "position": "relative",
+                "touchAction": "manipulation",
+              }
+            }
+            tabIndex="0"
+          >
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitAlignItems": "center",
+                  "WebkitBoxAlign": "center",
+                  "WebkitBoxDirection": "normal",
+                  "WebkitBoxOrient": "horizontal",
+                  "WebkitBoxPack": "center",
+                  "WebkitFlexDirection": "row",
+                  "WebkitJustifyContent": "center",
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "letterSpacing": "0px",
+                  "msFlexAlign": "center",
+                  "msFlexDirection": "row",
+                  "msFlexPack": "center",
+                }
+              }
+            >
+              <div
+                className="css-text-901oao css-textOneLine-bfa6kz"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(255,255,255,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                    "letterSpacing": "1px",
+                    "marginBottom": "9px",
+                    "marginLeft": "16px",
+                    "marginRight": "16px",
+                    "marginTop": "9px",
+                    "textAlign": "center",
+                  }
+                }
+              >
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitAlignItems": "center",
+                      "WebkitBoxAlign": "center",
+                      "WebkitBoxDirection": "normal",
+                      "WebkitBoxFlex": 1,
+                      "WebkitBoxOrient": "horizontal",
+                      "WebkitFlexBasis": "0%",
+                      "WebkitFlexDirection": "row",
+                      "WebkitFlexGrow": 1,
+                      "WebkitFlexShrink": 1,
+                      "alignItems": "center",
+                      "display": "flex",
+                      "flexBasis": "0%",
+                      "flexDirection": "row",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "msFlexAlign": "center",
+                      "msFlexDirection": "row",
+                      "msFlexNegative": 1,
+                      "msFlexPositive": 1,
+                      "msFlexPreferredSize": "0%",
+                    }
+                  }
+                >
+                  <span
+                    className="css-text-901oao css-textHasAncestor-16my406"
+                    dir="auto"
+                    style={
+                      Object {
+                        "WebkitAlignItems": "center",
+                        "WebkitBoxAlign": "center",
+                        "WebkitBoxPack": "center",
+                        "WebkitJustifyContent": "center",
+                        "alignItems": "center",
+                        "color": "rgba(255,255,255,1.00)",
+                        "direction": "ltr",
+                        "fontFamily": "Roboto",
+                        "fontSize": "16px",
+                        "fontWeight": "500",
+                        "justifyContent": "center",
+                        "letterSpacing": "0px",
+                        "lineHeight": "22px",
+                        "msFlexAlign": "center",
+                        "msFlexPack": "center",
+                        "paddingTop": "1px",
+                        "textAlign": "center",
+                        "textDecoration": "none",
+                        "textTransform": "uppercase",
+                      }
+                    }
+                  >
+                    Continue on Web
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
+++ b/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
@@ -367,15 +367,13 @@ on your mobile device.
           }
         >
           <div
-            className="css-cursor-18t94o4 css-view-1dbjc4n"
-            data-focusable={true}
-            disabled={false}
+            aria-disabled={true}
+            className="css-view-1dbjc4n"
+            disabled={true}
             onKeyDown={[Function]}
-            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
-            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -386,15 +384,11 @@ on your mobile device.
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
-                "cursor": "pointer",
-                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
-                "touchAction": "manipulation",
               }
             }
-            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import './index.css'
 import fontMaterialIcons from 'react-native-vector-icons/Fonts/MaterialIcons.ttf'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
-import { initStore } from './lib/undux/SimpleStore'
+import { initStore, default as SimpleStore } from './lib/undux/SimpleStore'
 
 const fontStylesMaterialIcons = `@font-face { src: url(${fontMaterialIcons}); font-family: MaterialIcons; }`
 const style = document.createElement('style')
@@ -21,7 +21,12 @@ document.head.appendChild(style)
 // init().then(() => {
 //load simple store with initial async values from localStorage(asyncstorage)
 initStore().then(() => {
-  ReactDOM.render(<App />, document.getElementById('root'))
+  ReactDOM.render(
+    <SimpleStore.Container>
+      <App />
+    </SimpleStore.Container>,
+    document.getElementById('root')
+  )
 })
 
 // })

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import type { $AxiosXHR, AxiosInstance, AxiosPromise } from 'axios'
 import { AsyncStorage } from 'react-native'
 import Config from '../../config/config'
+import { JWT } from '../constants/localStorage'
 import logger from '../logger/pino-logger'
 import type { NameRecord } from '../../components/signup/NameForm'
 import type { EmailRecord } from '../../components/signup/EmailForm'
@@ -45,7 +46,7 @@ class API {
    */
   init() {
     log.info('initializing api...', Config.serverUrl)
-    return (this.ready = AsyncStorage.getItem('GoodDAPP_jwt').then(async jwt => {
+    return (this.ready = AsyncStorage.getItem(JWT).then(async jwt => {
       this.jwt = jwt
       let instance: AxiosInstance = axios.create({
         baseURL: Config.serverUrl,

--- a/src/lib/constants/localStorage.js
+++ b/src/lib/constants/localStorage.js
@@ -1,1 +1,6 @@
 export const USE_DESKTOP = 'GOODDAPP_useDesktop'
+export const JWT = 'GoodDAPP_jwt'
+export const CREDS = 'GoodDAPP_creds'
+export const DESTINATION_PATH = 'destinationPath'
+export const IS_LOGGED_IN = 'GOODDAPP_isLoggedIn'
+export const GD_USER_MNEMONIC = 'GD_USER_MNEMONIC'

--- a/src/lib/constants/localStorage.js
+++ b/src/lib/constants/localStorage.js
@@ -1,4 +1,3 @@
-export const USE_DESKTOP = 'GOODDAPP_useDesktop'
 export const JWT = 'GoodDAPP_jwt'
 export const CREDS = 'GoodDAPP_creds'
 export const DESTINATION_PATH = 'destinationPath'

--- a/src/lib/constants/localStorage.js
+++ b/src/lib/constants/localStorage.js
@@ -1,0 +1,1 @@
+export const USE_DESKTOP = 'GOODDAPP_useDesktop'

--- a/src/lib/login/LoginService.js
+++ b/src/lib/login/LoginService.js
@@ -2,6 +2,7 @@
 import { AsyncStorage } from 'react-native'
 import type { Credentials } from '../API/api'
 import API from '../API/api'
+import { CREDS, JWT } from '../constants/localStorage'
 import logger from '../logger/pino-logger'
 
 const log = logger.child({ from: 'LoginService' })
@@ -25,25 +26,25 @@ class LoginService {
       return
     }
     this.credentials = creds
-    AsyncStorage.setItem('GoodDAPP_creds', JSON.stringify(this.credentials))
+    AsyncStorage.setItem(CREDS, JSON.stringify(this.credentials))
   }
 
   // eslint-disable-next-line class-methods-use-this
   storeJWT(jwt: string) {
     this.jwt = jwt
     if (jwt) {
-      AsyncStorage.setItem('GoodDAPP_jwt', jwt)
+      AsyncStorage.setItem(JWT, jwt)
     }
   }
 
   async getCredentials(): Promise<?Credentials> {
-    const data = await AsyncStorage.getItem('GoodDAPP_creds')
+    const data = await AsyncStorage.getItem(CREDS)
     return data ? JSON.parse(data) : null
   }
 
   // eslint-disable-next-line class-methods-use-this
   getJWT(): Promise<?string> {
-    return AsyncStorage.getItem('GoodDAPP_jwt')
+    return AsyncStorage.getItem(JWT)
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/lib/undux/SimpleStore.js
+++ b/src/lib/undux/SimpleStore.js
@@ -1,6 +1,7 @@
 // @flow
 import { createConnectedStore } from 'undux'
 import { AsyncStorage } from 'react-native'
+import { IS_LOGGED_IN } from '../constants/localStorage'
 import withPinoLogger from './plugins/logger'
 
 /**
@@ -84,7 +85,7 @@ const initialState: State = {
  */
 let SimpleStore: UnduxStore = createConnectedStore(initialState, withPinoLogger) // default value for tests
 const initStore = async () => {
-  let isLoggedIn = await AsyncStorage.getItem('GOODDAPP_isLoggedIn').then(JSON.parse)
+  let isLoggedIn = await AsyncStorage.getItem(IS_LOGGED_IN).then(JSON.parse)
   initialState.isLoggedIn = isLoggedIn
   SimpleStore = createConnectedStore(initialState, withPinoLogger)
   return SimpleStore

--- a/src/lib/undux/effects/loggedin.js
+++ b/src/lib/undux/effects/loggedin.js
@@ -1,9 +1,10 @@
 // @flow
 import type { Effects, Store } from 'undux'
 import { AsyncStorage } from 'react-native'
+import { IS_LOGGED_IN } from '../../constants/localStorage'
 
 const updateLoggedIn: Effects<State> = async (store: Store) => {
-  const isLoggedIn = await AsyncStorage.getItem('GOODDAPP_isLoggedIn').then(JSON.parse)
+  const isLoggedIn = await AsyncStorage.getItem(IS_LOGGED_IN).then(JSON.parse)
   const curStatus = store.get('isLoggedIn')
   if (isLoggedIn !== curStatus) {
     store.set('isLoggedIn')(isLoggedIn)

--- a/src/lib/wallet/SoftwareWalletProvider.js
+++ b/src/lib/wallet/SoftwareWalletProvider.js
@@ -4,13 +4,12 @@ import bip39 from 'bip39-light'
 import type { HttpProvider, WebSocketProvider } from 'web3-providers'
 import { AsyncStorage } from 'react-native'
 import Config from '../../config/config'
+import { GD_USER_MNEMONIC } from '../constants/localStorage'
 import logger from '../logger/pino-logger'
 import type { WalletConfig } from './WalletFactory'
 import MultipleAddressWallet from './MultipleAddressWallet'
 
 const log = logger.child({ from: 'SoftwareWalletProvider' })
-
-const GD_USER_MNEMONIC: string = 'GD_USER_MNEMONIC'
 
 /**
  * save mnemonics (secret phrase) to user device


### PR DESCRIPTION
This PR closes #457, by:

* Adding `SplashDesktop` component
* Adding a new local storage variable `GOODDAPP_useDesktop`
* Updating `App.js`, `RouterSelector`, and `QRCode` components to match requirements
* Grouping LocalStorage variables into a `localStorage` constants file

![splash-desktop](https://user-images.githubusercontent.com/3315606/64201931-44564000-ce66-11e9-916b-1632d379b7ed.gif)

**NOTE:** In the last step of the gif, it looks like it's displaying the SplashDesktop after the Splash, but it's just the gif starting over.

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
