### PR TITLE
Better error messages for payment code withdraw

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -288,13 +288,13 @@ const Dashboard = props => {
             // eslint-disable-next-line no-await-in-loop
             await delay(2000)
             // eslint-disable-next-line no-await-in-loop
-            const status = await goodWallet.getWithdrawStatus(decodeURI(paymentCode))
+            const { status } = await goodWallet.getWithdrawDetails(decodeURI(paymentCode))
             if (status === WITHDRAW_STATUS_PENDING) {
               // eslint-disable-next-line no-await-in-loop
               return await handleWithdraw()
             }
           }
-          showErrorDialog('Could not find payment or incorrect code')
+          showErrorDialog('Could not find payment details. Check your link or try again later.')
         }
       }
     } catch (e) {

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -15,7 +15,11 @@ import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { getInitialFeed, getNextFeed, PAGE_SIZE } from '../../lib/undux/utils/feed'
 import { executeWithdraw } from '../../lib/undux/utils/withdraw'
 import { weiToMask } from '../../lib/wallet/utils'
-import { ERROR_PAYMENT_LINK_INCORRECT } from '../../lib/wallet/GoodWalletClass'
+import {
+  WITHDRAW_STATUS_COMPLETE,
+  WITHDRAW_STATUS_PENDING,
+  WITHDRAW_STATUS_UNKNOWN,
+} from '../../lib/wallet/GoodWalletClass'
 
 import { createStackNavigator } from '../appNavigation/stackNavigation'
 
@@ -260,10 +264,9 @@ const Dashboard = props => {
 
   showOutOfGasError(props)
 
-  const handleWithdraw = async (attempts: number) => {
+  const handleWithdraw = async () => {
     const { paymentCode, reason } = props.navigation.state.params
     const { styles }: DashboardProps = props
-    const activeAttempts = attempts ? attempts : 0
     try {
       showDialog({
         title: 'Processing Payment Link...',
@@ -271,16 +274,32 @@ const Dashboard = props => {
         message: 'please wait while processing...',
         buttons: [{ text: 'YAY!', style: styles.disabledButton }],
       })
-      await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
-      hideDialog()
-    } catch (e) {
-      if (e.code && e.code === ERROR_PAYMENT_LINK_INCORRECT && activeAttempts < 3) {
-        await delay(2000)
-        await handleWithdraw(activeAttempts + 1)
-      } else {
-        log.error('withdraw failed:', e.code, e.message, e)
-        showErrorDialog(e.message)
+      const { status, transactionHash } = await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
+      if (transactionHash) {
+        hideDialog()
+        return
       }
+      switch (status) {
+        case WITHDRAW_STATUS_COMPLETE:
+          showErrorDialog('Payment already withdrawn or canceled by sender')
+          break
+        case WITHDRAW_STATUS_UNKNOWN: {
+          for (let activeAttempts = 0; activeAttempts < 3; activeAttempts++) {
+            // eslint-disable-next-line no-await-in-loop
+            await delay(2000)
+            // eslint-disable-next-line no-await-in-loop
+            const status = await goodWallet.getWithdrawStatus(decodeURI(paymentCode))
+            if (status === WITHDRAW_STATUS_PENDING) {
+              // eslint-disable-next-line no-await-in-loop
+              return await handleWithdraw()
+            }
+          }
+          showErrorDialog('Could not find payment or incorrect code')
+        }
+      }
+    } catch (e) {
+      log.error('withdraw failed:', e.code, e.message, e)
+      showErrorDialog(e.message)
     }
   }
 

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -260,9 +260,10 @@ const Dashboard = props => {
 
   showOutOfGasError(props)
 
-  const handleWithdraw = async (attempts: number = 0) => {
+  const handleWithdraw = async (attempts: number) => {
     const { paymentCode, reason } = props.navigation.state.params
     const { styles }: DashboardProps = props
+    const activeAttempts = attempts ? attempts : 0
     try {
       showDialog({
         title: 'Processing Payment Link...',
@@ -273,9 +274,9 @@ const Dashboard = props => {
       await executeWithdraw(store, decodeURI(paymentCode), decodeURI(reason))
       hideDialog()
     } catch (e) {
-      if (e.code && e.code === ERROR_PAYMENT_LINK_INCORRECT && attempts < 3) {
+      if (e.code && e.code === ERROR_PAYMENT_LINK_INCORRECT && activeAttempts < 3) {
         await delay(2000)
-        await handleWithdraw(attempts + 1)
+        await handleWithdraw(activeAttempts + 1)
       } else {
         log.error('withdraw failed:', e.code, e.message, e)
         showErrorDialog(e.message)

--- a/src/lib/undux/utils/withdraw.js
+++ b/src/lib/undux/utils/withdraw.js
@@ -28,7 +28,7 @@ type ReceiptType = {
 export const executeWithdraw = async (store: Store, code: string, reason: string): Promise<ReceiptType> => {
   log.info('executeWithdraw', code, reason)
   try {
-    const { amount, sender, status } = await goodWallet.canWithdraw(code)
+    const { amount, sender, status } = await goodWallet.getWithdrawDetails(code)
     if (status === WITHDRAW_STATUS_PENDING) {
       return new Promise((res, rej) => {
         goodWallet.withdraw(code, {

--- a/src/lib/undux/utils/withdraw.js
+++ b/src/lib/undux/utils/withdraw.js
@@ -4,6 +4,7 @@ import goodWallet from '../../wallet/GoodWallet'
 import pino from '../../logger/pino-logger'
 import userStorage from '../../gundb/UserStorage'
 import type { TransactionEvent } from '../../gundb/UserStorage'
+import { WITHDRAW_STATUS_PENDING } from '../../wallet/GoodWalletClass'
 
 const log = pino.child({ from: 'withdraw' })
 
@@ -27,30 +28,33 @@ type ReceiptType = {
 export const executeWithdraw = async (store: Store, code: string, reason: string): Promise<ReceiptType> => {
   log.info('executeWithdraw', code, reason)
   try {
-    const { amount, sender } = await goodWallet.canWithdraw(code)
-    return new Promise((res, rej) => {
-      goodWallet.withdraw(code, {
-        onTransactionHash: transactionHash => {
-          const transactionEvent: TransactionEvent = {
-            id: transactionHash,
-            date: new Date().toString(),
-            type: 'withdraw',
-            data: {
-              from: sender,
-              amount,
-              code,
-              reason,
-            },
-          }
-          userStorage.enqueueTX(transactionEvent)
-          res(transactionHash)
-        },
-        onError: e => {
-          userStorage.markWithErrorEvent(e)
-          rej(e)
-        },
+    const { amount, sender, status } = await goodWallet.canWithdraw(code)
+    if (status === WITHDRAW_STATUS_PENDING) {
+      return new Promise((res, rej) => {
+        goodWallet.withdraw(code, {
+          onTransactionHash: transactionHash => {
+            const transactionEvent: TransactionEvent = {
+              id: transactionHash,
+              date: new Date().toString(),
+              type: 'withdraw',
+              data: {
+                from: sender,
+                amount,
+                code,
+                reason,
+              },
+            }
+            userStorage.enqueueTX(transactionEvent)
+            res({ status, transactionHash })
+          },
+          onError: e => {
+            userStorage.markWithErrorEvent(e)
+            rej(e)
+          },
+        })
       })
-    })
+    }
+    return { status }
   } catch (e) {
     log.error('code withdraw failed', code, e.message, e)
     throw e

--- a/src/lib/wallet/__tests__/GoodWallet.fuse.js
+++ b/src/lib/wallet/__tests__/GoodWallet.fuse.js
@@ -94,10 +94,10 @@ describe('GoodWalletShare/ReceiveTokens', () => {
 
     const isused = await testWallet.isWithdrawLinkUsed(DEPOSIT_CODE_HASH)
     expect(isused).toBeTruthy()
-    const res = await testWallet.canWithdraw(DEPOSIT_CODE)
+    const res = await testWallet.getWithdrawDetails(DEPOSIT_CODE)
 
     expect(parseInt(res.amount)).toEqual(balance - fee)
-
+    expect(res.sender).toEqual(testWallet.account)
     await testWallet2.withdraw(DEPOSIT_CODE)
 
     const res2 = await testWallet2.isWithdrawLinkUsed(DEPOSIT_CODE_HASH)


### PR DESCRIPTION
# Description

the error definition in the canWithdraw method has been changed, an error code has also been added for the recursive start of a transaction

About #802 

# How Has This Been Tested?

Create a link to the payment and go to it twice, For the second time, get the error "**Payment already withdrawn or canceled by sender**", Or create a non-correct code in this link, we also get the error

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
