### PR TITLE
(Bug) #850 Icon not seen well on "spend GoodDollars" card pop up (Desktop, Chrome)

### DIFF
--- a/src/components/common/modal/ModalTopImage.js
+++ b/src/components/common/modal/ModalTopImage.js
@@ -99,8 +99,8 @@ const getStylesFromProps = ({ theme }) => ({
     width: '100%',
   },
   spending: {
-    width: getDesignRelativeWidth(176, false),
-    height: getDesignRelativeHeight(76, false),
+    width: getDesignRelativeWidth(176),
+    height: getDesignRelativeHeight(76),
     margin: '10%',
   },
 })


### PR DESCRIPTION
# Description

Remove isMax=false property from getDesignRelative width/height for start spending top image as it breaks the image size on desktop.

About #850 

# How Has This Been Tested?

You should be running on etoro network.
Open the App.
Go to the dashboard.
Open the start spending feed card.
See top image.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot:
<img width="477" alt="2" src="https://user-images.githubusercontent.com/49862004/68384770-0379f080-0161-11ea-8c15-bffac890a783.png">
