### PR TITLE
(Bug) #684 signup from web3 doesnt always start at mobile form

### DIFF
--- a/src/components/auth/Auth.js
+++ b/src/components/auth/Auth.js
@@ -45,6 +45,8 @@ class Auth extends React.Component<Props> {
     const destinationPath = JSON.parse(_destinationPath)
     const paymentCode = _get(destinationPath, 'params.paymentCode')
 
+    log.info('checkWeb3TokenAndPaymentCode', web3Token, paymentCode)
+
     if (paymentCode) {
       return this.setState({
         asGuest: true,
@@ -65,10 +67,16 @@ class Auth extends React.Component<Props> {
 
         if (w3User.has_wallet) {
           behaviour = 'goToSignInScreen'
+        } else {
+          this.setState({
+            w3User,
+          })
         }
       } catch (e) {
         behaviour = 'showTokenError'
       }
+
+      log.info('behaviour', behaviour)
 
       switch (behaviour) {
         case 'showTokenError':
@@ -86,9 +94,13 @@ class Auth extends React.Component<Props> {
   }
 
   handleSignUp = async () => {
+    const { w3User } = this.state
+    const w3Token = await AsyncStorage.getItem('web3Token')
+    const redirectTo = w3Token ? 'Phone' : 'Signup'
+
     await AsyncStorage.removeItem('gun/').catch(e => log.error('Failed to clear localStorage', e.message, e))
 
-    this.props.navigation.navigate('Signup')
+    this.props.navigation.navigate(redirectTo, { w3User })
 
     //Hack to get keyboard up on mobile need focus from user event such as click
     setTimeout(() => {
@@ -131,7 +143,7 @@ class Auth extends React.Component<Props> {
       </Text>
     )
     const firstButtonColor = asGuest ? undefined : mainTheme.colors.orange
-    const firstButtontextStyle = asGuest ? undefined : styles.textBlack
+    const firstButtonTextStyle = asGuest ? undefined : styles.textBlack
 
     return (
       <Wrapper backgroundColor="#fff" style={styles.mainWrapper}>
@@ -166,7 +178,7 @@ class Auth extends React.Component<Props> {
           <CustomButton
             color={firstButtonColor}
             style={styles.buttonLayout}
-            textStyle={firstButtontextStyle}
+            textStyle={firstButtonTextStyle}
             onPress={firstButtonHandler}
           >
             {firstButtonText}

--- a/src/components/signup/NameForm.js
+++ b/src/components/signup/NameForm.js
@@ -25,10 +25,17 @@ export type NameRecord = {
 }
 
 class NameForm extends React.Component<Props, State> {
-  state = {
-    errorMessage: '',
-    fullName: this.props.screenProps.data.fullName || '',
-    isValid: false,
+  constructor(props) {
+    super(props)
+
+    const fullName = props.screenProps.data.fullName || ''
+    const errorMessage = validateFullName(fullName)
+
+    this.state = {
+      errorMessage: '',
+      fullName,
+      isValid: errorMessage === '',
+    }
   }
 
   input = undefined

--- a/src/components/signup/PhoneForm.web.js
+++ b/src/components/signup/PhoneForm.web.js
@@ -39,6 +39,14 @@ class PhoneForm extends React.Component<Props, State> {
     isValid: true,
   }
 
+  componentDidUpdate() {
+    if (this.props.screenProps.data.countryCode !== this.state.countryCode) {
+      this.setState({
+        countryCode: this.props.screenProps.data.countryCode,
+      })
+    }
+  }
+
   handleChange = (mobile: string) => {
     this.checkErrorsSlow()
 

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -94,9 +94,11 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
   }
 
   const checkWeb3Token = async () => {
+    setLoading(true)
     const web3Token = await AsyncStorage.getItem('web3Token')
 
     if (!web3Token) {
+      setLoading(false)
       return
     }
 
@@ -168,6 +170,8 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
       default:
         break
     }
+
+    setLoading(false)
   }
 
   useEffect(() => {

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -3,8 +3,9 @@ import React, { useEffect, useState } from 'react'
 import { AsyncStorage, ScrollView, StyleSheet, View } from 'react-native'
 import { createSwitchNavigator } from '@react-navigation/core'
 import { isMobileSafari } from 'mobile-device-detect'
-import { GD_USER_MNEMONIC, IS_LOGGED_IN } from '../../lib/constants/localStorage'
+import _get from 'lodash/get'
 
+import { GD_USER_MNEMONIC, IS_LOGGED_IN } from '../../lib/constants/localStorage'
 import NavBar from '../appNavigation/NavBar'
 import { navigationConfig } from '../appNavigation/navigationConfig'
 import logger from '../../lib/logger/pino-logger'
@@ -100,20 +101,28 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
     }
 
     let behaviour = ''
-    let w3User = {}
+    const _w3User = _get(navigation, 'state.params.w3User')
+    let w3User = _w3User && typeof _w3User === 'object' ? _w3User : {}
 
-    try {
-      const w3userData = await API.getUserFromW3ByToken(web3Token)
-      w3User = w3userData.data
+    if (!Object.keys(w3User).length) {
+      try {
+        const w3userData = await API.getUserFromW3ByToken(web3Token)
 
+        w3User = w3userData.data
+      } catch (e) {
+        behaviour = 'showTokenError'
+      }
+    }
+
+    if (!behaviour) {
       if (w3User.has_wallet) {
         behaviour = 'goToSignInScreen'
       } else {
         behaviour = 'goToPhone'
       }
-    } catch (e) {
-      behaviour = 'showTokenError'
     }
+
+    log.info('behaviour', behaviour)
 
     const userScreenData = {
       email: w3User.email,
@@ -137,14 +146,14 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
           email: w3User.email,
           token: web3Token,
         }).catch(e => {
-          log.error(e.message, e)
+          log.error('W3 Email verification failed', e.message, e)
 
           showErrorDialog('Email verification failed', e)
         })
 
         if (w3User.image) {
           userScreenData.avatar = await API.getBase64FromImageUrl(w3User.image).catch(e => {
-            logger.error('Fetch base 64 from image uri failed', e.message, e)
+            log.error('Fetch base 64 from image uri failed', e.message, e)
           })
         }
 
@@ -187,12 +196,14 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
 
     setReady(ready)
 
-    //don't allow to start signup flow not from begining
-    if (navigation.state.index > 0) {
-      log.debug('redirecting to start, got index:', navigation.state.index)
-      setLoading(true)
-      return navigateWithFocus(navigation.state.routes[0].key)
-    }
+    // don't allow to start sign up flow not from begining except when w3Token provided
+    AsyncStorage.getItem('web3Token').then(token => {
+      if (!token && navigation.state.index > 0) {
+        log.debug('redirecting to start, got index:', navigation.state.index)
+        setLoading(true)
+        return navigateWithFocus(navigation.state.routes[0].key)
+      }
+    })
 
     checkWeb3Token()
   }, [])

--- a/src/components/signup/__tests__/__snapshots__/NameForm.js.snap
+++ b/src/components/signup/__tests__/__snapshots__/NameForm.js.snap
@@ -335,7 +335,7 @@ exports[`NameForm matches snapshot 1`] = `
               "WebkitFlexShrink": 1,
               "WebkitJustifyContent": "center",
               "alignItems": "stretch",
-              "backgroundColor": "rgba(0,0,0,0.12)",
+              "backgroundColor": "rgba(0,175,255,1.00)",
               "borderBottomColor": "rgba(0,175,255,1.00)",
               "borderBottomLeftRadius": "50px",
               "borderBottomRightRadius": "50px",
@@ -352,6 +352,7 @@ exports[`NameForm matches snapshot 1`] = `
               "borderTopRightRadius": "50px",
               "borderTopStyle": "solid",
               "borderTopWidth": "0px",
+              "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
               "display": "flex",
               "flexBasis": "0%",
               "flexGrow": 1,
@@ -376,13 +377,15 @@ exports[`NameForm matches snapshot 1`] = `
           }
         >
           <div
-            aria-disabled={true}
-            className="css-view-1dbjc4n"
-            disabled={true}
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
             onKeyDown={[Function]}
+            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
+            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -393,11 +396,15 @@ exports[`NameForm matches snapshot 1`] = `
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
+                "touchAction": "manipulation",
               }
             }
+            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"
@@ -424,7 +431,7 @@ exports[`NameForm matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(0,0,0,0.32)",
+                    "color": "rgba(255,255,255,1.00)",
                     "direction": "ltr",
                     "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
                     "letterSpacing": "1px",

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -343,6 +343,7 @@ describe('UserStorage', () => {
   })
 
   it('has the welcome event already set', async () => {
+    await userStorage.updateFeedEvent(welcomeMessage)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(welcomeMessage)
   })


### PR DESCRIPTION
# Description

when user presses create a wallet from w3 he always starts at the mobile form with name+email already filled

Fixes #684 

# How Has This Been Tested?

type in your browser: http://localhost:3000?web3=w3token
you will see crate wallet button.
click on it and you should be redirected to signup/phone screen

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Gif:
![2019-10-08_18-04-29 (1)](https://user-images.githubusercontent.com/49862004/66407916-b33f2f80-e9f6-11e9-9251-5bcebef1824e.gif)
