### PR TITLE
(Bug) #831 Dashboard - Good market card: Last word gets cut on small devices

### DIFF
--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -202,7 +202,7 @@ export const startSpending = {
   status: 'completed',
   data: {
     customName: 'Go to GoodMarket',
-    subtitle: 'Start spending your GoodDollars',
+    subtitle: "Start spending your G$'s",
     receiptData: {
       from: '0x0000000000000000000000000000000000000000',
     },


### PR DESCRIPTION
# Description

Change the text for 'start spending G$' feed card from ‘Start spending your GoodDollars’ to ‘Start spending your G$'s’.

About #831 

# How Has This Been Tested?

You should be running with etoro environment.
After 1 minute the start spending feed card will appear.
Se update text.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot:
![1](https://user-images.githubusercontent.com/49862004/68946364-7adffd80-07bb-11ea-90dc-970c17ef55e4.png)
