### PR TITLE
(Bug) 966 fix the position of amount and units for claim page

### DIFF
--- a/src/components/common/view/BigNumber.js
+++ b/src/components/common/view/BigNumber.js
@@ -27,22 +27,16 @@ class BigNumber extends React.Component {
       color,
       styles,
       testID,
+      reverse,
     } = this.props
-    return (
-      <View style={[styles.bigNumberWrapper, style]} testID={testID}>
-        <Text
-          fontFamily="slab"
-          fontSize={36}
-          fontWeight="bold"
-          textAlign="right"
-          color={color || 'gray'}
-          {...bigNumberProps}
-          style={[styles.bigNumber, bigNumberStyles]}
-        >
-          {number}
-        </Text>
-        {unit ? (
+
+    const components = []
+
+    if (reverse) {
+      components.push(
+        unit ? (
           <Text
+            key="big_number_unit"
             fontFamily="slab"
             fontSize={18}
             fontWeight="bold"
@@ -55,7 +49,57 @@ class BigNumber extends React.Component {
           </Text>
         ) : (
           children
-        )}
+        ),
+        <Text key="big_number_space"> </Text>,
+        <Text
+          key="big_number_amount"
+          fontFamily="slab"
+          fontSize={36}
+          fontWeight="bold"
+          textAlign="right"
+          color={color || 'gray'}
+          {...bigNumberProps}
+          style={[styles.bigNumber, bigNumberStyles]}
+        >
+          {number}
+        </Text>
+      )
+    } else {
+      components.push(
+        <Text
+          key="big_number_amount"
+          fontFamily="slab"
+          fontSize={36}
+          fontWeight="bold"
+          textAlign="right"
+          color={color || 'gray'}
+          {...bigNumberProps}
+          style={[styles.bigNumber, bigNumberStyles]}
+        >
+          {number}
+        </Text>,
+        unit ? (
+          <Text
+            key="big_number_unit"
+            fontFamily="slab"
+            fontSize={18}
+            fontWeight="bold"
+            textAlign="right"
+            color={color || 'gray'}
+            {...bigNumberUnitProps}
+            style={bigNumberUnitStyles}
+          >
+            {unit}
+          </Text>
+        ) : (
+          children
+        )
+      )
+    }
+
+    return (
+      <View style={[styles.bigNumberWrapper, style]} testID={testID}>
+        {components}
       </View>
     )
   }

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -210,6 +210,7 @@ const Claim = props => {
             <Section.Text style={styles.mainTextBigMarginBottom}>
               <BigGoodDollar
                 number={1}
+                reverse
                 formatter={number => number}
                 bigNumberProps={{ color: 'surface' }}
                 bigNumberUnitProps={{ color: 'surface', fontSize: 20 }}

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -201,26 +201,6 @@ exports[`Claim matches snapshot 1`] = `
                 dir="auto"
                 style={
                   Object {
-                    "color": "rgba(255,255,255,1.00)",
-                    "direction": "ltr",
-                    "fontFamily": "Roboto Slab",
-                    "fontSize": "36px",
-                    "fontWeight": "700",
-                    "lineHeight": "30px",
-                    "marginRight": "2px",
-                    "textAlign": "right",
-                    "textDecoration": "none",
-                    "textTransform": "none",
-                  }
-                }
-              >
-                1
-              </span>
-              <span
-                className="css-text-901oao css-textHasAncestor-16my406"
-                dir="auto"
-                style={
-                  Object {
                     "color": "rgba(66,69,74,1.00)",
                     "direction": "ltr",
                     "fontFamily": "Roboto",
@@ -271,6 +251,45 @@ exports[`Claim matches snapshot 1`] = `
                 >
                   $
                 </span>
+              </span>
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(66,69,74,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto",
+                    "fontSize": "16px",
+                    "fontWeight": "normal",
+                    "lineHeight": "22px",
+                    "textAlign": "center",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                 
+              </span>
+              <span
+                className="css-text-901oao css-textHasAncestor-16my406"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(255,255,255,1.00)",
+                    "direction": "ltr",
+                    "fontFamily": "Roboto Slab",
+                    "fontSize": "36px",
+                    "fontWeight": "700",
+                    "lineHeight": "30px",
+                    "marginRight": "2px",
+                    "textAlign": "right",
+                    "textDecoration": "none",
+                    "textTransform": "none",
+                  }
+                }
+              >
+                1
               </span>
             </div>
             <span


### PR DESCRIPTION
# Description

Add the reverse property for BigNumber component to have a possibility showing the units before amount without breaking the positioning in other places where the BigNumber component used.

About #966 

# How Has This Been Tested?

Open the claim page
See the changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot: 
<img width="473" alt="1" src="https://user-images.githubusercontent.com/49862004/70432608-5a3c5800-1a88-11ea-8b1f-9e855c74f99d.png">
