### PR TITLE
(Bug) #991 User receive the verification code to the wrong email address when try to change profile email

### DIFF
--- a/src/components/profile/VerifyEdit.js
+++ b/src/components/profile/VerifyEdit.js
@@ -25,12 +25,14 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
   const firstName = fullName && fullName.split(' ')[0]
   const field = _get(navigation, 'state.params.field')
   const content = _get(navigation, 'state.params.content')
+  let fieldToSend
   let fieldToShow
   let sendToText
   let sendCodeRequestFn
 
   switch (field) {
     case 'phone':
+      fieldToSend = 'mobile'
       fieldToShow = 'phone number'
       sendToText = 'number'
       sendCodeRequestFn = 'sendOTP'
@@ -38,6 +40,7 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
 
     case 'email':
     default:
+      fieldToSend = 'email'
       fieldToShow = 'email'
       sendToText = 'email'
       sendCodeRequestFn = 'sendVerificationEmail'
@@ -52,7 +55,7 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
     try {
       setLoading(true)
 
-      await API[sendCodeRequestFn]({ [field]: content })
+      await API[sendCodeRequestFn]({ [fieldToSend]: content })
 
       navigation.navigate('VerifyEditCode', { field, content })
     } catch (e) {

--- a/src/components/profile/VerifyEdit.js
+++ b/src/components/profile/VerifyEdit.js
@@ -52,7 +52,7 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
     try {
       setLoading(true)
 
-      await API[sendCodeRequestFn](content)
+      await API[sendCodeRequestFn]({ [field]: content })
 
       navigation.navigate('VerifyEditCode', { field, content })
     } catch (e) {


### PR DESCRIPTION
# Description

Send the right structure of user obj to the server for send verification code via /mobile/email.

The link to GoodServer PR - https://github.com/GoodDollar/GoodServer/pull/129

About #991 

# How Has This Been Tested?

In GoodServer set the SKIP_EMAIL_VERIFICATION to false.
In GoodServer set the development option to /sendemail endpoint
Try to change the email on the Edit Profile page.
The verification code should be sent to a new email.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
