### PR TITLE
(Bug) #1031 claim counter title lette spacing should be 0.08px

### DIFF
--- a/src/components/dashboard/ClaimButton.js
+++ b/src/components/dashboard/ClaimButton.js
@@ -110,6 +110,7 @@ const getStylesFromProps = ({ theme }) => ({
   },
   extraInfoCountdownTitle: {
     marginBottom: theme.sizes.default,
+    letterSpacing: 0.08,
   },
   amountInButton: {
     display: 'inline',

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -626,6 +626,7 @@ exports[`Claim matches snapshot 1`] = `
                           "fontFamily": "Roboto",
                           "fontSize": "16px",
                           "fontWeight": "700",
+                          "letterSpacing": "0.08px",
                           "lineHeight": "22px",
                           "marginBottom": "8px",
                           "textAlign": "center",

--- a/src/components/dashboard/__tests__/__snapshots__/ClaimButton.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/ClaimButton.js.snap
@@ -457,6 +457,7 @@ exports[`ClaimButton matches snapshot for citizen without entitlement 1`] = `
                     "fontFamily": "Roboto",
                     "fontSize": "16px",
                     "fontWeight": "700",
+                    "letterSpacing": "0.08px",
                     "lineHeight": "22px",
                     "marginBottom": "8px",
                     "textAlign": "center",


### PR DESCRIPTION
# Description

Set the letter spacing 0.08px for the Claim counter title.

About #1031 

# How Has This Been Tested?

Open the claim page.
See the claim counter title text. You can inspect the element and see its letter-spacing CSS property.

If some G4 available to claim for you - do the claim.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Screenshot:
<img width="474" alt="2" src="https://user-images.githubusercontent.com/49862004/70533430-baeb9380-1b61-11ea-8ba1-0e2509573f60.png">
