### PR TITLE
(Bug) #948 error in ios pwa signin screen

### DIFF
--- a/src/components/signin/IOSWebAppSignIn.js
+++ b/src/components/signin/IOSWebAppSignIn.js
@@ -24,7 +24,7 @@ const Mnemonics = ({ screenProps, navigation, styles }) => {
   //lazy load heavy wallet stuff for fast initial app load (part of initial routes)
   const [code, setCode] = useState()
   const [isRecovering, setRecovering] = useState(false)
-  const [isValid, setValid] = useState(true)
+  const [isValid, setValid] = useState(false)
   const [showErrorDialog] = useErrorDialog()
 
   const handleChange = (newCode: string) => {

--- a/src/components/signin/__tests__/__snapshots__/IOSWebAppSignIn.js.snap
+++ b/src/components/signin/__tests__/__snapshots__/IOSWebAppSignIn.js.snap
@@ -448,7 +448,7 @@ sent to you by text message:
             "WebkitBoxPack": "center",
             "WebkitJustifyContent": "center",
             "alignItems": "stretch",
-            "backgroundColor": "rgba(0,175,255,1.00)",
+            "backgroundColor": "rgba(0,0,0,0.12)",
             "borderBottomColor": "rgba(0,175,255,1.00)",
             "borderBottomLeftRadius": "50px",
             "borderBottomRightRadius": "50px",
@@ -465,7 +465,6 @@ sent to you by text message:
             "borderTopRightRadius": "50px",
             "borderTopStyle": "solid",
             "borderTopWidth": "0px",
-            "boxShadow": "0px 0.75px 1.5px rgba(0,0,0,0.24)",
             "display": "flex",
             "justifyContent": "center",
             "marginBottom": "20px",
@@ -484,15 +483,13 @@ sent to you by text message:
         }
       >
         <div
-          className="css-cursor-18t94o4 css-view-1dbjc4n"
-          data-focusable={true}
-          disabled={false}
+          aria-disabled={true}
+          className="css-view-1dbjc4n"
+          disabled={true}
           onKeyDown={[Function]}
-          onKeyPress={[Function]}
           onKeyUp={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
-          onResponderRelease={[Function]}
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
@@ -503,15 +500,11 @@ sent to you by text message:
               "borderBottomRightRadius": "50px",
               "borderTopLeftRadius": "50px",
               "borderTopRightRadius": "50px",
-              "cursor": "pointer",
-              "msTouchAction": "manipulation",
               "overflowX": "hidden",
               "overflowY": "hidden",
               "position": "relative",
-              "touchAction": "manipulation",
             }
           }
-          tabIndex="0"
         >
           <div
             className="css-view-1dbjc4n"
@@ -538,7 +531,7 @@ sent to you by text message:
               dir="auto"
               style={
                 Object {
-                  "color": "rgba(255,255,255,1.00)",
+                  "color": "rgba(0,0,0,0.32)",
                   "direction": "ltr",
                   "fontFamily": "Roboto-Medium, Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
                   "letterSpacing": "1px",


### PR DESCRIPTION
# Description

Make the isValid local variable for the IOSWebAppSignIn component to be false by default.

About #948 

# How Has This Been Tested?

Go to /IOSWebAppSignIn route
and the submit button should be disabled by default.
It should become active after some value will be pasted/typed into the field.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
