### PR TITLE
(Feature) #955 - add simulate withdraw tx reverted option

### DIFF
--- a/src/components/about/__tests__/__snapshots__/About.js.snap
+++ b/src/components/about/__tests__/__snapshots__/About.js.snap
@@ -245,7 +245,7 @@ exports[`About matches snapshot 1`] = `
             }
           }
         >
-          V2
+          Vv0
         </div>
         <div
           className="css-text-901oao"

--- a/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
@@ -563,6 +563,7 @@ exports[`AppNavigation matches snapshot 1`] = `
           >
             <div
               className="css-view-1dbjc4n"
+              data-testid="amount_value"
               style={
                 Object {
                   "WebkitAlignItems": "baseline",
@@ -892,6 +893,7 @@ exports[`AppNavigation matches snapshot 1`] = `
           >
             <div
               className="css-view-1dbjc4n"
+              data-testid="claim_button"
               style={
                 Object {
                   "WebkitAlignItems": "center",

--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -13,6 +13,7 @@ import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import { updateAll as updateWalletStatus } from '../../lib/undux/utils/account'
 import { checkAuthStatus as getLoginState } from '../../lib/login/checkAuthStatus'
 import userStorage from '../../lib/gundb/UserStorage'
+import goodWallet from '../../lib/wallet/GoodWallet'
 import Splash from '../splash/Splash'
 import config from '../../config/config'
 
@@ -212,7 +213,6 @@ const AppSwitch = (props: LoadingProps) => {
   useEffect(() => {
     init()
     navigateToUrlAction()
-    setConnectEvents()
     AppState.addEventListener('change', handleAppFocus)
 
     return function() {

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -314,8 +314,6 @@ const Dashboard = props => {
     }
   }
 
-  showOutOfGasError(props)
-
   const handleWithdraw = async params => {
     const { styles }: DashboardProps = props
     const paymentParams = prepareDataWithdraw(params)

--- a/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
@@ -563,6 +563,7 @@ exports[`Dashboard matches snapshot 1`] = `
           >
             <div
               className="css-view-1dbjc4n"
+              data-testid="amount_value"
               style={
                 Object {
                   "WebkitAlignItems": "baseline",
@@ -892,6 +893,7 @@ exports[`Dashboard matches snapshot 1`] = `
           >
             <div
               className="css-view-1dbjc4n"
+              data-testid="claim_button"
               style={
                 Object {
                   "WebkitAlignItems": "center",

--- a/src/components/sidemenu/__tests__/__snapshots__/SideMenuItem.js.snap
+++ b/src/components/sidemenu/__tests__/__snapshots__/SideMenuItem.js.snap
@@ -88,6 +88,7 @@ exports[`SideMenuItem matches snapshot 1`] = `
     >
       <div
         className="css-text-901oao"
+        data-testid="burger_button"
         dir="auto"
         style={
           Object {

--- a/src/components/sidemenu/__tests__/__snapshots__/SideMenuPanel.js.snap
+++ b/src/components/sidemenu/__tests__/__snapshots__/SideMenuPanel.js.snap
@@ -68,6 +68,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
       <div
         className="css-view-1dbjc4n"
         data-focusable={true}
+        data-testid="close_burger_button"
         onKeyDown={[Function]}
         onKeyUp={[Function]}
         onResponderGrant={[Function]}
@@ -224,6 +225,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -328,6 +330,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -432,6 +435,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -536,6 +540,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -640,6 +645,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -744,6 +750,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -848,6 +855,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -952,6 +960,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
+              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -1064,6 +1073,7 @@ exports[`SideMenuPanel matches snapshot 1`] = `
             >
               <div
                 className="css-text-901oao"
+                data-testid="burger_button"
                 dir="auto"
                 style={
                   Object {

--- a/src/components/splash/__tests__/__snapshots__/Splash.js.snap
+++ b/src/components/splash/__tests__/__snapshots__/Splash.js.snap
@@ -228,7 +228,7 @@ exports[`Splash matches snapshot 1`] = `
             }
           }
         >
-          V2
+          Vv0
         </div>
       </div>
     </div>

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -65,6 +65,8 @@ const Config = {
 
 Config.web3SiteUrlEconomyPage = `${Config.web3SiteUrl}${Config.web3SiteUrlEconomyEndpoint}`
 
+global.config = Config
+
 // Forcing value as number, if not MNID encoder/decoder may fail
 // Config.networkId = Config.ethereum[Config.networkId].network_id
 export default Config

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -105,8 +105,6 @@ export class GoodWallet {
 
   config: {}
 
-  accountsContract: Web3.eth.Contract
-
   tokenContract: Web3.eth.Contract
 
   identityContract: Web3.eth.Contract
@@ -606,7 +604,15 @@ export class GoodWallet {
    * @param {PromiEvents} callbacks
    */
   async withdraw(otlCode: string, callbacks: PromiEvents) {
-    const withdrawCall = this.oneTimePaymentsContract.methods.withdraw(otlCode)
+    let method = 'withdraw'
+    let args = [otlCode]
+
+    if (Config.simulateWithdrawReverted) {
+      method = 'setIdentity'
+      args = [this.account, this.account]
+    }
+
+    const withdrawCall = this.oneTimePaymentsContract.methods[method](...args)
     const gasLimit = await this.oneTimePaymentsContract.methods.gasLimit.call().then(toBN)
 
     //contract enforces max gas of 80000 to prevent front running


### PR DESCRIPTION
# Description

Add the possibility to simulate withdraw tx as reverted.
Added simulateWithdrawReverted property to the GoodWalletClass. Added condition for withdrawing fn to check if it is needed to simulate the tx as reverted.

About #955 

# How Has This Been Tested?

Type in console:
window.config.simulateWithdrawReverted = true

Then paste in the browser address line the send link from another account.
The transaction should be reverted and the feed item should be shown as errored.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
