### PR TITLE
(Bug) #624 Splash + About: background texture should be at 40% opacity

### DIFF
--- a/config/web.jest.config.js
+++ b/config/web.jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
     '<rootDir>/config/initTest.js',
   ],
   testMatch: [
-    '<rootDir>/src/**/__tests__/**/UserStorage.{js,jsx,ts,tsx}',
+    '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
     '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}'
   ],
   testEnvironment: 'jsdom',

--- a/config/web.jest.config.js
+++ b/config/web.jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
     '<rootDir>/config/initTest.js',
   ],
   testMatch: [
-    '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/src/**/__tests__/**/UserStorage.{js,jsx,ts,tsx}',
     '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}'
   ],
   testEnvironment: 'jsdom',

--- a/src/assets/wave50.svg
+++ b/src/assets/wave50.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="652.606" height="461.495" viewBox="0 0 652.606 461.495">
     <defs>
         <style>
-            .a{fill:#fff;}.b{fill:none;}.c{clip-path:url(#a);}.d{opacity:0.5;clip-path:url(#b);}
+            .a{fill:#fff;}.b{fill:none;}.c{clip-path:url(#a);}.d{clip-path:url(#b);}
         </style>
         <clipPath id="a">
             <rect width="461.495" height="652.606" class="b"/>

--- a/src/components/about/About.js
+++ b/src/components/about/About.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Image, StyleSheet } from 'react-native'
+import { Image, StyleSheet, View } from 'react-native'
 import splashImage from '../../assets/Splash/logo.svg'
 import goodDollarImage from '../../assets/Splash/goodDollar.svg'
 import wavePattern from '../../assets/wave50.svg'
@@ -16,6 +16,7 @@ Image.prefetch(wavePattern)
 const About = () => (
   <Wrapper style={styles.wrapper}>
     <Section style={styles.container}>
+      <View style={styles.backgroundWaves} />
       <Section.Stack style={styles.content} grow justifyContent="space-between">
         <Section.Text fontSize={22} color="darkBlue">
           Welcome to
@@ -47,12 +48,19 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: 'transparent',
+    transform: [{ rotateY: '180deg' }],
+    position: 'relative',
+    flex: 1,
+  },
+  backgroundWaves: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
     backgroundImage: `url(${wavePattern})`,
     backgroundRepeat: 'repeat-y',
-    backgroundColor: 'transparent',
     backgroundSize: 'cover',
-    transform: [{ rotateY: '180deg' }],
-    flex: 1,
+    opacity: 0.4,
   },
   content: {
     transform: [{ rotateY: '180deg' }],

--- a/src/components/about/__tests__/__snapshots__/About.js.snap
+++ b/src/components/about/__tests__/__snapshots__/About.js.snap
@@ -59,9 +59,6 @@ exports[`About matches snapshot 1`] = `
           "WebkitTransform": "rotateY(180deg)",
           "alignItems": "center",
           "backgroundColor": "rgba(0,0,0,0.00)",
-          "backgroundImage": "url(wave50.svg)",
-          "backgroundRepeat": "repeat-y",
-          "backgroundSize": "cover",
           "borderBottomLeftRadius": "5px",
           "borderBottomRightRadius": "5px",
           "borderTopLeftRadius": "5px",
@@ -79,10 +76,25 @@ exports[`About matches snapshot 1`] = `
           "paddingLeft": "12px",
           "paddingRight": "12px",
           "paddingTop": "16px",
+          "position": "relative",
           "transform": "rotateY(180deg)",
         }
       }
     >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "backgroundImage": "url(wave50.svg)",
+            "backgroundRepeat": "repeat-y",
+            "backgroundSize": "cover",
+            "height": "100%",
+            "opacity": 0.4,
+            "position": "absolute",
+            "width": "100%",
+          }
+        }
+      />
       <div
         className="css-view-1dbjc4n"
         style={

--- a/src/components/splash/Splash.js
+++ b/src/components/splash/Splash.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Image, StyleSheet } from 'react-native'
+import { Image, StyleSheet, View } from 'react-native'
 import splashImage from '../../assets/Splash/logo.svg'
 import goodDollarImage from '../../assets/Splash/goodDollar.svg'
 import wavePattern from '../../assets/wave50.svg'
@@ -15,6 +15,7 @@ Image.prefetch(wavePattern)
 const Splash = () => (
   <Wrapper style={styles.wrapper}>
     <Section style={styles.container}>
+      <View style={styles.backgroundWaves} />
       <Section.Stack style={styles.content} grow justifyContent="space-between">
         <Section.Text fontSize={22} color="darkBlue">
           {`Welcome and thank you\nfor participating in GoodDollar's\n`}
@@ -43,12 +44,19 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
+    transform: [{ rotateY: '180deg' }],
+    position: 'relative',
+    backgroundColor: 'transparent',
+    flex: 1,
+  },
+  backgroundWaves: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
     backgroundImage: `url(${wavePattern})`,
     backgroundRepeat: 'repeat-y',
-    backgroundColor: 'transparent',
     backgroundSize: 'cover',
-    transform: [{ rotateY: '180deg' }],
-    flex: 1,
+    opacity: 0.4,
   },
   content: {
     transform: [{ rotateY: '180deg' }],

--- a/src/components/splash/SplashDesktop.js
+++ b/src/components/splash/SplashDesktop.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Image, StyleSheet } from 'react-native'
+import { Image, StyleSheet, View } from 'react-native'
 import goodDollarImage from '../../assets/Splash/goodDollar.svg'
 import wavePattern from '../../assets/wave50.svg'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
