### PR TITLE
User should be able to retry signup on error #935

### DIFF
--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -118,7 +118,8 @@ class API {
    * @param {UserRecord} user
    */
   addUser(user: UserRecord): AxiosPromise<any> {
-    return this.client.post('/user/add', { user })
+    //-skipRegistrationStep ONLY FOR TESTING  delete this condition aftere testing
+    return this.client.post('/user/add', { user, skipRegistrationStep: global.skipRegistrationStep })
   }
 
   /**


### PR DESCRIPTION
# Description

User should be able to retry signup on error

**Only in conjunction with server changes https://github.com/GoodDollar/GoodServer/pull/141**

### **(This PR is only testing this task)**

About #935 

# How Has This Been Tested?

when registering, at the step of entering the email you should enter
window.skipRegistrationStep = (1-6)
in the console. This will stop user registration at the step you entered.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
