### PR TITLE
(Bug) #513 The cursor is displayed in the field after clicking the “RECOVER MY WALLET” button

### DIFF
--- a/src/components/signin/Mnemonics.js
+++ b/src/components/signin/Mnemonics.js
@@ -30,6 +30,7 @@ const Mnemonics = ({ screenProps, navigation, styles }) => {
   const [showDialog] = useDialog()
   const [errorMessage, setErrorMessage] = useState()
   const [showErrorDialog, hideDialog] = useErrorDialog()
+  const input = React.createRef()
 
   AsyncStorage.removeItem('GD_web3Token')
 
@@ -50,6 +51,7 @@ const Mnemonics = ({ screenProps, navigation, styles }) => {
   }
 
   const recover = async () => {
+    input.current.blur()
     setRecovering(true)
     fireEvent(CLICK_BTN_RECOVER_WALLET)
     const showError = () =>
@@ -158,6 +160,7 @@ const Mnemonics = ({ screenProps, navigation, styles }) => {
               error={errorMessage}
               onKeyPress={handleEnter}
               onCleanUpField={handleChange}
+              getRef={input}
               autoFocus
             />
           </Section.Row>


### PR DESCRIPTION
# Description

Remove focus from mnemonics input right after user click on 'recover wallet' button

About #513 

# How Has This Been Tested?

Go to recover by pass phrase screen.
Paste invalid mnemonic and try to press recover wallet button.
Repeat prev step a few times - every time the focus should be removed from input.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

VIdeo: https://www.screencast.com/t/Vv0OHffbI8ja