### PR TITLE
(Bug) #971 Feed - Pop up slide: the cards should be inside the max width (on desktop)

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { useEffect, useState } from 'react'
 import { Animated, AppState, Dimensions, Easing } from 'react-native'
+import { isBrowser } from 'mobile-device-detect'
 import debounce from 'lodash/debounce'
 import _get from 'lodash/get'
 import moment from 'moment'
@@ -496,7 +497,7 @@ const Dashboard = props => {
       />
       {currentFeed && (
         <FeedModalList
-          data={feeds}
+          data={isBrowser ? [currentFeed] : feeds}
           handleFeedSelection={handleFeedSelection}
           initialNumToRender={PAGE_SIZE}
           onEndReached={nextFeed}


### PR DESCRIPTION
# Description

Pass only currentFeed object to the Modal FlatList to display only selected feed and to remove possibility of switching between existed feed on desktop.

About #971 

# How Has This Been Tested?

Try to open the modal feed item and scroll to another. You shouldn't be able to do that.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
