### PR TITLE
(Bug) #1096 iphone safari always show add to home screen

### DIFF
--- a/src/components/common/view/AddWebApp.web.js
+++ b/src/components/common/view/AddWebApp.web.js
@@ -170,6 +170,10 @@ const AddWebApp = props => {
 
     showDialog({
       content: <InitialDialog showDesc={!isReminder} />,
+      onDismiss: () => {
+        fireEvent(ADDTOHOME_LATER, { skipCount })
+        handleLater()
+      },
       buttons: [
         {
           text: 'Later',


### PR DESCRIPTION
# Description

Make the x button do the same as later button on add web app popup.

About #1096 

# How Has This Been Tested?

Open the app (Dashboard) for the first time (with a new account) and try to close the add web app popup with the x button.
Then reload the page - the popup shouldnt be shown again.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
