### PR TITLE
(Bug) #853 reward card the reason isnt shown

### DIFF
--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -140,6 +140,10 @@ const FeedText = withStyles(getFeedTextStyles)(({ styles, feed }) => {
       result = <ReadMoreText text="here >>>" buttonText="Read more..." />
       break
 
+    case 'bonus':
+      result = <ReadMoreText buttonText={feed.data && feed.data.message} />
+      break
+
     default:
       result = (
         <Text numberOfLines={1} color="gray80Percent" fontSize={10} textTransform="capitalize" style={styles.message}>


### PR DESCRIPTION
The base branch of this PR is beta.

# Description

Show the reason text for the bonus feed item. Added condition to show sub-message for bonus feed event.

About #853 

# How Has This Been Tested?

You should be running on etoro network.
register a new account.
Wait for the success bonus event
see the bonus feed item.

The base branch of this PR is beta.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
