### PR TITLE
(bug) Profile privacy pop up: background should be blurred and brightend li…

### DIFF
--- a/src/components/profile/ProfilePrivacy.js
+++ b/src/components/profile/ProfilePrivacy.js
@@ -7,7 +7,8 @@ import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
 import { BackButton } from '../appNavigation/stackNavigation'
 import { withStyles } from '../../lib/styles'
-import { CustomButton, CustomDialog, Icon, Section, Text } from '../common'
+import { CustomButton, Icon, Section, Text } from '../common'
+import { useDialog } from '../../lib/undux/utils/dialog'
 import OptionsRow from './OptionsRow'
 
 const TITLE = 'PROFILE PRIVACY'
@@ -30,8 +31,8 @@ const ProfilePrivacy = props => {
   const [initialPrivacy, setInitialPrivacy] = useState(initialState)
   const [privacy, setPrivacy] = useState(initialState)
   const [loading, setLoading] = useState(false)
-  const [showTips, setShowTips] = useState(false)
   const { screenProps, styles, theme } = props
+  const [showDialog] = useDialog()
 
   useEffect(() => {
     // looks for the users fields' privacy
@@ -48,6 +49,31 @@ const ProfilePrivacy = props => {
 
     privacyGatherer()
   }, [])
+
+  const handleSaveShowTips = () => {
+    showDialog({
+      content: (
+        <>
+          {privacyOptions.map(field => (
+            <Section.Stack grow key={field} style={styles.dialogTipItem}>
+              <Text fontWeight="bold" fontSize={18} color="primary" textAlign="left">
+                {startCase(field)}
+              </Text>
+              <Text textAlign="left">{tips[field]}</Text>
+            </Section.Stack>
+          ))}
+        </>
+      ),
+      buttons: [
+        {
+          text: 'Ok',
+          onPress: dismiss => {
+            dismiss()
+          },
+        },
+      ],
+    })
+  }
 
   /**
    * filters the fields to be updated
@@ -83,7 +109,7 @@ const ProfilePrivacy = props => {
           <Section.Text fontWeight="bold" color="gray">
             Manage your privacy settings
           </Section.Text>
-          <InfoIcon style={styles.infoIcon} color={theme.colors.primary} onPress={() => setShowTips(true)} />
+          <InfoIcon style={styles.infoIcon} color={theme.colors.primary} onPress={() => handleSaveShowTips()} />
         </Section.Row>
 
         <Section.Stack justifyContent="flex-start" style={styles.optionsRowContainer}>
@@ -115,17 +141,6 @@ const ProfilePrivacy = props => {
           Save
         </CustomButton>
       </Section.Row>
-
-      <CustomDialog visible={showTips} onDismiss={() => setShowTips(false)} title="SETTINGS" image={<React.Fragment />}>
-        {privacyOptions.map(field => (
-          <Section.Stack grow key={field} style={styles.dialogTipItem}>
-            <Text fontWeight="bold" fontSize={18} color="primary" textAlign="left">
-              {startCase(field)}
-            </Text>
-            <Text textAlign="left">{tips[field]}</Text>
-          </Section.Stack>
-        ))}
-      </CustomDialog>
     </Section>
   )
 }


### PR DESCRIPTION
# Description

pop-up window is implemented using the useDialog method, this solved the problem

Fixes #746 
 
# How Has This Been Tested?

1. In to dashboard
2. Go to PROFILE PRIVACY
3. Click on the icon (Manage your privacy settings)

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

![image](https://user-images.githubusercontent.com/8187382/67665831-28a57c80-f973-11e9-8357-71b90a90f0f6.png)
