### PR TITLE
(bug) Profile privacy pop up: background should be blurred and brightend li…

### DIFF
--- a/src/components/profile/ProfilePrivacy.js
+++ b/src/components/profile/ProfilePrivacy.js
@@ -52,6 +52,7 @@ const ProfilePrivacy = props => {
 
   const handleSaveShowTips = () => {
     showDialog({
+      title: 'SETTINGS',
       content: (
         <>
           {privacyOptions.map(field => (


### PR DESCRIPTION
# Description

added title to pop-up

for #746

# How Has This Been Tested?

Go to PROFILE PRIVACY and click **Manage your privacy settings** icon

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
![image](https://user-images.githubusercontent.com/8187382/67783225-9dabab80-fa72-11e9-942c-e82f2942f14b.png)
