### PR TITLE
(Fix) Sync gun with localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16031,7 +16031,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",

--- a/src/components/auth/Auth.js
+++ b/src/components/auth/Auth.js
@@ -85,7 +85,9 @@ class Auth extends React.Component<Props> {
     }
   }
 
-  handleSignUp = () => {
+  handleSignUp = async () => {
+    await AsyncStorage.removeItem('gun/').catch(e => log.error('Failed to clear localStorage', e.message, e))
+
     this.props.navigation.navigate('Signup')
 
     //Hack to get keyboard up on mobile need focus from user event such as click


### PR DESCRIPTION
This PR closes #439, by:

* Deleting `gun/` from localStorage on signup, as stated in the bug discussion.

<!-- **Considerations:** -->
<!-- * PR Title Convention: (Feature|Bug|Chore) Task Name -->
<!-- * Be as descriptive as possible, assisting reviewers as much as possible. -->
<!-- * If frontend, paste screenshots that display the UI changes. -->
<!-- * If there is interactivity, paste a gif showing the feature. -->
