### PR TITLE
React Native Endless state update fix

### DIFF
--- a/src/components/appNavigation/stackNavigation.js
+++ b/src/components/appNavigation/stackNavigation.js
@@ -1,7 +1,8 @@
 // @flow
 import React, { Component, useEffect, useState } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
-import SideMenu from 'react-native-side-menu-gooddapp'
+// TODO SideMenu needs to be fixed first
+// import SideMenu from 'react-native-side-menu-gooddapp'
 import { createNavigator, Route, SceneView, SwitchRouter } from '@react-navigation/core'
 import { withStyles } from '../../lib/styles'
 import SimpleStore from '../../lib/undux/SimpleStore'
@@ -251,15 +252,16 @@ class AppView extends Component<AppViewProps, AppViewState> {
 
     return (
       <React.Fragment>
-        <View style={[styles.sideMenuContainer, open ? styles.menuOpenStyle : styles.hideMenu]}>
-          <SideMenu
-            menu={menu}
-            menuPosition="right"
-            isOpen={open}
-            disableGestures={true}
-            onChange={this.sideMenuSwap}
-          />
-        </View>
+        {/* TODO SideMenu needs to be fixed first */}
+        {/*<View style={[styles.sideMenuContainer, open ? styles.menuOpenStyle : styles.hideMenu]}>*/}
+        {/*  <SideMenu*/}
+        {/*    menu={menu}*/}
+        {/*    menuPosition="right"*/}
+        {/*    isOpen={open}*/}
+        {/*    disableGestures={true}*/}
+        {/*    onChange={this.sideMenuSwap}*/}
+        {/*  />*/}
+        {/*</View>*/}
         {/*<Blurred style={fullScreenContainer} blur={open || dialogVisible || currentFeed}>*/}
         {!navigationBarHidden &&
           (NavigationBar ? (

--- a/src/lib/hooks/hasConnectionChange.js
+++ b/src/lib/hooks/hasConnectionChange.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { AppState, Platform } from 'react-native'
 import Config from '../../config/config'
 import API from '../API/api'

--- a/src/lib/undux/utils/dialog.js
+++ b/src/lib/undux/utils/dialog.js
@@ -56,12 +56,16 @@ export const showDialogWithData = (store: Store, dialogData: DialogProps) => {
 export const hideDialog = (store: Store) => {
   log.debug('hideDialog')
 
-  store.set('currentScreen')({
-    ...store.get('currentScreen'),
-    dialogData: {
-      visible: false,
-    },
-  })
+  const currentScreen = store.get('currentScreen') || {}
+
+  if (currentScreen.dialogData && currentScreen.dialogData.visible) {
+    store.set('currentScreen')({
+      ...store.get('currentScreen'),
+      dialogData: {
+        visible: false,
+      },
+    })
+  }
 }
 
 export const useDialog = () => {


### PR DESCRIPTION
# Description

Only updating the dialog state if needed.
![Screen Shot 2020-01-08 at 09 42 49](https://user-images.githubusercontent.com/2942206/71979089-9f74b680-31fb-11ea-8404-5aa1c2636efb.png)

Also commenting out the sidemenu