### PR TITLE
(Bug) #931 User stays on the "You're got mail" screen after entering the already used mail address

### DIFF
--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -361,7 +361,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
         return navigateWithFocus(nextRoute.key)
       } catch (e) {
         log.error('Send mobile code failed', e.message, e)
-        showErrorDialog('Could not send verification code. Please try again')
+        return showErrorDialog('Could not send verification code. Please try again')
       } finally {
         setLoading(false)
       }
@@ -397,7 +397,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
         return navigateWithFocus(nextRoute.key)
       } catch (e) {
         log.error('email verification failed unexpected:', e.message, e)
-        showErrorDialog('Could not send verification email. Please try again', 'EMAIL-UNEXPECTED-1')
+        return showErrorDialog('Could not send verification email. Please try again', 'EMAIL-UNEXPECTED-1')
       } finally {
         setLoading(false)
       }

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -379,7 +379,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
 
         const { data } = await API.sendVerificationEmail(newState)
         if (data.ok === 0) {
-          showErrorDialog('Could not send verification email. Please try again')
+          return showErrorDialog('Could not send verification email. Please try again')
         }
         log.debug('skipping email verification?', { ...data, skip: Config.skipEmailVerification })
         if (Config.skipEmailVerification || data.onlyInEnv) {


### PR DESCRIPTION
# Description

Stop executing the done fn flow if an error occurred while sending a verification email.

About #931 

# How Has This Been Tested?

Try to register two users with the same email.
You should not be redirected to the next step if the duplicated email is used after pressing the ok or close button on error popup.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Gif:
![2019-11-15_17-22-22 (1)](https://user-images.githubusercontent.com/49862004/68954569-f6967600-07cc-11ea-9204-36be8530768c.gif)
