### PR TITLE
(Bug) #1080 receive payment card is in orange and should be green

### DIFF
--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -1538,7 +1538,7 @@ export class UserStorage {
     return data
   }
 
-  _extractWithdrawStatus(withdrawCode, otplStatus = 'pending', status) {
+  _extractWithdrawStatus(withdrawCode, otplStatus = '', status) {
     return status === 'error' ? status : withdrawCode ? otplStatus : ''
   }
 


### PR DESCRIPTION
# Description

Remove default otplStatus value which cause the success withdraw to display in yellow color

About #1080 

# How Has This Been Tested?

Send some G$ and see the receive feed card color.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
