### PR TITLE
(Bug) #751 Send and Receive flow: All titles font should be Medium wight and match the design

### DIFF
--- a/src/components/common/view/AmountInput.js
+++ b/src/components/common/view/AmountInput.js
@@ -30,7 +30,7 @@ const AmountInput = ({ amount, handleAmountChange, styles, error, title }: Amoun
   return (
     <View style={styles.wrapper}>
       <View style={styles.container}>
-        {title && <SectionTitle>{title}</SectionTitle>}
+        {title && <SectionTitle style={styles.mediumFontWeight}>{title}</SectionTitle>}
         <TouchableWithoutFeedback
           onPress={() => (isMobile ? Keyboard.dismiss() : null)}
           accessible={false}
@@ -76,6 +76,10 @@ const mapPropsToStyles = ({ theme }) => {
       color: theme.colors.error,
       borderBottomColor: theme.colors.error,
       marginTop: 'auto',
+    },
+    mediumFontWeight: {
+      marginVertical: theme.sizes.default,
+      fontWeight: '500',
     },
   }
 }

--- a/src/components/common/view/AmountInput.js
+++ b/src/components/common/view/AmountInput.js
@@ -30,7 +30,7 @@ const AmountInput = ({ amount, handleAmountChange, styles, error, title }: Amoun
   return (
     <View style={styles.wrapper}>
       <View style={styles.container}>
-        {title && <SectionTitle fontWeight="500">{title}</SectionTitle>}
+        {title && <SectionTitle fontWeight="medium">{title}</SectionTitle>}
         <TouchableWithoutFeedback
           onPress={() => (isMobile ? Keyboard.dismiss() : null)}
           accessible={false}

--- a/src/components/common/view/AmountInput.js
+++ b/src/components/common/view/AmountInput.js
@@ -30,7 +30,7 @@ const AmountInput = ({ amount, handleAmountChange, styles, error, title }: Amoun
   return (
     <View style={styles.wrapper}>
       <View style={styles.container}>
-        {title && <SectionTitle style={styles.mediumFontWeight}>{title}</SectionTitle>}
+        {title && <SectionTitle fontWeight="500">{title}</SectionTitle>}
         <TouchableWithoutFeedback
           onPress={() => (isMobile ? Keyboard.dismiss() : null)}
           accessible={false}
@@ -76,10 +76,6 @@ const mapPropsToStyles = ({ theme }) => {
       color: theme.colors.error,
       borderBottomColor: theme.colors.error,
       marginTop: 'auto',
-    },
-    mediumFontWeight: {
-      marginVertical: theme.sizes.default,
-      fontWeight: '500',
     },
   }
 }

--- a/src/components/dashboard/Reason.js
+++ b/src/components/dashboard/Reason.js
@@ -6,7 +6,6 @@ import { Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 import { BackButton, NextButton, useScreenState } from '../appNavigation/stackNavigation'
 import { withStyles } from '../../lib/styles'
-import { theme } from '../theme/styles'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import { navigationOptions } from './utils/sendReceiveFlow'
 
@@ -28,7 +27,7 @@ const SendReason = (props: AmountProps) => {
       <TopBar push={screenProps.push} />
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title style={styles.mediumFontWeight}>What For?</Section.Title>
+          <Section.Title fontWeight="500">What For?</Section.Title>
           <InputText
             autoFocus
             style={[props.styles.input, styles.bottomContent]}
@@ -64,10 +63,6 @@ const styles = StyleSheet.create({
   },
   bottomContent: {
     marginTop: 'auto',
-  },
-  mediumFontWeight: {
-    marginVertical: theme.sizes.default,
-    fontWeight: '500',
   },
 })
 

--- a/src/components/dashboard/Reason.js
+++ b/src/components/dashboard/Reason.js
@@ -27,7 +27,7 @@ const SendReason = (props: AmountProps) => {
       <TopBar push={screenProps.push} />
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title fontWeight="500">What For?</Section.Title>
+          <Section.Title fontWeight="medium">What For?</Section.Title>
           <InputText
             autoFocus
             style={[props.styles.input, styles.bottomContent]}

--- a/src/components/dashboard/Reason.js
+++ b/src/components/dashboard/Reason.js
@@ -6,6 +6,7 @@ import { Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 import { BackButton, NextButton, useScreenState } from '../appNavigation/stackNavigation'
 import { withStyles } from '../../lib/styles'
+import { theme } from '../theme/styles'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import { navigationOptions } from './utils/sendReceiveFlow'
 
@@ -27,7 +28,7 @@ const SendReason = (props: AmountProps) => {
       <TopBar push={screenProps.push} />
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title>What For?</Section.Title>
+          <Section.Title style={styles.mediumFontWeight}>What For?</Section.Title>
           <InputText
             autoFocus
             style={[props.styles.input, styles.bottomContent]}
@@ -64,6 +65,10 @@ const styles = StyleSheet.create({
   bottomContent: {
     marginTop: 'auto',
   },
+  mediumFontWeight: {
+    marginVertical: theme.sizes.default,
+    fontWeight: '500',
+  },
 })
 
 SendReason.navigationOptions = navigationOptions
@@ -73,4 +78,8 @@ SendReason.shouldNavigateToComponent = props => {
   return screenState.amount >= 0 && screenState.nextRoutes
 }
 
-export default withStyles(({ theme }) => ({ input: { marginTop: theme.sizes.defaultDouble } }))(SendReason)
+export default withStyles(({ theme }) => ({
+  input: {
+    marginTop: theme.sizes.defaultDouble,
+  },
+}))(SendReason)

--- a/src/components/dashboard/ReceiveSummary.js
+++ b/src/components/dashboard/ReceiveSummary.js
@@ -9,7 +9,6 @@ import { PushButton } from '../appNavigation/PushButton'
 
 import goodWallet from '../../lib/wallet/GoodWallet'
 import { generateCode } from '../../lib/share'
-import { theme } from '../theme/styles'
 import { navigationOptions } from './utils/sendReceiveFlow'
 
 export type ReceiveProps = {
@@ -37,7 +36,7 @@ const ReceiveAmount = ({ screenProps, ...props }: ReceiveProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section justifyContent="space-between" grow>
-        <Section.Title style={{ fontWeight: '500', marginVertical: theme.sizes.default }}>Summary</Section.Title>
+        <Section.Title fontWeight="500">Summary</Section.Title>
         <SummaryTable
           actionReceive={true}
           counterPartyDisplayName={counterPartyDisplayName}

--- a/src/components/dashboard/ReceiveSummary.js
+++ b/src/components/dashboard/ReceiveSummary.js
@@ -36,7 +36,7 @@ const ReceiveAmount = ({ screenProps, ...props }: ReceiveProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section justifyContent="space-between" grow>
-        <Section.Title fontWeight="500">Summary</Section.Title>
+        <Section.Title fontWeight="medium">Summary</Section.Title>
         <SummaryTable
           actionReceive={true}
           counterPartyDisplayName={counterPartyDisplayName}

--- a/src/components/dashboard/ReceiveSummary.js
+++ b/src/components/dashboard/ReceiveSummary.js
@@ -9,6 +9,7 @@ import { PushButton } from '../appNavigation/PushButton'
 
 import goodWallet from '../../lib/wallet/GoodWallet'
 import { generateCode } from '../../lib/share'
+import { theme } from '../theme/styles'
 import { navigationOptions } from './utils/sendReceiveFlow'
 
 export type ReceiveProps = {
@@ -36,7 +37,7 @@ const ReceiveAmount = ({ screenProps, ...props }: ReceiveProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section justifyContent="space-between" grow>
-        <Section.Title>Summary</Section.Title>
+        <Section.Title style={{ fontWeight: '500', marginVertical: theme.sizes.default }}>Summary</Section.Title>
         <SummaryTable
           actionReceive={true}
           counterPartyDisplayName={counterPartyDisplayName}

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -157,7 +157,7 @@ const SendLinkSummary = ({ screenProps }: AmountProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section grow>
-        <Section.Title fontWeight="500">SUMMARY</Section.Title>
+        <Section.Title fontWeight="medium">SUMMARY</Section.Title>
         <Section.Row justifyContent="center">
           <Section.Text color="gray80Percent">{'* the transaction may take\na few seconds to complete'}</Section.Text>
         </Section.Row>

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -12,7 +12,6 @@ import { BackButton, useScreenState } from '../appNavigation/stackNavigation'
 import { CustomButton, Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 import SummaryTable from '../common/view/SummaryTable'
-import { theme } from '../theme/styles'
 import { SEND_TITLE } from './utils/sendReceiveFlow'
 import SurveySend from './SurveySend'
 const log = logger.child({ from: 'SendLinkSummary' })
@@ -158,7 +157,7 @@ const SendLinkSummary = ({ screenProps }: AmountProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section grow>
-        <Section.Title style={{ fontWeight: '500', marginVertical: theme.sizes.default }}>SUMMARY</Section.Title>
+        <Section.Title fontWeight="500">SUMMARY</Section.Title>
         <Section.Row justifyContent="center">
           <Section.Text color="gray80Percent">{'* the transaction may take\na few seconds to complete'}</Section.Text>
         </Section.Row>

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -12,6 +12,7 @@ import { BackButton, useScreenState } from '../appNavigation/stackNavigation'
 import { CustomButton, Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 import SummaryTable from '../common/view/SummaryTable'
+import { theme } from '../theme/styles'
 import { SEND_TITLE } from './utils/sendReceiveFlow'
 import SurveySend from './SurveySend'
 const log = logger.child({ from: 'SendLinkSummary' })
@@ -157,7 +158,7 @@ const SendLinkSummary = ({ screenProps }: AmountProps) => {
     <Wrapper>
       <TopBar push={screenProps.push} />
       <Section grow>
-        <Section.Title>SUMMARY</Section.Title>
+        <Section.Title style={{ fontWeight: '500', marginVertical: theme.sizes.default }}>SUMMARY</Section.Title>
         <Section.Row justifyContent="center">
           <Section.Text color="gray80Percent">{'* the transaction may take\na few seconds to complete'}</Section.Text>
         </Section.Row>

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -45,7 +45,7 @@ const Who = (props: AmountProps) => {
       </TopBar>
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title style={styles.mediumFontWeight}>{text}</Section.Title>
+          <Section.Title fontWeight="500">{text}</Section.Title>
           <InputText
             autoFocus
             error={state.error}
@@ -91,9 +91,5 @@ export default withStyles(({ theme }) => ({
   container: {
     minHeight: getDesignRelativeHeight(180),
     height: getDesignRelativeHeight(180),
-  },
-  mediumFontWeight: {
-    marginVertical: theme.sizes.default,
-    fontWeight: '500',
   },
 }))(Who)

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -45,7 +45,7 @@ const Who = (props: AmountProps) => {
       </TopBar>
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title fontWeight="500">{text}</Section.Title>
+          <Section.Title fontWeight="medium">{text}</Section.Title>
           <InputText
             autoFocus
             error={state.error}

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -45,7 +45,7 @@ const Who = (props: AmountProps) => {
       </TopBar>
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
-          <Section.Title>{text}</Section.Title>
+          <Section.Title style={styles.mediumFontWeight}>{text}</Section.Title>
           <InputText
             autoFocus
             error={state.error}
@@ -91,5 +91,9 @@ export default withStyles(({ theme }) => ({
   container: {
     minHeight: getDesignRelativeHeight(180),
     height: getDesignRelativeHeight(180),
+  },
+  mediumFontWeight: {
+    marginVertical: theme.sizes.default,
+    fontWeight: '500',
   },
 }))(Who)

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -365,7 +365,7 @@ exports[`Amount matches snapshot 1`] = `
                   "direction": "ltr",
                   "fontFamily": "Roboto",
                   "fontSize": "24px",
-                  "fontWeight": "normal",
+                  "fontWeight": "500",
                   "lineHeight": "30px",
                   "marginBottom": "8px",
                   "marginTop": "8px",

--- a/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Reason.js.snap
@@ -331,7 +331,7 @@ exports[`Reason matches snapshot 1`] = `
               "direction": "ltr",
               "fontFamily": "Roboto",
               "fontSize": "24px",
-              "fontWeight": "normal",
+              "fontWeight": "500",
               "lineHeight": "30px",
               "marginBottom": "8px",
               "marginTop": "8px",

--- a/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendLinkSummary.js.snap
@@ -309,7 +309,7 @@ exports[`SendLinkSummary matches snapshot 1`] = `
             "direction": "ltr",
             "fontFamily": "Roboto",
             "fontSize": "24px",
-            "fontWeight": "normal",
+            "fontWeight": "500",
             "lineHeight": "30px",
             "marginBottom": "8px",
             "marginTop": "8px",

--- a/src/components/dashboard/__tests__/__snapshots__/Who.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Who.js.snap
@@ -343,7 +343,7 @@ exports[`Who matches snapshot 1`] = `
               "direction": "ltr",
               "fontFamily": "Roboto",
               "fontSize": "24px",
-              "fontWeight": "normal",
+              "fontWeight": "500",
               "lineHeight": "30px",
               "marginBottom": "8px",
               "marginTop": "8px",


### PR DESCRIPTION
# Description

make titles of send and receive flow screens medium font weight.

about #751 

# How Has This Been Tested?

register/signin to the app
1. click on send button 
go through send flow

2. click on receive
click on receive specific amount
go through receive flow.

see tittles

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes


Screenshots:

| 1 | 2 | 3 |
| --- | --- | --- |
| <img width="473" alt="1" src="https://user-images.githubusercontent.com/49862004/67776391-ea8a8480-fa68-11e9-8e74-11d899c951e6.png"> | <img width="473" alt="2" src="https://user-images.githubusercontent.com/49862004/67776413-f37b5600-fa68-11e9-8d34-eaaa0dc3c575.png"> | <img width="475" alt="3" src="https://user-images.githubusercontent.com/49862004/67776443-fc6c2780-fa68-11e9-9d82-9c90af84715b.png"> |
| <img width="475" alt="4" src="https://user-images.githubusercontent.com/49862004/67776496-10178e00-fa69-11e9-974f-e47655afb9e1.png"> | <img width="473" alt="5" src="https://user-images.githubusercontent.com/49862004/67776530-173e9c00-fa69-11e9-999e-98a718b4e512.png"> | <img width="472" alt="7" src="https://user-images.githubusercontent.com/49862004/67776539-1b6ab980-fa69-11e9-8f2a-cdc319a36176.png"> |
| <img width="474" alt="8" src="https://user-images.githubusercontent.com/49862004/67776700-5a007400-fa69-11e9-9555-157173ea3088.png"> | <img width="467" alt="9" src="https://user-images.githubusercontent.com/49862004/67776688-5240cf80-fa69-11e9-9ffd-d7dc377ffb4c.png"> |








