### PR TITLE
(Bug) feed cards should be sorted correctly by date and date shouldnt change

### DIFF
--- a/localStorage.tmp/GD_USER_MNEMONIC
+++ b/localStorage.tmp/GD_USER_MNEMONIC
@@ -1,1 +1,0 @@
-differ lady civil rabbit damage hobby bag vehicle dove hobby allow cram

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -730,7 +730,7 @@ export class UserStorage {
     const firstVisitAppDate = userProperties.firstVisitApp
 
     // first time user visit
-    if (!firstVisitAppDate) {
+    if (firstVisitAppDate == null) {
       if (Config.isEToro) {
         this.enqueueTX(welcomeMessageOnlyEtoro)
 
@@ -1447,6 +1447,7 @@ export class UserStorage {
       const existingEvent = await this.feed
         .get('byid')
         .get(event.id)
+        .then()
         .catch(_ => false)
       if (existingEvent) {
         logger.warn('enqueueTx skipping existing event id', event, existingEvent)

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -1451,7 +1451,7 @@ export class UserStorage {
         .catch(_ => false)
       if (existingEvent) {
         logger.warn('enqueueTx skipping existing event id', event, existingEvent)
-        return
+        return false
       }
       event.status = event.status || 'pending'
       event.createdDate = event.createdDate || new Date().toString()
@@ -1462,8 +1462,10 @@ export class UserStorage {
         .putAck(event)
       this.updateFeedEvent(event)
       logger.debug('enqueueTX ok:', { event, putRes })
+      return true
     } catch (e) {
       logger.error('enqueueTX failed: ', e.message, e)
+      return false
     } finally {
       release()
     }

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -12,6 +12,7 @@ import orderBy from 'lodash/orderBy'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
 import values from 'lodash/values'
+import get from 'lodash/get'
 import isEmail from 'validator/lib/isEmail'
 import moment from 'moment'
 import Config from '../../config/config'
@@ -572,11 +573,21 @@ export class UserStorage {
       const initialEvent = (await this.dequeueTX(receipt.transactionHash)) || { data: {} }
       logger.debug('handleReceiptUpdated got enqueued event:', { id: receipt.transactionHash, initialEvent })
 
+      const receiptDate = await this.wallet.wallet.eth
+        .getBlock(receipt.blockNumber)
+        .then(_ => new Date(_.timestamp * 1000))
+        .catch(_ => new Date())
+
       //get existing or make a new event
       const feedEvent = (await this.getFeedItemByTransactionHash(receipt.transactionHash)) || {
         id: receipt.transactionHash,
-        createdDate: new Date().toString(),
+        createdDate: receiptDate.toString(),
         type: getOperationType(data, this.wallet.account),
+      }
+
+      if (get(feedEvent, 'data.receipt')) {
+        logger.debug('handleReceiptUpdated skipping event with receipt', feedEvent, receipt)
+        return feedEvent
       }
 
       //merge incoming receipt data into existing event
@@ -584,7 +595,7 @@ export class UserStorage {
         ...feedEvent,
         ...initialEvent,
         status: feedEvent.status === 'cancelled' ? feedEvent.status : receipt.status ? 'completed' : 'error',
-        date: new Date().toString(),
+        date: receiptDate.toString(),
         data: {
           ...feedEvent.data,
           ...initialEvent.data,
@@ -625,6 +636,15 @@ export class UserStorage {
       }
       const feedEvent = await this.getFeedItemByTransactionHash(originalTXHash)
 
+      if (get(feedEvent, 'data.otplReceipt')) {
+        logger.debug('handleOTPLUpdated skipping event with receipt', feedEvent, receipt)
+        return feedEvent
+      }
+      const receiptDate = await this.wallet.wallet.eth
+        .getBlock(receipt.blockNumber)
+        .then(_ => new Date(_.timestamp * 1000))
+        .catch(_ => new Date())
+
       //if we withdrawn the payment link then its canceled
       const otplStatus = data.name === 'PaymentCancel' || data.to === data.from ? 'cancelled' : 'completed'
       const prevDate = feedEvent.date
@@ -632,7 +652,7 @@ export class UserStorage {
       feedEvent.data.otplReceipt = receipt
       feedEvent.data.otplData = data
       feedEvent.status = feedEvent.data.otplStatus = otplStatus
-      feedEvent.date = new Date().toString()
+      feedEvent.date = receiptDate.toString()
       logger.debug('handleOTPLUpdated receiptReceived', { feedEvent, otplStatus, receipt, data })
       await this.updateFeedEvent(feedEvent, prevDate)
       return feedEvent
@@ -1424,8 +1444,17 @@ export class UserStorage {
     //a race exists between enqueing and receipt from websockets/polling
     const release = await this.feedMutex.lock()
     try {
+      const existingEvent = await this.feed
+        .get('byid')
+        .get(event.id)
+        .catch(_ => false)
+      if (existingEvent) {
+        logger.warn('enqueueTx skipping existing event id', event, existingEvent)
+        return
+      }
       event.status = event.status || 'pending'
       event.createdDate = event.createdDate || new Date().toString()
+      event.date = event.date || event.createdDate
       let putRes = await this.feed
         .get('queue')
         .get(event.id)

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -91,6 +91,15 @@ describe('UserStorage', () => {
     expect(res.firstVisitApp).toBeTruthy()
   })
 
+  it('events/has the welcome event already set', async () => {
+    const events = await userStorage.getAllFeed()
+    if (Config.isEToro) {
+      expect(events).toContainEqual(welcomeMessageOnlyEtoro)
+    } else {
+      expect(events).toContainEqual(welcomeMessage)
+    }
+  })
+
   it('set all user properties', async () => {
     const res = await userStorage.userProperties.set('isMadeBackup', true)
     expect(res).toBeTruthy()
@@ -260,7 +269,7 @@ describe('UserStorage', () => {
     expect(res).toEqual(expect.objectContaining({ privacy: 'private', display: '******' }))
   })
 
-  it('add event', async () => {
+  it('events/add event', async () => {
     await userStorage.updateFeedEvent(event)
     const index = await userStorage.feed
       .get('index')
@@ -271,7 +280,7 @@ describe('UserStorage', () => {
     expect(events).toContainEqual(event)
   })
 
-  it('add second event', async () => {
+  it('events/add second event', async () => {
     await userStorage.updateFeedEvent(event)
     await userStorage.updateFeedEvent(event2)
     const index = await userStorage.feed
@@ -284,7 +293,7 @@ describe('UserStorage', () => {
     expect(events).toContainEqual(event)
   })
 
-  it('updates first event', async () => {
+  it('events/updates first event', async () => {
     await userStorage.updateFeedEvent(event)
     await delay(0)
     let updatedEvent = {
@@ -303,7 +312,7 @@ describe('UserStorage', () => {
     expect(events).toContainEqual(updatedEvent)
   })
 
-  it('add middle event', async () => {
+  it('events/add middle event', async () => {
     await userStorage.updateFeedEvent(mergedEvent)
     await userStorage.updateFeedEvent(event2)
     await userStorage.updateFeedEvent(event3)
@@ -316,7 +325,7 @@ describe('UserStorage', () => {
     expect(events).toEqual(expect.arrayContaining([event2, event3, mergedEvent]))
   })
 
-  it('keeps event index sorted', async () => {
+  it('events/keeps event index sorted', async () => {
     await userStorage.updateFeedEvent(event4)
     const index = await userStorage.feed
       .get('index')
@@ -327,12 +336,14 @@ describe('UserStorage', () => {
     expect(events.map(event => event.id)).toEqual([event4.id])
   })
 
-  it('gets events first page', async () => {
+  it('events/gets events first page', async () => {
+    //welcome message+01-02 event =2
     const gunRes = await userStorage.getFeedPage(2)
     expect(gunRes.length).toEqual(2)
   })
 
-  it('gets events second page', async () => {
+  it('events/gets events second page using cursor', async () => {
+    //rest of other 3 01-01 events
     const gunRes = await userStorage.getFeedPage(2)
     expect(gunRes.length).toEqual(3)
   })
@@ -342,7 +353,7 @@ describe('UserStorage', () => {
     expect(gunRes.length).toEqual(1)
   })
 
-  it('add TransactionEvent event', async () => {
+  it('events/add TransactionEvent event', async () => {
     const date = '2020-01-01'
     const transactionEvent: TransactionEvent = {
       id: 'xyz32',
@@ -366,28 +377,19 @@ describe('UserStorage', () => {
     expect(events).toContainEqual(transactionEvent)
   })
 
-  it('add invite event', async () => {
+  it('events/add invite event', async () => {
     await userStorage.updateFeedEvent(inviteFriendsMessage)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(inviteFriendsMessage)
   })
 
-  it('add invite event', async () => {
+  it('events/add invite event', async () => {
     await userStorage.updateFeedEvent(startSpending)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(startSpending)
   })
 
-  it('has the welcome event already set', async () => {
-    const events = await userStorage.getAllFeed()
-    if (Config.isEToro) {
-      expect(events).toContainEqual(welcomeMessageOnlyEtoro)
-    } else {
-      expect(events).toContainEqual(welcomeMessage)
-    }
-  })
-
-  it('has the welcome event already set', async () => {
+  it('events/doesnt have the welcome event already set', async () => {
     const events = await userStorage.getAllFeed()
     if (Config.isEToro) {
       expect(events).toEqual(expect.not.objectContaining(welcomeMessage))
@@ -396,13 +398,13 @@ describe('UserStorage', () => {
     }
   })
 
-  it('add welcome etoro', async () => {
+  it('events/add welcome etoro', async () => {
     await userStorage.updateFeedEvent(welcomeMessageOnlyEtoro)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(welcomeMessageOnlyEtoro)
   })
 
-  it('has the backupMessage event already set', async () => {
+  it('events/has the backupMessage event already set', async () => {
     await userStorage.updateFeedEvent(backupMessage)
     const events = await userStorage.getAllFeed()
     expect(events).toContainEqual(backupMessage)

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -909,4 +909,14 @@ describe('users index', () => {
     expect(isValid).toBeFalsy()
     expect(errors).toEqual({ email: 'Unavailable email' })
   })
+
+  it('events/doesnt enqueue existing event', async () => {
+    const prevmsg = welcomeMessage
+    await userStorage.enqueueTX(welcomeMessage)
+    const newmsg = Object.assign({ date: 'fake date' }, welcomeMessage)
+    const res = await userStorage.enqueueTX(newmsg)
+    expect(res).toBeFalsy()
+    const fromfeed = await userStorage.getFeedItemByTransactionHash(welcomeMessage.id)
+    expect(fromfeed).toEqual(prevmsg)
+  })
 })


### PR DESCRIPTION
# Description

- when updating feed item from blockchain receipt we use receipt date instead of current date
- if feed item was updated from receipt we skip updating it again, maybe for some reason we get the blockchain event again.
- if feed item with same id exists we prevent enqueueTx from working.

About #849

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
