### PR TITLE
(Chore) #830 Dashboard: Update timing of system cards

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -43,7 +43,7 @@ const onRouteChange = (prevNav, nav, route) => {
   fireEventFromNavigation(route)
 }
 const Router = () => {
-  userStorage.onlyForEToro()
+  userStorage.startSystemFeed()
   return (
     <GDStore.Container>
       <SimpleStoreDialog />

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -508,7 +508,7 @@ export class UserStorage {
       })
       logger.debug('init to events')
 
-      await this.initFeed()
+      this.initFeed()
       await this.initProperties()
 
       //save ref to user
@@ -700,24 +700,36 @@ export class UserStorage {
    * Subscribes to changes on the event index of day to number of events
    * the "false" (see gundb docs) passed is so we get the complete 'index' on every change and not just the day that changed
    */
-  async initFeed() {
+  initFeed() {
     this.feed = this.gunuser.get('feed')
     this.feed.get('index').on(this.updateFeedIndex, false)
+  }
 
-    //first time user
-    if ((await this.feed) === undefined) {
-      const w3Token = await this.getProfileFieldValue('w3Token')
+  async startSystemFeed() {
+    const userProperties = await this.userProperties.getAll()
+    const firstVisitAppDate = userProperties.firstVisitApp
 
+    // first time user visit
+    if (!firstVisitAppDate) {
       if (Config.isEToro) {
         this.enqueueTX(welcomeMessageOnlyEtoro)
+
+        setTimeout(() => {
+          this.enqueueTX(startSpending)
+        }, 60000)
       } else {
         this.enqueueTX(welcomeMessage)
       }
+
+      const w3Token = await this.getProfileFieldValue('w3Token')
+
       if (!w3Token) {
         setTimeout(() => {
           this.enqueueTX(inviteFriendsMessage)
         }, 60000)
       }
+
+      await this.userProperties.set('firstVisitApp', Date.now())
     }
   }
 
@@ -745,25 +757,6 @@ export class UserStorage {
     if (!userProperties.isMadeBackup) {
       await this.enqueueTX(backupMessage)
       await this.userProperties.set('isMadeBackup', true)
-    }
-  }
-
-  async onlyForEToro() {
-    if (Config.isEToro) {
-      const userProperties = await this.userProperties.getAll()
-      if (
-        userProperties.firstVisitApp &&
-        Date.now() - userProperties.firstVisitApp >= 68400 &&
-        userProperties.etoroAddCardSpending
-      ) {
-        await this.enqueueTX(startSpending)
-        await this.userProperties.set('etoroAddCardSpending', false)
-      }
-
-      if (!userProperties.firstVisitApp) {
-        await this.userProperties.set('firstVisitApp', Date.now())
-        await this.userProperties.set('etoroAddCardSpending', true)
-      }
     }
   }
 

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -716,7 +716,7 @@ export class UserStorage {
 
         setTimeout(() => {
           this.enqueueTX(startSpending)
-        }, 60000)
+        }, 60 * 1000) // 1 minute
       } else {
         this.enqueueTX(welcomeMessage)
       }
@@ -726,7 +726,7 @@ export class UserStorage {
       if (!w3Token) {
         setTimeout(() => {
           this.enqueueTX(inviteFriendsMessage)
-        }, 60000)
+        }, 2 * 60 * 1000) // 2 minutes
       }
 
       await this.userProperties.set('firstVisitApp', Date.now())

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -754,7 +754,11 @@ export class UserStorage {
    */
   async addBackupCard() {
     const userProperties = await this.userProperties.getAll()
-    if (!userProperties.isMadeBackup) {
+    const firstVisitAppDate = userProperties.firstVisitApp
+    const displayTimeFilter = 24 * 60 * 60 * 1000 // 24 hours
+    const allowToShowByTimeFilter = firstVisitAppDate && Date.now() - firstVisitAppDate >= displayTimeFilter
+
+    if (!userProperties.isMadeBackup && allowToShowByTimeFilter) {
       await this.enqueueTX(backupMessage)
       await this.userProperties.set('isMadeBackup', true)
     }

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -84,6 +84,13 @@ describe('UserStorage', () => {
     expect(res).toEqual(expect.objectContaining(UserPropertiesClass.defaultProperties))
   })
 
+  it('start system feeds', async () => {
+    await userStorage.startSystemFeed()
+    const res = await userStorage.userProperties.getAll()
+
+    expect(res.firstVisitApp).toBeTruthy()
+  })
+
   it('set all user properties', async () => {
     const res = await userStorage.userProperties.set('isMadeBackup', true)
     expect(res).toBeTruthy()


### PR DESCRIPTION
# Description

Change the logic of timing to show 'invite friends' and 'start spending' feed cards. Make corrections for start system feed cards logic.

About #830 

# How Has This Been Tested?

Register a new wallet.
You will be redirected to the dashboard.
On the dashboard you should see a welcome message appear right after application start.
The 'invite friends' feed card should appear after 1 minute.

EToro specific:
The ''start spending' feed card should appear after 1 minute.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
