### PR TITLE
(Bug) #922 the number on the how much screen arent highlighted with black color

### DIFF
--- a/src/components/common/view/AmountInput.js
+++ b/src/components/common/view/AmountInput.js
@@ -38,7 +38,7 @@ const AmountInput = ({ amount, handleAmountChange, styles, error, title }: Amoun
         >
           <InputGoodDollar
             style={error ? styles.errorInput : styles.section}
-            disabled={isMobile}
+            editable={!isMobile}
             autoFocus
             amount={amount}
             onChangeAmount={handleAmountChange}

--- a/src/components/common/view/__tests__/__snapshots__/AmountInput.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/AmountInput.js.snap
@@ -93,7 +93,6 @@ exports[`AmountInput matches snapshot 1`] = `
             autoFocus={true}
             className="css-textinput-1cwyjr8 r-placeholderTextColor-1xktb6b"
             dir="auto"
-            disabled={false}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -420,7 +420,6 @@ exports[`Amount matches snapshot 1`] = `
                   autoFocus={true}
                   className="css-textinput-1cwyjr8 r-placeholderTextColor-1xktb6b"
                   dir="auto"
-                  disabled={false}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}


### PR DESCRIPTION
# Description

The amount field is disabled on mobile devices. There is an opacity: 0.4 style prop applied for disabled inputs. The solution is to set opacity 1 for the amount field used in send flow.
Also, want to admit that the text shouldn't be black. It should be #42454a according to design.

About #922 

# How Has This Been Tested?

Open the app on ios simulator.
Go to the dashboard.
Click on the send button.
Go to amount (how much?) step.
Type some amount to see text color in the input.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Applied color is: #42454a
Screenshot:
![1](https://user-images.githubusercontent.com/49862004/69337518-bbcb8c80-0c69-11ea-8585-d8a1e9f661c6.png)
