### PR TITLE
wire is undefined in gundb connection test

### DIFF
--- a/src/lib/hooks/hasConnectionChange.js
+++ b/src/lib/hooks/hasConnectionChange.js
@@ -87,9 +87,9 @@ export const useConnectionGun = () => {
       }
 
       const instanceGun = userStorage.gun._
-      const wire = instanceGun.opt.peers[Config.gunPublicUrl].wire
-      log.debug('gun wirestate:', wire)
-      if (wire.readyState === wire.OPEN) {
+      const connection = instanceGun.opt.peers[Config.gunPublicUrl]
+      log.debug('gun connection:', connection)
+      if (connection) {
         setIsConnection(true)
         bindEvents()
       } else {

--- a/src/lib/hooks/hasConnectionChange.js
+++ b/src/lib/hooks/hasConnectionChange.js
@@ -89,7 +89,7 @@ export const useConnectionGun = () => {
       const instanceGun = userStorage.gun._
       const connection = instanceGun.opt.peers[Config.gunPublicUrl]
       log.debug('gun connection:', connection)
-      if (connection) {
+      if (connection && connection.wire && connection.wire.readyState === connection.wire.OPEN) {
         setIsConnection(true)
         bindEvents()
       } else {


### PR DESCRIPTION
# Description

refactor: changed logic check status connection with GUN, don't uses "wire" params

About #1066 

# How Has This Been Tested?

Run app, and disconnect gun

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
