### PR TITLE
(Feature) #798 image editor should have trash icon instead of x

### DIFF
--- a/src/components/common/view/UserAvatar.js
+++ b/src/components/common/view/UserAvatar.js
@@ -5,7 +5,6 @@ import { getDesignRelativeWidth } from '../../../lib/utils/sizes'
 
 import { withStyles } from '../../../lib/styles'
 
-import Section from '../layout/Section'
 import Avatar from './Avatar'
 
 const AVATAR_DESIGN_WIDTH = 136
@@ -45,9 +44,6 @@ const UserAvatar = (props: AvatarProps) => {
         <Avatar size={avatarSize} {...props} source={profile.avatar}>
           {children}
         </Avatar>
-        <Section.Title fontSize={22} textTransform="none" fontFamily="slab" style={styles.fullNameContainer}>
-          {profile.fullName}
-        </Section.Title>
       </View>
     </View>
   )

--- a/src/components/common/view/__tests__/__snapshots__/UserAvatar.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/UserAvatar.js.snap
@@ -163,26 +163,6 @@ exports[`UserAvatar matches snapshot 1`] = `
           </div>
         </div>
       </div>
-      <div
-        className="css-text-901oao"
-        dir="auto"
-        style={
-          Object {
-            "color": "rgba(66,69,74,1.00)",
-            "direction": "ltr",
-            "fontFamily": "Roboto Slab",
-            "fontSize": "22px",
-            "fontWeight": "normal",
-            "lineHeight": "30px",
-            "marginTop": "8px",
-            "textAlign": "center",
-            "textDecoration": "none",
-            "textTransform": "none",
-          }
-        }
-      >
-        John Doe
-      </div>
     </div>
   </div>
 </div>

--- a/src/components/profile/ViewAvatar.js
+++ b/src/components/profile/ViewAvatar.js
@@ -46,7 +46,7 @@ const ViewAvatar = props => {
             <CircleButtonWrapper
               style={styles.closeButton}
               iconName={'trash'}
-              iconSize={21}
+              iconSize={22}
               onPress={handleClosePress}
             />
             <CameraButton style={styles.cameraButton} handleCameraPress={handleCameraPress} />

--- a/src/components/profile/ViewAvatar.js
+++ b/src/components/profile/ViewAvatar.js
@@ -46,7 +46,7 @@ const ViewAvatar = props => {
             <CircleButtonWrapper
               style={styles.closeButton}
               iconName={'trash'}
-              iconSize={20}
+              iconSize={21}
               onPress={handleClosePress}
             />
             <CameraButton style={styles.cameraButton} handleCameraPress={handleCameraPress} />

--- a/src/components/profile/ViewAvatar.js
+++ b/src/components/profile/ViewAvatar.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import GDStore from '../../lib/undux/GDStore'
-import { Section, UserAvatar, Wrapper } from '../common'
+import { CustomButton, Section, UserAvatar, Wrapper } from '../common'
 import { withStyles } from '../../lib/styles'
 import { useWrappedUserStorage } from '../../lib/gundb/useWrappedStorage'
 import { useErrorDialog } from '../../lib/undux/utils/dialog'
@@ -33,6 +33,10 @@ const ViewAvatar = props => {
     props.screenProps.push('EditAvatar')
   }
 
+  const goToProfile = () => {
+    props.screenProps.push('EditProfile')
+  }
+
   return (
     <Wrapper>
       <Section style={styles.section}>
@@ -41,7 +45,7 @@ const ViewAvatar = props => {
             <UserAvatar profile={profile} size={272} />
             <CircleButtonWrapper
               style={styles.closeButton}
-              iconName={'close'}
+              iconName={'trash'}
               iconSize={20}
               onPress={handleClosePress}
             />
@@ -57,6 +61,9 @@ const ViewAvatar = props => {
             </InputFile>
           </>
         )}
+        <CustomButton style={styles.doneButton} onPress={goToProfile}>
+          Done
+        </CustomButton>
       </Section>
     </Wrapper>
   )
@@ -81,6 +88,9 @@ const getStylesFromProps = ({ theme }) => ({
     left: 12,
     position: 'absolute',
     top: theme.sizes.defaultDouble,
+  },
+  doneButton: {
+    marginTop: 'auto',
   },
 })
 

--- a/src/components/profile/__tests__/__snapshots__/Profile.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/Profile.js.snap
@@ -723,24 +723,6 @@ exports[`Profile matches snapshot 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="css-text-901oao"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(66,69,74,1.00)",
-                        "direction": "ltr",
-                        "fontFamily": "Roboto Slab",
-                        "fontSize": "22px",
-                        "fontWeight": "normal",
-                        "lineHeight": "30px",
-                        "marginTop": "8px",
-                        "textAlign": "center",
-                        "textDecoration": "none",
-                        "textTransform": "none",
-                      }
-                    }
-                  />
                 </div>
               </div>
               <div


### PR DESCRIPTION
# Description

Change the icon of delete avatar from x to trash.
Remove user name from edit avatar screen.
Add done button at the bottom of edit avatar screen which redirects user back to Edit Profile screen.

About #798 

# How Has This Been Tested?

Register/login to the app.
Go to profile from side menu.
Go to edit profile.
Click on the photo button(edit avatar) under the avatar.
Add a new photo if not exists.
See the updated page according to design.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot:
<img width="475" alt="1" src="https://user-images.githubusercontent.com/49862004/68287738-e0c9d800-008b-11ea-8897-9d8cf0b6a368.png">
