### PR TITLE
(Bug) #1091 start claiming feed card is added multiple times

### DIFF
--- a/src/lib/gundb/UserPropertiesClass.js
+++ b/src/lib/gundb/UserPropertiesClass.js
@@ -12,6 +12,8 @@ export default class UserProperties {
    */
   static defaultProperties = {
     isMadeBackup: false,
+    startClaimingFeedCardAdded: false,
+    hanukaBonusFeedCardAdded: false,
     firstVisitApp: null,
     etoroAddCardSpending: true,
     isAddedToHomeScreen: false,
@@ -21,6 +23,8 @@ export default class UserProperties {
 
   fields = [
     'isMadeBackup',
+    'startClaimingFeedCardAdded',
+    'hanukaBonusFeedCardAdded',
     'firstVisitApp',
     'etoroAddCardSpending',
     'isAddedToHomeScreen',

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -823,8 +823,8 @@ export class UserStorage {
     const firstVisitAppDate = userProperties.firstVisitApp
     const isCameFromW3Site = userProperties.cameFromW3Site
 
-    this.addBackupCard()
-    this.addStartClaimingCard()
+    await this.addBackupCard()
+    await this.addStartClaimingCard()
 
     // first time user visit
     if (firstVisitAppDate == null) {
@@ -847,7 +847,7 @@ export class UserStorage {
       await this.userProperties.set('firstVisitApp', Date.now())
     }
 
-    this.addHanukaBonusStartsCard()
+    await this.addHanukaBonusStartsCard()
   }
 
   /**
@@ -891,8 +891,9 @@ export class UserStorage {
     const displayTimeFilter = Config.displayStartClaimingCardTime
     const allowToShowByTimeFilter = firstVisitAppDate && Date.now() - firstVisitAppDate >= displayTimeFilter
 
-    if (allowToShowByTimeFilter) {
+    if (!userProperties.startClaimingFeedCardAdded && allowToShowByTimeFilter) {
       await this.enqueueTX(startClaiming)
+      await this.userProperties.set('startClaimingFeedCardAdded', true)
     }
   }
 
@@ -902,16 +903,18 @@ export class UserStorage {
    * @returns {Promise<void>}
    */
   async addHanukaBonusStartsCard() {
+    const userProperties = await this.userProperties.getAll()
     const now = moment().utcOffset('+0200')
     const startHanuka = moment(Config.hanukaStartDate, 'DD/MM/YYYY').utcOffset('+0200')
     const endHanuka = moment(Config.hanukaEndDate, 'DD/MM/YYYY')
       .endOf('day')
       .utcOffset('+0200')
 
-    if (startHanuka.isBefore(now) && now.isBefore(endHanuka)) {
+    if (!userProperties.hanukaBonusFeedCardAdded && startHanuka.isBefore(now) && now.isBefore(endHanuka)) {
       hanukaBonusStartsMessage.id = `hanuka-${now.format('YYYY')}`
 
       await this.enqueueTX(hanukaBonusStartsMessage)
+      await this.userProperties.set('hanukaBonusFeedCardAdded', true)
     }
   }
 


### PR DESCRIPTION
# Description

Make the enqueueTx return true if an error occurred while trying to verify existed feed event if called from startSystemFeed. Add userProperties flags to the system feeds.

About #1091 

# How Has This Been Tested?

There should not be feed card duplicates.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
