### PR TITLE
[React Native] Fix eslint error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
     "prettier/react"
   ],
   "plugins": [
-    "dependencies",
+    // FIXME "Error: Failed to load plugin 'dependencies' declared in '.eslintrc': Cannot find module './util/traverser'"
+    // "dependencies",
     "flowtype",
     "import",
     "prettier",


### PR DESCRIPTION
# Description

Fixing eslint error, could be caused by a version mismatch. commenting out dependencies plugin for now.