### PR TITLE
(Feature) #1081 verify user has small avatar image

### DIFF
--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -9,7 +9,6 @@ import { extractQueryParams } from './lib/share/index'
 import logger from './lib/logger/pino-logger'
 import { fireEvent, initAnalytics, SIGNIN_FAILED, SIGNIN_SUCCESS } from './lib/analytics/analytics'
 import Config from './config/config'
-import resizeBase64Image from './lib/utils/resizeBase64Image'
 
 const log = logger.child({ from: 'RouterSelector' })
 log.debug({ Config })
@@ -22,24 +21,6 @@ let SignupRouter = React.lazy(() =>
     )
     .then(r => r[0])
 )
-
-/**
- * Set small avatar for user in case he doesn't have it
- *
- * @returns {Promise}
- */
-const checkSmallAvatar = async userStorage => {
-  const avatar = await userStorage.getProfileFieldValue('avatar')
-  const smallAvatar = await userStorage.getProfileFieldValue('smallAvatar')
-
-  if (avatar && !smallAvatar) {
-    log.debug('Updating small avatar')
-
-    const smallAvatar = await resizeBase64Image(avatar, 50)
-
-    await userStorage.setProfileField('smallAvatar', smallAvatar, 'public')
-  }
-}
 
 /**
  * handle in-app links for unsigned users such as magiclink and paymentlinks
@@ -97,10 +78,7 @@ const handleLinks = async () => {
 let AppRouter = React.lazy(() => {
   log.debug('initializing storage and wallet...')
   let walletAndStorageReady = import(/* webpackChunkName: "init" */ './init')
-  let p2 = walletAndStorageReady
-    .then(({ init, _ }) => init())
-    .then(d => checkSmallAvatar(d.userStorage))
-    .then(_ => log.debug('storage and wallet ready'))
+  let p2 = walletAndStorageReady.then(({ init, _ }) => init()).then(_ => log.debug('storage and wallet ready'))
 
   return Promise.all([import(/* webpackChunkName: "router" */ './Router'), p2])
     .then(r => {

--- a/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
@@ -282,6 +282,7 @@ exports[`AppNavigation matches snapshot 1`] = `
         >
           <div
             className="css-text-901oao"
+            data-testid="burger_button"
             dir="auto"
             style={
               Object {

--- a/src/components/appNavigation/__tests__/__snapshots__/TabsView.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/TabsView.js.snap
@@ -161,6 +161,7 @@ exports[`TabsView matches snapshot 1`] = `
     >
       <div
         className="css-text-901oao"
+        data-testid="burger_button"
         dir="auto"
         style={
           Object {

--- a/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
@@ -282,6 +282,7 @@ exports[`Dashboard matches snapshot 1`] = `
         >
           <div
             className="css-text-901oao"
+            data-testid="burger_button"
             dir="auto"
             style={
               Object {

--- a/src/components/sidemenu/__tests__/__snapshots__/SideMenuItem.js.snap
+++ b/src/components/sidemenu/__tests__/__snapshots__/SideMenuItem.js.snap
@@ -88,7 +88,6 @@ exports[`SideMenuItem matches snapshot 1`] = `
     >
       <div
         className="css-text-901oao"
-        data-testid="burger_button"
         dir="auto"
         style={
           Object {

--- a/src/components/sidemenu/__tests__/__snapshots__/SideMenuPanel.js.snap
+++ b/src/components/sidemenu/__tests__/__snapshots__/SideMenuPanel.js.snap
@@ -225,7 +225,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -330,7 +329,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -435,7 +433,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -540,7 +537,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -645,7 +641,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -750,7 +745,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -855,7 +849,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -960,7 +953,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
           >
             <div
               className="css-text-901oao"
-              data-testid="burger_button"
               dir="auto"
               style={
                 Object {
@@ -1073,7 +1065,6 @@ exports[`SideMenuPanel matches snapshot 1`] = `
             >
               <div
                 className="css-text-901oao"
-                data-testid="burger_button"
                 dir="auto"
                 style={
                   Object {

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -558,8 +558,11 @@ export class UserStorage {
         .get('users')
         .get(this.gunuser.is.pub)
         .put(this.gunuser)
+
       logger.debug('GunDB logged in', { username, pubkey: this.wallet.account })
       logger.debug('subscribing')
+
+      this.checkSmallAvatar()
 
       this.wallet.subscribeToEvent(EVENT_TYPE_RECEIVE, event => {
         logger.debug({ event }, EVENT_TYPE_RECEIVE)
@@ -572,6 +575,24 @@ export class UserStorage {
       this.wallet.subscribeToEvent('receiptReceived', receipt => this.handleReceiptUpdated(receipt))
       res(true)
     })
+  }
+
+  /**
+   * Set small avatar for user in case he doesn't have it
+   *
+   * @returns {Promise}
+   */
+  async checkSmallAvatar() {
+    const avatar = await this.getProfileFieldValue('avatar')
+    const smallAvatar = await this.getProfileFieldValue('smallAvatar')
+
+    if (avatar && !smallAvatar) {
+      logger.debug('Updating small avatar')
+
+      const smallAvatar = await resizeBase64Image(avatar, 50)
+
+      await this.setProfileField('smallAvatar', smallAvatar, 'public')
+    }
   }
 
   setAvatar(avatar) {


### PR DESCRIPTION
# Description

Add method which chacking if a user has small avatar at the app loading. If not then creating and setting it to the user profile.

About #1081 

# How Has This Been Tested?

Register/login to the app.
Set an avatar for your wallet.
In console paste this code: userStorage.setProfileField('smallAvatar', null, 'public')
Then check if small avatar deleted by pasting this code in the console:
await userStorage.getProfileFieldValue('smallAvatar')
The result should appear: null.
Then refresh the page.
Try to get the small avatar again:
await userStorage.getProfileFieldValue('smallAvatar')
There should be a base64 string.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
