### PR TITLE
(Bug) #988 payment from receive link shows up with claim icon

### DIFF
--- a/src/components/dashboard/FeedItems/EventSettingsByType.js
+++ b/src/components/dashboard/FeedItems/EventSettingsByType.js
@@ -48,7 +48,7 @@ const getEventSettingsByType = (theme, type) => {
     receive: {
       actionSymbol: '+',
       color: theme.colors.lightGreen,
-      name: 'claim-filled',
+      name: 'receive-filled',
     },
     withdraw: {
       actionSymbol: '+',

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/EventIcon.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/EventIcon.js.snap
@@ -15,7 +15,7 @@ exports[`EventIcon - Receive matches snapshot 1`] = `
     }
   }
 >
-  
+  
 </div>
 `;
 

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
@@ -511,7 +511,7 @@ exports[`ListEventItem receive matches snapshot 1`] = `
             }
           }
         >
-          
+          
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Set correct icons name for receive feed event

About #988 

# How Has This Been Tested?

Create request specific amount link.
Open in another browser.
Look at the feed created on the first browser. The icon . should be correct

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot:
<img width="467" alt="1" src="https://user-images.githubusercontent.com/49862004/69551059-bd1bf280-0fa4-11ea-925a-f8ad25e5e954.png">
