### PR TITLE
(Bug) #799 bonus event should be from good dollar and not unknown

### DIFF
--- a/src/components/common/view/AddWebApp.web.js
+++ b/src/components/common/view/AddWebApp.web.js
@@ -236,7 +236,7 @@ const AddWebApp = props => {
       }
     }
 
-    if ((installPrompt && show) || (iOSAdded === false && isMobileSafari && show)) {
+    if ((installPrompt && show) || (!iOSAdded && isMobileSafari && show)) {
       setDialogShown(true)
     }
   }, [installPrompt, show, lastCheck])

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -13,11 +13,10 @@ import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { getInitialFeed, getNextFeed, PAGE_SIZE } from '../../lib/undux/utils/feed'
 import { executeWithdraw } from '../../lib/undux/utils/withdraw'
-import { gdToWei, weiToMask } from '../../lib/wallet/utils'
+import { weiToMask } from '../../lib/wallet/utils'
 
 import { createStackNavigator } from '../appNavigation/stackNavigation'
 
-import type { TransactionEvent } from '../../lib/gundb/UserStorage'
 import userStorage from '../../lib/gundb/UserStorage'
 import goodWallet from '../../lib/wallet/GoodWallet'
 import { PushButton } from '../appNavigation/PushButton'
@@ -127,22 +126,7 @@ const Dashboard = props => {
 
     API.redeemBonuses()
       .then(res => {
-        const resData = res.data
-        log.debug('redeemBonuses', { resData })
-        if (resData.hash && resData.bonusAmount) {
-          const transactionEvent: TransactionEvent = {
-            id: resData.hash,
-            date: new Date().toString(),
-            type: 'bonus',
-            status: 'completed',
-            data: {
-              customName: 'GoodDollar',
-              amount: gdToWei(resData.bonusAmount),
-            },
-          }
-
-          userStorage.enqueueTX(transactionEvent)
-        }
+        log.debug('redeemBonuses', { resData: res && res.data })
       })
       .catch(err => {
         log.error('Failed to redeem bonuses', err.message, err)

--- a/src/components/webView/__tests__/__snapshots__/WebViewScreen.js.snap
+++ b/src/components/webView/__tests__/__snapshots__/WebViewScreen.js.snap
@@ -57,7 +57,7 @@ exports[`WebViewScreen Instances TermsOfUse matches snapshot 1`] = `
   height="100%"
   onLoad={[Function]}
   seamless={true}
-  src="https://community.gooddollar.org/dappterms/"
+  src="https://community.gooddollar.org/dappterms"
   style={
     Object {
       "height": 844,

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -603,11 +603,11 @@ export class UserStorage {
         return feedEvent
       }
 
-      const receiptLogEvents = get(receipt, 'logs[0].events') || []
-      const fromLog = receiptLogEvents.find(e => e.name === 'from') || {}
-      const fromContract = fromLog.value
+      const fromContract = data.from
       const SignUpBonusContractAddress = this.wallet.getSignUpBonusAddress()
-      const isSignUpBonus = SignUpBonusContractAddress.toLowerCase() === fromContract.toLowerCase()
+      const isSignUpBonus =
+        data.name === CONTRACT_EVENT_TYPE_TRANSFER &&
+        SignUpBonusContractAddress.toLowerCase() === fromContract.toLowerCase()
 
       if (isSignUpBonus) {
         feedEvent.type = EVENT_TYPE_BONUS

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -198,6 +198,10 @@ export class GoodWallet {
     return this.ready
   }
 
+  getSignUpBonusAddress() {
+    return get(ContractsAddress, `${this.network}.SignupBonus`)
+  }
+
   /**
    * Subscribes to Transfer events (from and to) the current account
    * This is used to verify account balance changes


### PR DESCRIPTION
# Description

Remove enqueueTx from the dashboard for redeeming bonuses process. Detect the bonus event in handleReceiptUpdated fn by comparing bonus address with received in a transfer event.

Also here is the fix for displaying adwebbapp for ios devices.

About #799 #853 

# How Has This Been Tested?

Register new account
When you will be redirected to the dashboard - wait for redeem bonus feed item appear
The feed item should be with the logo icon and the text 'From' should be GoodDollar.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

The link to GoodServer PR - https://github.com/GoodDollar/GoodServer/pull/120

Gif:
![2019-11-11_12-18-39 (1)](https://user-images.githubusercontent.com/49862004/68580178-7abfc500-047e-11ea-807b-21bba996bea6.gif)
