### PR TITLE
(Bug) #699 user shouldn't be able to start signup at /signup/name

### DIFF
--- a/src/components/auth/__tests__/Auth.js
+++ b/src/components/auth/__tests__/Auth.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { getWebRouterComponentWithMocks } from './__util__'
+
+// Note: test renderer must be required after react-native.
+
+describe('Amount', () => {
+  it('renders without errors', () => {
+    const Auth = getWebRouterComponentWithMocks('../Auth')
+    const tree = renderer.create(<Auth />)
+    expect(tree.toJSON()).toBeTruthy()
+  })
+
+  it('matches snapshot', () => {
+    const Auth = getWebRouterComponentWithMocks('../Auth')
+    const component = renderer.create(<Auth />)
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/auth/__tests__/__snapshots__/Auth.js.snap
+++ b/src/components/auth/__tests__/__snapshots__/Auth.js.snap
@@ -1,0 +1,774 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Amount matches snapshot 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitBoxFlex": 1,
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
+    }
+  }
+>
+  <div
+    className="css-view-1dbjc4n"
+    style={
+      Object {
+        "WebkitTransform": "translateX(200vw)",
+        "bottom": "0px",
+        "left": "0px",
+        "position": "absolute",
+        "right": "0px",
+        "top": "0px",
+        "transform": "translateX(200vw)",
+        "zIndex": 100,
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+      style={
+        Object {
+          "WebkitBoxPack": "center",
+          "WebkitJustifyContent": "center",
+          "bottom": "0px",
+          "justifyContent": "center",
+          "left": "0px",
+          "msFlexPack": "center",
+          "position": "absolute",
+          "right": "0px",
+          "top": "0px",
+        }
+      }
+    >
+      <div
+        className="css-view-1dbjc4n"
+        onMoveShouldSetResponder={[Function]}
+        onMoveShouldSetResponderCapture={[Function]}
+        onResponderEnd={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderReject={[Function]}
+        onResponderRelease={[Function]}
+        onResponderStart={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onStartShouldSetResponderCapture={[Function]}
+        style={
+          Object {
+            "WebkitBoxFlex": 1,
+            "WebkitFlexBasis": "0%",
+            "WebkitFlexGrow": 1,
+            "WebkitFlexShrink": 1,
+            "WebkitTransform": "translateX([object Object])",
+            "backgroundColor": "rgba(0,0,0,0.00)",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "height": "768px",
+            "left": "0px",
+            "msFlexNegative": 1,
+            "msFlexPositive": 1,
+            "msFlexPreferredSize": "0%",
+            "overflowX": "hidden",
+            "overflowY": "hidden",
+            "position": "absolute",
+            "top": "0px",
+            "transform": "translateX([object Object])",
+            "width": "1024px",
+          }
+        }
+      >
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "backgroundColor": "rgba(255,255,255,1.00)",
+              "borderBottomLeftRadius": "5px",
+              "borderTopLeftRadius": "5px",
+              "bottom": "0px",
+              "boxShadow": "rgba(0, 0, 0, 0.5) 0px 0px 30px",
+              "left": "341.33333333333337px",
+              "position": "absolute",
+              "right": "0px",
+              "top": "0px",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=""
+    style={
+      Object {
+        "bottom": 0,
+        "display": "flex",
+        "flexDirection": "column",
+        "flexGrow": 1,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+      onResponderGrant={[Function]}
+      onResponderReject={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onScroll={[Function]}
+      onScrollShouldSetResponder={[Function]}
+      onStartShouldSetResponder={[Function]}
+      onStartShouldSetResponderCapture={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      onWheel={[Function]}
+      style={
+        Object {
+          "WebkitBoxDirection": "normal",
+          "WebkitBoxFlex": 1,
+          "WebkitBoxOrient": "vertical",
+          "WebkitFlexDirection": "column",
+          "WebkitFlexGrow": 1,
+          "WebkitFlexShrink": 1,
+          "WebkitOverflowScrolling": "touch",
+          "WebkitTransform": "translateZ(0px)",
+          "display": "flex",
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "msFlexDirection": "column",
+          "msFlexNegative": 1,
+          "msFlexPositive": 1,
+          "overflowX": "hidden",
+          "overflowY": "auto",
+          "transform": "translateZ(0px)",
+        }
+      }
+    >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "WebkitBoxFlex": 1,
+            "WebkitFlexGrow": 1,
+            "display": "flex",
+            "flexGrow": 1,
+            "height": "100%",
+            "msFlexPositive": 1,
+          }
+        }
+      >
+        <div
+          className="css-view-1dbjc4n"
+          data-name="viewWrapper"
+          style={
+            Object {
+              "WebkitBoxDirection": "normal",
+              "WebkitBoxFlex": 1,
+              "WebkitBoxOrient": "vertical",
+              "WebkitBoxPack": "justify",
+              "WebkitFlexDirection": "column",
+              "WebkitFlexGrow": 1,
+              "WebkitJustifyContent": "space-between",
+              "backgroundColor": "rgba(255,255,255,1.00)",
+              "display": "flex",
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "justifyContent": "space-between",
+              "maxHeight": "844px",
+              "msFlexDirection": "column",
+              "msFlexPack": "justify",
+              "msFlexPositive": 1,
+              "paddingBottom": "0px",
+              "paddingLeft": "0px",
+              "paddingRight": "0px",
+              "paddingTop": "0px",
+              "position": "relative",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "backgroundColor": "rgba(0,175,255,1.00)",
+                "boxShadow": "0px 3px 4px rgba(0,0,0,0.24)",
+                "paddingBottom": "env(safe-area-inset-bottom)",
+                "paddingLeft": "env(safe-area-inset-left)",
+                "paddingRight": "env(safe-area-inset-right)",
+                "paddingTop": "env(safe-area-inset-top)",
+                "zIndex": 0,
+              }
+            }
+          >
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitAlignItems": "center",
+                  "WebkitBoxAlign": "center",
+                  "WebkitBoxDirection": "normal",
+                  "WebkitBoxFlex": 0,
+                  "WebkitBoxOrient": "horizontal",
+                  "WebkitFlexDirection": "row",
+                  "WebkitFlexGrow": 0,
+                  "WebkitFlexShrink": 0,
+                  "alignItems": "center",
+                  "backgroundColor": "rgba(0,175,255,1.00)",
+                  "flexDirection": "row",
+                  "flexGrow": 0,
+                  "flexShrink": 0,
+                  "height": "56px",
+                  "msFlexAlign": "center",
+                  "msFlexDirection": "row",
+                  "msFlexNegative": 0,
+                  "msFlexPositive": 0,
+                  "paddingLeft": "4px",
+                  "paddingRight": "4px",
+                }
+              }
+            >
+              <div
+                className="css-view-1dbjc4n"
+                data-focusable={true}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "WebkitBoxFlex": 1,
+                    "WebkitFlexBasis": "0%",
+                    "WebkitFlexGrow": 1,
+                    "WebkitFlexShrink": 1,
+                    "cursor": "pointer",
+                    "flexBasis": "0%",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "msFlexNegative": 1,
+                    "msFlexPositive": 1,
+                    "msFlexPreferredSize": "0%",
+                    "msTouchAction": "manipulation",
+                    "paddingLeft": "12px",
+                    "paddingRight": "12px",
+                    "touchAction": "manipulation",
+                  }
+                }
+                tabIndex="0"
+              >
+                <h1
+                  className="css-reset-4rbku5 css-text-901oao css-textOneLine-bfa6kz"
+                  dir="auto"
+                  role="heading"
+                  style={
+                    Object {
+                      "color": "rgba(255,255,255,1.00)",
+                      "direction": "ltr",
+                      "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                      "fontSize": "16px",
+                      "fontWeight": "500",
+                      "textAlign": "center",
+                      "textTransform": "uppercase",
+                    }
+                  }
+                >
+                  Welcome
+                </h1>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "WebkitBoxFlex": 1,
+                "WebkitFlexBasis": "auto",
+                "WebkitFlexGrow": 1,
+                "WebkitFlexShrink": 0,
+                "flexBasis": "auto",
+                "flexGrow": 1,
+                "flexShrink": 0,
+                "marginBottom": "8px",
+                "maxHeight": "192px",
+                "maxWidth": "100%",
+                "minHeight": "100px",
+                "msFlexNegative": 0,
+                "msFlexPositive": 1,
+                "msFlexPreferredSize": "auto",
+                "overflowX": "hidden",
+                "overflowY": "hidden",
+                "paddingTop": "8px",
+                "zIndex": 0,
+              }
+            }
+          >
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "backgroundColor": "rgba(0,0,0,0.00)",
+                  "backgroundImage": "url(\\"Illustration.svg\\")",
+                  "backgroundPosition": "center",
+                  "backgroundRepeat": "no-repeat",
+                  "backgroundSize": "contain",
+                  "bottom": "0px",
+                  "height": "100%",
+                  "left": "0px",
+                  "position": "absolute",
+                  "right": "0px",
+                  "top": "0px",
+                  "width": "100%",
+                  "zIndex": -1,
+                }
+              }
+            />
+            <img
+              alt=""
+              className="css-accessibilityImage-9pa8cd"
+              draggable={false}
+              src="Illustration.svg"
+            />
+          </div>
+          <div
+            className="css-view-1dbjc4n"
+            style={
+              Object {
+                "backgroundColor": "rgba(255,255,255,1.00)",
+                "borderBottomLeftRadius": "5px",
+                "borderBottomRightRadius": "5px",
+                "borderTopLeftRadius": "5px",
+                "borderTopRightRadius": "5px",
+                "paddingBottom": "16px",
+                "paddingLeft": "16px",
+                "paddingRight": "16px",
+                "paddingTop": "16px",
+              }
+            }
+          >
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitAlignItems": "stretch",
+                  "WebkitBoxAlign": "stretch",
+                  "WebkitBoxPack": "center",
+                  "WebkitJustifyContent": "center",
+                  "alignItems": "stretch",
+                  "backgroundColor": "rgba(248,175,64,1.00)",
+                  "borderBottomColor": "rgba(0,175,255,1.00)",
+                  "borderBottomLeftRadius": "50px",
+                  "borderBottomRightRadius": "50px",
+                  "borderBottomStyle": "solid",
+                  "borderBottomWidth": "0px",
+                  "borderLeftColor": "rgba(0,175,255,1.00)",
+                  "borderLeftStyle": "solid",
+                  "borderLeftWidth": "0px",
+                  "borderRightColor": "rgba(0,175,255,1.00)",
+                  "borderRightStyle": "solid",
+                  "borderRightWidth": "0px",
+                  "borderTopColor": "rgba(0,175,255,1.00)",
+                  "borderTopLeftRadius": "50px",
+                  "borderTopRightRadius": "50px",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": "0px",
+                  "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginBottom": "20px",
+                  "marginLeft": "0px",
+                  "marginRight": "0px",
+                  "marginTop": "20px",
+                  "minHeight": "44px",
+                  "minWidth": "64px",
+                  "msFlexAlign": "stretch",
+                  "msFlexPack": "center",
+                  "paddingBottom": "0px",
+                  "paddingLeft": "0px",
+                  "paddingRight": "0px",
+                  "paddingTop": "0px",
+                }
+              }
+            >
+              <div
+                className="css-cursor-18t94o4 css-view-1dbjc4n"
+                data-focusable={true}
+                disabled={false}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "borderBottomLeftRadius": "50px",
+                    "borderBottomRightRadius": "50px",
+                    "borderTopLeftRadius": "50px",
+                    "borderTopRightRadius": "50px",
+                    "cursor": "pointer",
+                    "msTouchAction": "manipulation",
+                    "overflowX": "hidden",
+                    "overflowY": "hidden",
+                    "position": "relative",
+                    "touchAction": "manipulation",
+                  }
+                }
+                tabIndex="0"
+              >
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitAlignItems": "center",
+                      "WebkitBoxAlign": "center",
+                      "WebkitBoxDirection": "normal",
+                      "WebkitBoxOrient": "horizontal",
+                      "WebkitBoxPack": "center",
+                      "WebkitFlexDirection": "row",
+                      "WebkitJustifyContent": "center",
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "msFlexAlign": "center",
+                      "msFlexDirection": "row",
+                      "msFlexPack": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="css-text-901oao css-textOneLine-bfa6kz"
+                    dir="auto"
+                    style={
+                      Object {
+                        "color": "rgba(255,255,255,1.00)",
+                        "direction": "ltr",
+                        "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                        "letterSpacing": "1px",
+                        "marginBottom": "9px",
+                        "marginLeft": "16px",
+                        "marginRight": "16px",
+                        "marginTop": "9px",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                      style={
+                        Object {
+                          "WebkitAlignItems": "center",
+                          "WebkitBoxAlign": "center",
+                          "WebkitBoxDirection": "normal",
+                          "WebkitBoxFlex": 1,
+                          "WebkitBoxOrient": "horizontal",
+                          "WebkitFlexBasis": "0%",
+                          "WebkitFlexDirection": "row",
+                          "WebkitFlexGrow": 1,
+                          "WebkitFlexShrink": 1,
+                          "alignItems": "center",
+                          "display": "flex",
+                          "flexBasis": "0%",
+                          "flexDirection": "row",
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "msFlexAlign": "center",
+                          "msFlexDirection": "row",
+                          "msFlexNegative": 1,
+                          "msFlexPositive": 1,
+                          "msFlexPreferredSize": "0%",
+                        }
+                      }
+                    >
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "WebkitAlignItems": "center",
+                            "WebkitBoxAlign": "center",
+                            "WebkitBoxPack": "center",
+                            "WebkitJustifyContent": "center",
+                            "alignItems": "center",
+                            "color": "rgba(66,69,74,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto",
+                            "fontSize": "16px",
+                            "fontWeight": "500",
+                            "justifyContent": "center",
+                            "letterSpacing": "0px",
+                            "lineHeight": "22px",
+                            "msFlexAlign": "center",
+                            "msFlexPack": "center",
+                            "paddingTop": "1px",
+                            "textAlign": "center",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        NEW HERE?
+                        <span
+                          className="css-text-901oao css-textHasAncestor-16my406"
+                          dir="auto"
+                          style={
+                            Object {
+                              "WebkitAlignItems": "center",
+                              "WebkitBoxAlign": "center",
+                              "WebkitBoxPack": "center",
+                              "WebkitJustifyContent": "center",
+                              "alignItems": "center",
+                              "color": "rgba(66,69,74,1.00)",
+                              "direction": "ltr",
+                              "fontFamily": "Roboto",
+                              "fontSize": "16px",
+                              "fontWeight": "800",
+                              "justifyContent": "center",
+                              "letterSpacing": "0px",
+                              "lineHeight": "22px",
+                              "msFlexAlign": "center",
+                              "msFlexPack": "center",
+                              "paddingTop": "1px",
+                              "textAlign": "center",
+                              "textDecoration": "none",
+                              "textTransform": "none",
+                            }
+                          }
+                        >
+                           GET INVITED
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-view-1dbjc4n"
+              style={
+                Object {
+                  "WebkitAlignItems": "stretch",
+                  "WebkitBoxAlign": "stretch",
+                  "WebkitBoxPack": "center",
+                  "WebkitJustifyContent": "center",
+                  "alignItems": "stretch",
+                  "backgroundColor": "rgba(0,0,0,0.00)",
+                  "borderBottomColor": "rgba(0,175,255,1.00)",
+                  "borderBottomLeftRadius": "50px",
+                  "borderBottomRightRadius": "50px",
+                  "borderBottomStyle": "solid",
+                  "borderBottomWidth": "1px",
+                  "borderLeftColor": "rgba(0,175,255,1.00)",
+                  "borderLeftStyle": "solid",
+                  "borderLeftWidth": "1px",
+                  "borderRightColor": "rgba(0,175,255,1.00)",
+                  "borderRightStyle": "solid",
+                  "borderRightWidth": "1px",
+                  "borderTopColor": "rgba(0,175,255,1.00)",
+                  "borderTopLeftRadius": "50px",
+                  "borderTopRightRadius": "50px",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": "1px",
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "marginBottom": "0px",
+                  "marginLeft": "0px",
+                  "marginRight": "0px",
+                  "marginTop": "0px",
+                  "minHeight": "44px",
+                  "minWidth": "64px",
+                  "msFlexAlign": "stretch",
+                  "msFlexPack": "center",
+                  "paddingBottom": "0px",
+                  "paddingLeft": "0px",
+                  "paddingRight": "0px",
+                  "paddingTop": "0px",
+                }
+              }
+            >
+              <div
+                className="css-cursor-18t94o4 css-view-1dbjc4n"
+                data-focusable={true}
+                disabled={false}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                role="button"
+                style={
+                  Object {
+                    "borderBottomLeftRadius": "50px",
+                    "borderBottomRightRadius": "50px",
+                    "borderTopLeftRadius": "50px",
+                    "borderTopRightRadius": "50px",
+                    "cursor": "pointer",
+                    "msTouchAction": "manipulation",
+                    "overflowX": "hidden",
+                    "overflowY": "hidden",
+                    "position": "relative",
+                    "touchAction": "manipulation",
+                  }
+                }
+                tabIndex="0"
+              >
+                <div
+                  className="css-view-1dbjc4n"
+                  style={
+                    Object {
+                      "WebkitAlignItems": "center",
+                      "WebkitBoxAlign": "center",
+                      "WebkitBoxDirection": "normal",
+                      "WebkitBoxOrient": "horizontal",
+                      "WebkitBoxPack": "center",
+                      "WebkitFlexDirection": "row",
+                      "WebkitJustifyContent": "center",
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "msFlexAlign": "center",
+                      "msFlexDirection": "row",
+                      "msFlexPack": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="css-text-901oao css-textOneLine-bfa6kz"
+                    dir="auto"
+                    style={
+                      Object {
+                        "color": "rgba(0,175,255,1.00)",
+                        "direction": "ltr",
+                        "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
+                        "letterSpacing": "1px",
+                        "marginBottom": "9px",
+                        "marginLeft": "16px",
+                        "marginRight": "16px",
+                        "marginTop": "9px",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                      style={
+                        Object {
+                          "WebkitAlignItems": "center",
+                          "WebkitBoxAlign": "center",
+                          "WebkitBoxDirection": "normal",
+                          "WebkitBoxFlex": 1,
+                          "WebkitBoxOrient": "horizontal",
+                          "WebkitFlexBasis": "0%",
+                          "WebkitFlexDirection": "row",
+                          "WebkitFlexGrow": 1,
+                          "WebkitFlexShrink": 1,
+                          "alignItems": "center",
+                          "display": "flex",
+                          "flexBasis": "0%",
+                          "flexDirection": "row",
+                          "flexGrow": 1,
+                          "flexShrink": 1,
+                          "msFlexAlign": "center",
+                          "msFlexDirection": "row",
+                          "msFlexNegative": 1,
+                          "msFlexPositive": 1,
+                          "msFlexPreferredSize": "0%",
+                        }
+                      }
+                    >
+                      <span
+                        className="css-text-901oao css-textHasAncestor-16my406"
+                        dir="auto"
+                        style={
+                          Object {
+                            "WebkitAlignItems": "center",
+                            "WebkitBoxAlign": "center",
+                            "WebkitBoxPack": "center",
+                            "WebkitJustifyContent": "center",
+                            "alignItems": "center",
+                            "color": "rgba(0,175,255,1.00)",
+                            "direction": "ltr",
+                            "fontFamily": "Roboto",
+                            "fontSize": "16px",
+                            "fontWeight": "normal",
+                            "justifyContent": "center",
+                            "letterSpacing": "0px",
+                            "lineHeight": "22px",
+                            "msFlexAlign": "center",
+                            "msFlexPack": "center",
+                            "paddingTop": "1px",
+                            "textAlign": "center",
+                            "textDecoration": "none",
+                            "textTransform": "none",
+                          }
+                        }
+                      >
+                        ALREADY REGISTERED?
+                        <span
+                          className="css-text-901oao css-textHasAncestor-16my406"
+                          dir="auto"
+                          style={
+                            Object {
+                              "WebkitAlignItems": "center",
+                              "WebkitBoxAlign": "center",
+                              "WebkitBoxPack": "center",
+                              "WebkitJustifyContent": "center",
+                              "alignItems": "center",
+                              "color": "rgba(0,175,255,1.00)",
+                              "direction": "ltr",
+                              "fontFamily": "Roboto",
+                              "fontSize": "16px",
+                              "fontWeight": "800",
+                              "justifyContent": "center",
+                              "letterSpacing": "0px",
+                              "lineHeight": "22px",
+                              "msFlexAlign": "center",
+                              "msFlexPack": "center",
+                              "paddingTop": "1px",
+                              "textAlign": "center",
+                              "textDecoration": "none",
+                              "textTransform": "uppercase",
+                            }
+                          }
+                        >
+                           SIGN IN
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/auth/__tests__/__util__/index.js
+++ b/src/components/auth/__tests__/__util__/index.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import { createSwitchNavigator } from '@react-navigation/core'
+import { createBrowserApp } from '@react-navigation/web'
+import * as libShare from '../../../../lib/share'
+import GDStore from '../../../../lib/undux/GDStore'
+import { withThemeProvider } from '../../../../__tests__/__util__'
+const { Container } = GDStore
+
+export const getComponentWithMocks = componentPath => {
+  // Will then mock the LocalizeContext module being used in our LanguageSelector component
+  jest.doMock('../../../../lib/share', () => {
+    return {
+      ...libShare,
+      generateCode: () => '0xfakeAddress',
+    }
+  })
+
+  // you need to re-require after calling jest.doMock.
+  return require(`../${componentPath}`).default
+}
+
+const withContainer = Component => props => {
+  const WrappedComponent = withThemeProvider(Component)
+  return (
+    <Container>
+      <WrappedComponent {...props} />
+    </Container>
+  )
+}
+
+export const getWebRouterComponentWithRoutes = routes => {
+  const AppNavigator = createSwitchNavigator(routes)
+  class AppNavigation extends React.Component<AppNavigationProps, AppNavigationState> {
+    static router = AppNavigator.router
+
+    static navigationOptions = AppNavigator.navigationOptions
+
+    render() {
+      return <AppNavigator navigation={this.props.navigation} screenProps={{ routes }} />
+    }
+  }
+  return withContainer(createBrowserApp(createSwitchNavigator({ AppNavigation })))
+}
+
+export const getWebRouterComponentWithMocks = componentPath => {
+  const Component = getComponentWithMocks(componentPath)
+
+  const routes = {
+    Component,
+  }
+
+  return getWebRouterComponentWithRoutes(routes)
+}
+
+export const convertDateToUTC = unixDate => {
+  let date = new Date(unixDate)
+  return date.getTime() + date.getTimezoneOffset() * 60000
+}
+
+export const mockEvent = (type, status) => ({
+  type,
+  id: '0x9812619905da200c4effe8cd2ca4b2b31eeddf133f8fd283069d2e5aec3b9f77',
+  date: convertDateToUTC(1554130994000),
+  createdDate: 'Fri Aug 02 2019 15:15:44 GMT-0300 (Argentina Standard Time)',
+  status: status || 'completed',
+  data: {
+    amount: 4,
+    message: 'aaa',
+    endpoint: {
+      address: undefined,
+      avatar:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAkCAIAAAB0Xu9BAAAABGdBTUEAALGPC/xhBQAAAuNJREFUWEetmD1WHDEQhDdxRMYlnBFyBIccgdQhKVcgJeQMpE5JSTd2uqnvIGpVUqmm9TPrffD0eLMzUn+qVnXPwiFd/PP6eLh47v7EaazbmxsOxjhTT88z9hV7GoNF1cUCvN7TTPv/gf/+uQPm862MWTL6fff4HfDx4S79/oVAlAUwqOmYR0rnazuFnhfOy/ErMKkcBFOr1vOjUi2MFn4nuMil6OPh5eGANLhW3y6u3aH7ijEDCxgCvzFmimvc95TekZLyMSeJC68Bkw0kqUy1K87FlpGZqsGFCyqEtQNDdFUtFctTiuhnPKNysid/WFEFLE2O102XJdEE+8IgeuGsjeJyGHm/xHvQ3JtKVsGGp85g9rK6xMHtvHO9+WACYjk5vkVM6XQ6OZubCJvTfPicYPeHO2AKFl5NuF5UK1VDUbeLxh2BcRGKTQE3irHm3+vPj6cfCod50Eqv5QxtwBQUGhZhbrGVuRia1B4MNp6edwBxld2sl1splfHCwfsvCZfrCQyWmX10djjOlWJSSy3VQlS6LmfrgNvaieRWx1LZ6s9co+P0DLsy3OdLU3lWRclQsVcHJBcUQ0k9/WVVrmpRzYQzpgAdQcAXxZzUnFX3proannrYH+Vq6KkLi+UkarH09mC8YPr2RMWOlEqFkQClsykGEv7CqCUbXcG8+SaGvJ4a8d4y6epND+pEhxoN0vWUu5ntXlFb5/JT7JfJJqoTdy9u9qc7ax3xJRHqJLADWEl23cFWl4K9fvoaCJ2BHpmJ3s3z+O0U/DmzdMjB9alWZtg4e3yxzPa7lUR7nkvxLHO9+tvJX3mtSDpwX8GajB283I8R8a7D2MhUZr1iNWdny256yYLd52DwRYBtRMvE7rsmtxIUE+zLKQCDO4jlxB6CZ8M17GhuY+XTE8vNhQiIiSE82ZsGwk1pht4ZSpT0YVpon6EvevOXXH8JxVR78QzNuamupW/7UB7wO/+7sG5V4ekXb4cL5Lyv+4IAAAAASUVORK5CYII=',
+      fullName: 'Misao Matimbo',
+    },
+  },
+})
+
+export const generateFeedItemProps = (type, status) => ({
+  item: mockEvent(type, status),
+  separators: {
+    highlight: () => {},
+    unhighlight: () => {},
+  },
+  onPress: () => {},
+})

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -343,6 +343,7 @@ describe('UserStorage', () => {
   })
 
   it('has the welcome event already set', async () => {
+    await userStorage.updateFeedEvent(welcomeMessage)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(welcomeMessage)
   })


### PR DESCRIPTION
# Description

Implement functionality to disable a possibility for the user to signup without an invitation.
Also, a user shouldn't be able to start sign-up flow by manually typing /signup/x in browser address line.
- It was done by adding verification of whether there is an invitation in AsyncStorage. If not then redirect to the Welcome page.

Fixes #699 

# How Has This Been Tested?

Open application. You should be not authorized.
Try to open signup flow by typing signup/x in your browser address line.
You shouldn't be able to do this.

Also, try to visit the wallet app with valid and not used w3Token or paymentCode.
Then try to open signup flow by typing signup/x in your browser address line.
Now should be able to do this.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video:
https://www.screencast.com/t/ZxrdpLsD5rfr
