### PR TITLE
(Bug) #1164 prepareLoginToken failed

### DIFF
--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -165,7 +165,9 @@ const AppSwitch = (props: LoadingProps) => {
 
         const _loginToken = _get(response, 'data.loginToken')
 
-        await userStorage.setProfileField('loginToken', _loginToken, 'private')
+        if (_loginToken) {
+          await userStorage.setProfileField('loginToken', _loginToken, 'private')
+        }
       } catch (e) {
         log.error('prepareLoginToken failed', e.message, e)
       }


### PR DESCRIPTION
# Description

Add a condition to prevent error occurring while trying to set the empty token value to the gun.

Link to the GoodServer PR - https://github.com/GoodDollar/GoodServer/pull/143

About #1164 

# How Has This Been Tested?

You need to create a new account. But before see and do the manual described in the same section in GoodServer PR.
You need to look at the login token request - error should not be logged in to the console.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
