### PR TITLE
(bug) Processing payment link - Pop up should match design

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -226,7 +226,8 @@ const Dashboard = props => {
       showDialog({
         title: 'Processing Payment Link...',
         image: <LoadingIcon />,
-        buttons: [{ text: 'YAY!', style: styles.disabledButton}]
+        message: 'please wait while processing...',
+        buttons: [{ text: 'YAY!', style: styles.disabledButton }]
       })
       await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
       hideDialog()

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -221,11 +221,12 @@ const Dashboard = props => {
 
   const handleWithdraw = async () => {
     const { paymentCode, reason } = props.navigation.state.params
+    const { styles }: DashboardProps = props
     try {
       showDialog({
         title: 'Processing Payment Link...',
         image: <LoadingIcon />,
-        showButtons: false,
+        buttons: [{ text: 'YAY!', style: styles.disabledButton}]
       })
       await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
       hideDialog()
@@ -440,6 +441,9 @@ const getStylesFromProps = ({ theme }) => ({
   bigNumberWrapper: {
     marginVertical: theme.sizes.defaultDouble,
     alignItems: 'baseline',
+  },
+  disabledButton: {
+    backgroundColor: theme.colors.gray50Percent,
   },
   bigNumberUnitStyles: {
     marginRight: normalize(-20),

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -36,6 +36,7 @@ import { extractQueryParams, readCode } from '../../lib/share'
 import { deleteAccountDialog } from '../sidemenu/SideMenuPanel'
 import config from '../../config/config'
 import { backupMessage } from '../../lib/gundb/UserStorageClass'
+import LoadingIcon from '../common/modal/LoadingIcon'
 import RewardsTab from './Rewards'
 import Amount from './Amount'
 import Claim from './Claim'
@@ -221,7 +222,11 @@ const Dashboard = props => {
   const handleWithdraw = async () => {
     const { paymentCode, reason } = props.navigation.state.params
     try {
-      showDialog({ title: 'Processing Payment Link...', loading: true, buttons: [{ text: 'YAY!' }] })
+      showDialog({
+        title: 'Processing Payment Link...',
+        image: <LoadingIcon />,
+        showButtons: false,
+      })
       await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
       hideDialog()
     } catch (e) {


### PR DESCRIPTION
# Description

Popup has snippet like Сlaim
I removed the button.
The button is not needed, because the pop-up window will be removed automatically or replaced with a pop-up error

about #754

# How Has This Been Tested?

Go to payment links

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
![image](https://user-images.githubusercontent.com/8187382/67680294-a4afbc80-f993-11e9-9c11-6be90e1bdb10.png)