@@ -16,6 +16,7 @@ Image.prefetch(wavePattern)
 const SplashDesktop = ({ onContinue, urlForQR }) => (
   <Wrapper style={styles.wrapper}>
     <Section style={styles.container}>
+      <View style={styles.backgroundWaves} />
       <Section.Stack style={styles.content} grow justifyContent="space-between">
         <Section.Text fontSize={22} color="darkBlue">
           {`For Best Experience\nplease scan and continue\non your mobile device.`}
@@ -44,12 +45,19 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundImage: `url(${wavePattern})`,
-    backgroundRepeat: 'repeat-y',
+    position: 'relative',
     backgroundColor: 'transparent',
-    backgroundSize: 'cover',
     transform: [{ rotateY: '180deg' }],
     flex: 1,
+  },
+  backgroundWaves: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundImage: `url(${wavePattern})`,
+    backgroundRepeat: 'repeat-y',
+    backgroundSize: 'cover',
+    opacity: 0.4,
   },
   content: {
     transform: [{ rotateY: '180deg' }],

--- a/src/components/splash/__tests__/__snapshots__/Splash.js.snap
+++ b/src/components/splash/__tests__/__snapshots__/Splash.js.snap
@@ -59,9 +59,6 @@ exports[`Splash matches snapshot 1`] = `
           "WebkitTransform": "rotateY(180deg)",
           "alignItems": "center",
           "backgroundColor": "rgba(0,0,0,0.00)",
-          "backgroundImage": "url(wave50.svg)",
-          "backgroundRepeat": "repeat-y",
-          "backgroundSize": "cover",
           "borderBottomLeftRadius": "5px",
           "borderBottomRightRadius": "5px",
           "borderTopLeftRadius": "5px",
@@ -79,10 +76,25 @@ exports[`Splash matches snapshot 1`] = `
           "paddingLeft": "12px",
           "paddingRight": "12px",
           "paddingTop": "16px",
+          "position": "relative",
           "transform": "rotateY(180deg)",
         }
       }
     >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "backgroundImage": "url(wave50.svg)",
+            "backgroundRepeat": "repeat-y",
+            "backgroundSize": "cover",
+            "height": "100%",
+            "opacity": 0.4,
+            "position": "absolute",
+            "width": "100%",
+          }
+        }
+      />
       <div
         className="css-view-1dbjc4n"
         style={

--- a/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
+++ b/src/components/splash/__tests__/__snapshots__/SplashDesktop.js.snap
@@ -59,9 +59,6 @@ exports[`SplashDesktop matches snapshot 1`] = `
           "WebkitTransform": "rotateY(180deg)",
           "alignItems": "center",
           "backgroundColor": "rgba(0,0,0,0.00)",
-          "backgroundImage": "url(wave50.svg)",
-          "backgroundRepeat": "repeat-y",
-          "backgroundSize": "cover",
           "borderBottomLeftRadius": "5px",
           "borderBottomRightRadius": "5px",
           "borderTopLeftRadius": "5px",
@@ -79,10 +76,25 @@ exports[`SplashDesktop matches snapshot 1`] = `
           "paddingLeft": "12px",
           "paddingRight": "12px",
           "paddingTop": "16px",
+          "position": "relative",
           "transform": "rotateY(180deg)",
         }
       }
     >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "backgroundImage": "url(wave50.svg)",
+            "backgroundRepeat": "repeat-y",
+            "backgroundSize": "cover",
+            "height": "100%",
+            "opacity": 0.4,
+            "position": "absolute",
+            "width": "100%",
+          }
+        }
+      />
       <div
         className="css-view-1dbjc4n"
         style={

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -343,6 +343,7 @@ describe('UserStorage', () => {
   })
 
   it('has the welcome event already set', async () => {
+    await userStorage.updateFeedEvent(welcomeMessage)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(welcomeMessage)
   })

--- a/src/lib/wallet/__tests__/GoodWallet.fuse.js
+++ b/src/lib/wallet/__tests__/GoodWallet.fuse.js
@@ -19,6 +19,7 @@ describe('GoodWalletShare/ReceiveTokens', () => {
       web3Transport: Config.web3TransportProvider,
     })
 
+    await adminWallet.ready
     await testWallet.ready
     await testWallet2.ready
 

--- a/src/lib/wallet/__tests__/__util__/AdminWallet.js
+++ b/src/lib/wallet/__tests__/__util__/AdminWallet.js
@@ -111,6 +111,7 @@ export class Wallet {
     }
     this.network = conf.network
     this.networkId = conf.ethNetwork.network_id
+    this.gasPrice = web3Utils.toWei('2', 'gwei')
     this.identityContract = new this.web3.eth.Contract(
       IdentityABI.abi,
       get(ContractsAddress, `${this.network}.Identity`, IdentityABI.networks[this.networkId].address),


### PR DESCRIPTION
# Description

remove opacity from svg file.
add specific opacity for About, Splash, SplashDesctop screens.

Fixes #624 

# How Has This Been Tested?

Splash, SplashDesctop: Reload the page and see Splash background
About: register/login to the app. Go to about page from side menu

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshots:
<img width="477" alt="1" src="https://user-images.githubusercontent.com/49862004/66320545-b0c1d480-e927-11e9-868e-bbb59a99562d.png">
<img width="472" alt="2" src="https://user-images.githubusercontent.com/49862004/66320546-b0c1d480-e927-11e9-8282-2b8d576791da.png">
<img width="473" alt="3" src="https://user-images.githubusercontent.com/49862004/66320547-b15a6b00-e927-11e9-8f33-e0d1bc1b95ce.png">
