### PR TITLE
(Bug) #942 user from w3 tries to register after deleting his account

### DIFF
--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -231,7 +231,7 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
 
     // don't allow to start sign up flow not from begining except when w3Token provided
     AsyncStorage.getItem('GD_web3Token').then(token => {
-      if (!token && navigation.state.index > 0) {
+      if ((token && navigation.state.index > 1) || (!token && navigation.state.index > 0)) {
         log.debug('redirecting to start, got index:', navigation.state.index)
         setLoading(true)
         return navigateWithFocus(navigation.state.routes[0].key)
@@ -296,7 +296,6 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
 
       //need to wait for API.addUser but we dont need to wait for it to finish
       Promise.all([
-        AsyncStorage.removeItem('GD_web3Token'),
         w3Token &&
           API.updateW3UserWithWallet(w3Token, goodWallet.account).catch(e =>
             log.error('failed updateW3UserWithWallet', e.message, e)
@@ -305,7 +304,11 @@ const Signup = ({ navigation, screenProps }: { navigation: any, screenProps: any
           log.error('failed sendMagicLinkByEmail', e.message, e)
         ),
       ])
+
       await AsyncStorage.setItem(IS_LOGGED_IN, true)
+
+      AsyncStorage.removeItem('GD_web3Token')
+
       log.debug('New user created')
       return true
     } catch (e) {


### PR DESCRIPTION
# Description

Remove w3Token from AsyncStorage after setting isLoggedIn to true in register flow.

About #942 

# How Has This Been Tested?

You need to somehow initiate the error in SignUpState finisgRegistration function. So after you reach the last step of registration you will see an error.
Try to register a new user.
After you will see an error - reload the page.
The w3Token should not be deleted from AsyncStorage and the registration process will be continued with w3Token, the data fetched from w3Site and email verified successfully.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
