### PR TITLE
(Bug) #1038 The popup error message is displayed after loading the photo

### DIFF
--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -590,20 +590,17 @@ export class UserStorage {
     if (avatar && !smallAvatar) {
       logger.debug('Updating small avatar')
 
-      const smallAvatar = await resizeBase64Image(avatar, 50)
-
-      await this.setProfileField('smallAvatar', smallAvatar, 'public')
+      await this.setSmallAvatar(avatar)
     }
   }
 
   setAvatar(avatar) {
-    return Promise.all([
-      this.setProfileField('avatar', avatar, 'public'),
-      async () => {
-        const smallAvatar = await resizeBase64Image(avatar, 50)
-        return this.setProfileField('smallAvatar', smallAvatar, 'public')
-      },
-    ])
+    return Promise.all([this.setProfileField('avatar', avatar, 'public'), this.setSmallAvatar(avatar)])
+  }
+
+  async setSmallAvatar(avatar) {
+    const smallAvatar = await resizeBase64Image(avatar, 50)
+    return this.setProfileField('smallAvatar', smallAvatar, 'public')
   }
 
   removeAvatar() {


### PR DESCRIPTION
# Description

Create a separate function to save small avatar into user storage.

About #1038 

# How Has This Been Tested?

There was an issue with a small avatar - it was not being saved together with main avatar.

Open the edit profile page.
Delete avatar if existed
Upload a new avatar.
The small avatar should be saved to userStorage.
To check if small avatar saved - use this command in the console:
await userStorage.getProfileFieldValue('smallAvatar')

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
