### PR TITLE
Fix CustomButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "browserify-zlib": "^0.1.4",
     "buffer": "^5.4.3",
     "canvas-prebuilt": "^2.0.0-alpha.14",
+    "color": "^3.1.2",
     "customize-cra": "^0.9.1",
     "dns.js": "^1.0.1",
     "ethereumjs-util": "^6.1.0",

--- a/src/components/common/buttons/BaseButton.js
+++ b/src/components/common/buttons/BaseButton.js
@@ -1,0 +1,218 @@
+// @flow
+
+/* This component is based on the react-native-paper's Button component and gracefully handles Views as children */
+
+import React from 'react'
+import { Animated, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, Colors, Surface, Text, TouchableRipple, withTheme } from 'react-native-paper'
+import Icon from 'react-native-paper/lib/module/components/Icon'
+import color from 'color'
+
+const { black, white } = Colors
+
+class Button extends React.Component<Props, State> {
+  static defaultProps = {
+    mode: 'text',
+    uppercase: true,
+  }
+
+  state = {
+    elevation: new Animated.Value(this.props.mode === 'contained' ? 2 : 0),
+  }
+
+  handlePressIn = () => {
+    if (this.props.mode === 'contained') {
+      const { scale } = this.props.theme.animation
+      Animated.timing(this.state.elevation, {
+        toValue: 8,
+        duration: 200 * scale,
+      }).start()
+    }
+  }
+
+  handlePressOut = () => {
+    if (this.props.mode === 'contained') {
+      const { scale } = this.props.theme.animation
+      Animated.timing(this.state.elevation, {
+        toValue: 2,
+        duration: 150 * scale,
+      }).start()
+    }
+  }
+
+  render() {
+    const {
+      disabled,
+      compact,
+      mode,
+      dark,
+      loading,
+      icon,
+      color: buttonColor,
+      children,
+      uppercase,
+      accessibilityLabel,
+      onPress,
+      style,
+      theme,
+      contentStyle,
+      labelStyle,
+      ...rest
+    } = this.props
+    const { colors, roundness } = theme
+    const font = theme.fonts.medium
+
+    let backgroundColor, borderColor, textColor, borderWidth
+
+    if (mode === 'contained') {
+      if (disabled) {
+        backgroundColor = color(theme.dark ? white : black)
+          .alpha(0.12)
+          .rgb()
+          .string()
+      } else if (buttonColor) {
+        backgroundColor = buttonColor
+      } else {
+        backgroundColor = colors.primary
+      }
+    } else {
+      backgroundColor = 'transparent'
+    }
+
+    if (mode === 'outlined') {
+      borderColor = color(theme.dark ? white : black)
+        .alpha(0.29)
+        .rgb()
+        .string()
+      borderWidth = StyleSheet.hairlineWidth
+    } else {
+      borderColor = 'transparent'
+      borderWidth = 0
+    }
+
+    if (disabled) {
+      textColor = color(theme.dark ? white : black)
+        .alpha(0.32)
+        .rgb()
+        .string()
+    } else if (mode === 'contained') {
+      let isDark
+
+      if (typeof dark === 'boolean') {
+        isDark = dark
+      } else {
+        isDark = backgroundColor === 'transparent' ? false : !color(backgroundColor).isLight()
+      }
+
+      textColor = isDark ? white : black
+    } else if (buttonColor) {
+      textColor = buttonColor
+    } else {
+      textColor = colors.primary
+    }
+
+    const rippleColor = color(textColor)
+      .alpha(0.32)
+      .rgb()
+      .string()
+    const buttonStyle = {
+      backgroundColor,
+      borderColor,
+      borderWidth,
+      borderRadius: roundness,
+    }
+    const touchableStyle = {
+      borderRadius: style ? StyleSheet.flatten(style).borderRadius || roundness : roundness,
+    }
+    const textStyle = { color: textColor, ...font }
+    const elevation = disabled || mode !== 'contained' ? 0 : this.state.elevation
+
+    const isChildrenString = typeof children === 'string'
+    const fullSizeStyle = { flex: 1, alignSelf: 'stretch' }
+    const extraStyle = isChildrenString ? null : fullSizeStyle
+
+    return (
+      <Surface {...rest} style={[styles.button, compact && styles.compact, { elevation }, buttonStyle, style]}>
+        <TouchableRipple
+          borderless
+          delayPressIn={0}
+          onPress={onPress}
+          onPressIn={this.handlePressIn}
+          onPressOut={this.handlePressOut}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityStates={disabled ? ['disabled'] : []}
+          disabled={disabled}
+          rippleColor={rippleColor}
+          style={[touchableStyle, extraStyle]}
+        >
+          <View style={[styles.content, contentStyle, extraStyle]}>
+            {icon && loading !== true ? (
+              <View style={styles.icon}>
+                <Icon source={icon} size={16} color={textColor} />
+              </View>
+            ) : null}
+            {loading ? <ActivityIndicator size={16} color={textColor} style={styles.icon} /> : null}
+            {isChildrenString ? (
+              <Text
+                numberOfLines={1}
+                style={[
+                  styles.label,
+                  compact && styles.compactLabel,
+                  uppercase && styles.uppercaseLabel,
+                  textStyle,
+                  font,
+                  labelStyle,
+                ]}
+              >
+                {children}
+              </Text>
+            ) : (
+              <View style={[styles.viewLabel, compact && styles.compactLabel]}>{children}</View>
+            )}
+          </View>
+        </TouchableRipple>
+      </Surface>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  button: {
+    minWidth: 64,
+    borderStyle: 'solid',
+  },
+  compact: {
+    minWidth: 'auto',
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    width: 16,
+    marginLeft: 12,
+    marginRight: -4,
+  },
+  label: {
+    textAlign: 'center',
+    letterSpacing: 1,
+    marginVertical: 9,
+    marginHorizontal: 16,
+  },
+  compactLabel: {
+    marginHorizontal: 8,
+  },
+  uppercaseLabel: {
+    textTransform: 'uppercase',
+  },
+  viewLabel: {
+    marginVertical: 9,
+    marginHorizontal: 16,
+  },
+})
+
+export default withTheme(Button)

--- a/src/components/common/buttons/CustomButton.js
+++ b/src/components/common/buttons/CustomButton.js
@@ -122,6 +122,7 @@ const IconButton = ({ theme, dark, icon, size, style }: IconButtonProps) => {
  * @param {boolean} [props.loading]
  * @param {string} [props.color=#555555]
  * @param {boolean} [props.dark]
+ * @param {string} [props.testID]
  * @param {boolean} [props.uppercase=true]
  * @param {string|(string => React.Node} [props.icon=edit)]
  * @param {string} [props.iconAlignment=right]
@@ -136,6 +137,7 @@ const CustomButton = (props: ButtonProps) => {
     mode,
     style,
     children,
+    testID,
     icon,
     iconAlignment,
     iconSize,
@@ -152,6 +154,7 @@ const CustomButton = (props: ButtonProps) => {
   return (
     <BaseButton
       dark={dark}
+      testID={testID}
       mode={mode}
       contentStyle={styles.contentStyle}
       theme={{ ...theme, roundness: 50 }}

--- a/src/components/common/buttons/CustomButton.js
+++ b/src/components/common/buttons/CustomButton.js
@@ -1,9 +1,11 @@
 // @flow
 import React from 'react'
-import { /*ActivityIndicator,*/ Button as BaseButton, DefaultTheme } from 'react-native-paper'
+import { View } from 'react-native'
+import { ActivityIndicator, DefaultTheme } from 'react-native-paper'
 import { withStyles } from '../../../lib/styles'
 import Icon from '../view/Icon'
 import Text from '../view/Text'
+import BaseButton from './BaseButton'
 
 type IconFunction = (string, number) => React.Node
 
@@ -60,8 +62,10 @@ const mapPropsToStyles = ({ theme, compact }) => ({
     letterSpacing: 0,
   },
   contentWrapper: {
-    width: 100,
-    height: 100,
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'row',
+    flex: 1,
   },
   activityIndicator: {
     marginRight: compact ? theme.sizes.defaultHalf : theme.sizes.default,
@@ -118,7 +122,6 @@ const IconButton = ({ theme, dark, icon, size, style }: IconButtonProps) => {
  * @param {boolean} [props.loading]
  * @param {string} [props.color=#555555]
  * @param {boolean} [props.dark]
- * @param {string} [props.testID]
  * @param {boolean} [props.uppercase=true]
  * @param {string|(string => React.Node} [props.icon=edit)]
  * @param {string} [props.iconAlignment=right]
@@ -133,7 +136,6 @@ const CustomButton = (props: ButtonProps) => {
     mode,
     style,
     children,
-    testID,
     icon,
     iconAlignment,
     iconSize,
@@ -147,11 +149,9 @@ const CustomButton = (props: ButtonProps) => {
   const dark = mode === 'contained'
   const uppercase = mode !== 'text'
   const color = props.color ? props.color : theme.colors.default
-
   return (
     <BaseButton
       dark={dark}
-      testID={testID}
       mode={mode}
       contentStyle={styles.contentStyle}
       theme={{ ...theme, roundness: 50 }}
@@ -159,37 +159,39 @@ const CustomButton = (props: ButtonProps) => {
       disabled={disabled || loading}
       {...buttonProps}
       color={color}
-      loading={
-        //eslint-disable-next-line
-        //FIXME: RN temporary show loading instead of not working activityindicator
-        loading
-      }
       style={[styles.buttonStyle, style]}
     >
-      {/*<View style={styles.contentWrapper}>*/}
-      {icon && (!iconAlignment || iconAlignment === 'left') && (
-        <IconButton icon={icon} theme={theme} dark={dark} size={iconSize || 14} style={iconStyle || styles.leftIcon} />
-      )}
-      {
-        //eslint-disable-next-line
-        //FIXME: RN doesnt work in android, first needs width and height otherwise throws an exception, but doesnt render at all
-        //even if given width+height, needs to make custom button baded on view+touchable??
-        /* {loading && (
+      <View style={styles.contentWrapper}>
+        {icon && (!iconAlignment || iconAlignment === 'left') && (
+          <IconButton
+            icon={icon}
+            theme={theme}
+            dark={dark}
+            size={iconSize || 14}
+            style={iconStyle || styles.leftIcon}
+          />
+        )}
+        {loading && (
           <ActivityIndicator
             style={styles.activityIndicator}
             animating={loading}
             color={dark ? theme.colors.surface : color}
             size={23}
           />
-        )} */
-      }
-      <TextContent dark={dark} uppercase={uppercase} textStyle={textStyle} color={buttonProps.color}>
-        {children}
-      </TextContent>
-      {icon && iconAlignment === 'right' && (
-        <IconButton icon={icon} theme={theme} dark={dark} size={iconSize || 14} style={iconStyle || styles.rightIcon} />
-      )}
-      {/*</View>*/}
+        )}
+        <TextContent dark={dark} uppercase={uppercase} textStyle={textStyle} color={buttonProps.color}>
+          {children}
+        </TextContent>
+        {icon && iconAlignment === 'right' && (
+          <IconButton
+            icon={icon}
+            theme={theme}
+            dark={dark}
+            size={iconSize || 14}
+            style={iconStyle || styles.rightIcon}
+          />
+        )}
+      </View>
     </BaseButton>
   )
 }


### PR DESCRIPTION
# Description

Current CustomButton doesn't support views as children because of the implementation of react-native-paper's Button component.
Made a component based on react-native-paper's Button that supports views as children.

About #1243

# How Has This Been Tested?
![Screen Shot 2020-02-20 at 21 45 00](https://user-images.githubusercontent.com/2942206/75083988-c3fec680-54fb-11ea-84d6-6a5ced59ec08.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-20 at 21 17 49](https://user-images.githubusercontent.com/2942206/75083989-c6f9b700-54fb-11ea-8464-2026564f3c74.png)
![Screenshot_1582745503](https://user-images.githubusercontent.com/2942206/75381622-d2603000-58b7-11ea-883f-cd46012ee540.png)
![Screenshot_1582746413](https://user-images.githubusercontent.com/2942206/75381627-d4c28a00-58b7-11ea-8d3e-55df1dce7e4d.png)