### PR TITLE
(Feature) Update JWT on wallet loading

### DIFF
--- a/src/lib/login/LoginService.js
+++ b/src/lib/login/LoginService.js
@@ -53,19 +53,13 @@ class LoginService {
   }
 
   async auth(): Promise<?Credentials | Error> {
-    if (this.credentials && this.jwt) {
-      this.credentials.jwt = this.jwt
-      log.info('Got existing credentials', this.credentials)
-      return Promise.resolve(this.credentials)
-    }
-
-    let creds = await this.login()
+    let creds = this.credentials || (await this.login())
     log.info('signed message', creds)
     this.storeCredentials(creds)
 
     // TODO: write the nonce https://gitlab.com/gooddollar/gooddapp/issues/1
     log.info('Calling server for authentication')
-    const authResult: Promise<Credentials | Error> = API.auth(creds)
+    return API.auth(creds)
       .then(res => {
         log.info('Got auth response', res)
         if (res.status === 200) {
@@ -82,7 +76,6 @@ class LoginService {
         log.error('Login service auth failed:', e.message, e)
         return e
       })
-    return authResult
   }
 }
 


### PR DESCRIPTION
This PR closes #438, by:

* Forcing JWT refresh on every wallet load.

## Note
I took extra time to come out with a most robust solution, using the response interceptor, capturing the `401` errors and retrying the POST call after refreshing the token.

Had to revert all those changes due to circular dependencies. I need to access/update not only AsyncStorage JWT value but also API's and LoginService's `jwt` properties to prevent the app from falling into an inconsistent state.

To prevent circular dependency I started to extract the management of `credentials` and `jwt` to a utility but then I had issues with API's initialization.

Thus, I opted for this simpler solution.

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
