### PR TITLE
(Chore) #1306 Feed cards: sum number font size should be 20pt and not 16pt

### DIFF
--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -55,7 +55,7 @@ const ListEvent = ({ item: feed, theme, styles }: FeedEventProps) => {
               <BigGoodDollar
                 number={feed.data.amount}
                 color={mainColor}
-                bigNumberProps={{ fontSize: 15, lineHeight: 18 }}
+                bigNumberProps={{ fontSize: 20, lineHeight: 18 }}
                 bigNumberStyles={styles.bigNumberStyles}
                 bigNumberUnitProps={{ fontSize: 10, lineHeight: 11 }}
                 bigNumberUnitStyles={styles.bigNumberUnitStyles}
@@ -210,7 +210,7 @@ const getStylesFromProps = ({ theme }) => ({
     flexDirection: 'row',
     flexShrink: 1,
     justifyContent: 'space-between',
-    paddingBottom: theme.sizes.default - 2,
+    paddingBottom: 5,
   },
   actionSymbol: {
     marginLeft: 'auto',


### PR DESCRIPTION
# Description

Make the feed card amount font size 20

About #1306 

# How Has This Been Tested?

Open dashboard.
You need to have some feed card with amount included and see the amount text size.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots

| Browser | Simulators |
| --- | --- |
| <img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/74239255-2677eb80-4ce0-11ea-9295-09d2906219e0.png"> | ![2](https://user-images.githubusercontent.com/49862004/74239271-31328080-4ce0-11ea-867c-a43463790dc0.png) |

