### PR TITLE
React native claim page

### DIFF
--- a/src/components/common/view/BigGoodDollar.js
+++ b/src/components/common/view/BigGoodDollar.js
@@ -22,7 +22,7 @@ const BigGoodDollar = ({ number, formatter, testID, ...props }: Props) => {
 
   return (
     <BigNumber number={number} {...props} testID={testID}>
-      {props.unit ? null : <GDUnits {...props} />}
+      {!props.unit && <GDUnits {...props} />}
     </BigNumber>
   )
 }

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -313,13 +313,14 @@ const getStylesFromProps = ({ theme }) => {
       paddingVertical: 0,
       paddingHorizontal: 0,
       justifyContent: 'space-between',
+      height: '100%',
     },
     mainText: {
+      flex: 1,
       alignItems: 'center',
       flexDirection: 'column',
       marginVertical: 'auto',
       zIndex: 1,
-      height: '40%',
       justifyContent: 'center',
     },
     mainTextTitle: {

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -274,7 +274,7 @@ const Claim = props => {
             </View>
           </Section.Row>
         </Section.Stack>
-        <Section.Stack style={[styles.extraInfo, Platform.OS !== 'web' && styles.mobileCenterContent]}>
+        <Section.Stack style={styles.extraInfo}>
           <Image source={illustration} style={[styles.illustration, illustrationSizes]} resizeMode="contain" />
           {!isCitizen && (
             <ClaimButton
@@ -396,10 +396,6 @@ const getStylesFromProps = ({ theme }) => {
       paddingVertical: theme.sizes.defaultDouble,
       paddingHorizontal: theme.sizes.default,
       marginTop: getDesignRelativeHeight(85),
-    },
-    mobileCenterContent: {
-      justifyContent: 'center',
-      alignItems: 'center',
     },
     extraInfoStats: {
       marginHorizontal: 0,

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -24,7 +24,8 @@ import { CLAIM_FAILED, CLAIM_SUCCESS, fireEvent } from '../../lib/analytics/anal
 import Config from '../../config/config'
 import type { DashboardProps } from './Dashboard'
 import ClaimButton from './ClaimButton'
-import { getMaxDeviceHeight } from '../../lib/utils/Orientation'
+
+// import { getMaxDeviceHeight } from '../../lib/utils/Orientation'
 
 if (Platform.OS === 'web') {
   Image.prefetch(illustration)
@@ -275,7 +276,7 @@ const Claim = props => {
             </View>
           </Section.Row>
         </Section.Stack>
-        <Section.Stack style={styles.extraInfo}>
+        <Section.Stack style={[styles.extraInfo, Platform.OS !== 'web' && styles.mobileCenterContent]}>
           <Image source={illustration} style={[styles.illustration, illustrationSizes]} resizeMode="contain" />
           {!isCitizen && (
             <ClaimButton
@@ -287,13 +288,13 @@ const Claim = props => {
             />
           )}
           <View style={styles.space} />
-          {/* <ClaimButton
+          <ClaimButton
             isCitizen={isCitizen}
             entitlement={state.entitlement}
             nextClaim={state.nextClaim}
             loading={loading}
             onPress={() => (isCitizen && state.entitlement ? handleClaim() : !isCitizen && faceRecognition())}
-          /> */}
+          />
           <Section.Row style={styles.extraInfoStats}>
             <Text style={styles.extraInfoWrapper}>
               <Section.Text fontWeight="bold">{numeral(state.claimedToday.people).format('0a')} </Section.Text>
@@ -314,8 +315,6 @@ const getStylesFromProps = ({ theme }) => {
       paddingVertical: 0,
       paddingHorizontal: 0,
       justifyContent: 'space-between',
-      maxHeight: getMaxDeviceHeight(),
-      paddingBottom: 60
     },
     mainText: {
       alignItems: 'center',
@@ -390,11 +389,16 @@ const getStylesFromProps = ({ theme }) => {
       maxHeight: Platform.select({
         // FIXME: RN
         web: 'fit-content',
-        default: 0,
+        default: 'auto',
       }),
+      width: '100%',
       paddingVertical: theme.sizes.defaultDouble,
       paddingHorizontal: theme.sizes.default,
       marginTop: getDesignRelativeHeight(85),
+    },
+    mobileCenterContent: {
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     extraInfoStats: {
       marginHorizontal: 0,

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -24,6 +24,7 @@ import { CLAIM_FAILED, CLAIM_SUCCESS, fireEvent } from '../../lib/analytics/anal
 import Config from '../../config/config'
 import type { DashboardProps } from './Dashboard'
 import ClaimButton from './ClaimButton'
+import { getMaxDeviceHeight } from '../../lib/utils/Orientation'
 
 if (Platform.OS === 'web') {
   Image.prefetch(illustration)
@@ -246,7 +247,7 @@ const Claim = props => {
             <Section.Text color="primary" size={16} fontFamily="Roboto" lineHeight={19} style={styles.mainTextToast}>
               {'YOU CAN GET'}
             </Section.Text>
-            <Section.Text style={styles.mainTextBigMarginBottom}>
+            <Section.Row style={styles.mainTextBigMarginBottom}>
               <BigGoodDollar
                 number={1}
                 reverse
@@ -255,11 +256,11 @@ const Claim = props => {
                 bigNumberUnitProps={{ color: 'surface', fontSize: 20 }}
                 style={styles.inline}
               />
-              <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36}>
+              <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36} lineHeight={36}>
                 {' Free'}
               </Section.Text>
-            </Section.Text>
-            <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36}>
+            </Section.Row>
+            <Section.Text color="surface" fontFamily="slab" fontWeight="bold" fontSize={36} lineHeight={36}>
               Every Day
             </Section.Text>
           </View>
@@ -286,13 +287,13 @@ const Claim = props => {
             />
           )}
           <View style={styles.space} />
-          <ClaimButton
+          {/* <ClaimButton
             isCitizen={isCitizen}
             entitlement={state.entitlement}
             nextClaim={state.nextClaim}
             loading={loading}
             onPress={() => (isCitizen && state.entitlement ? handleClaim() : !isCitizen && faceRecognition())}
-          />
+          /> */}
           <Section.Row style={styles.extraInfoStats}>
             <Text style={styles.extraInfoWrapper}>
               <Section.Text fontWeight="bold">{numeral(state.claimedToday.people).format('0a')} </Section.Text>
@@ -313,6 +314,8 @@ const getStylesFromProps = ({ theme }) => {
       paddingVertical: 0,
       paddingHorizontal: 0,
       justifyContent: 'space-between',
+      maxHeight: getMaxDeviceHeight(),
+      paddingBottom: 60
     },
     mainText: {
       alignItems: 'center',

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -319,7 +319,7 @@ const getStylesFromProps = ({ theme }) => {
       flexDirection: 'column',
       marginVertical: 'auto',
       zIndex: 1,
-      height: '42%',
+      height: '40%',
       justifyContent: 'center',
     },
     mainTextTitle: {

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -25,8 +25,6 @@ import Config from '../../config/config'
 import type { DashboardProps } from './Dashboard'
 import ClaimButton from './ClaimButton'
 
-// import { getMaxDeviceHeight } from '../../lib/utils/Orientation'
-
 if (Platform.OS === 'web') {
   Image.prefetch(illustration)
 }
@@ -321,6 +319,8 @@ const getStylesFromProps = ({ theme }) => {
       flexDirection: 'column',
       marginVertical: 'auto',
       zIndex: 1,
+      height: '42%',
+      justifyContent: 'center',
     },
     mainTextTitle: {
       marginBottom: 12,
@@ -372,6 +372,7 @@ const getStylesFromProps = ({ theme }) => {
       flexGrow: 0,
       flexShrink: 0,
       marginBottom: theme.sizes.default,
+      width: '100%',
     },
     illustrationForCitizen: {
       height: getDesignRelativeHeight(184, false),
@@ -384,7 +385,6 @@ const getStylesFromProps = ({ theme }) => {
     extraInfo: {
       backgroundColor: theme.colors.surface,
       borderRadius: theme.sizes.borderRadius,
-      flexGrow: 1,
       flexShrink: 1,
       maxHeight: Platform.select({
         // FIXME: RN

--- a/src/components/dashboard/ClaimButton.js
+++ b/src/components/dashboard/ClaimButton.js
@@ -42,7 +42,7 @@ export const ButtonCountdown = ({ styles, nextClaim }) => (
     <Text style={styles.extraInfoCountdownTitle} fontWeight="bold">
       Your next daily claim:
     </Text>
-    <Section.Text>
+    <Section.Text style={styles.textLineHeight}>
       {nextClaim &&
         nextClaim.split('').map((value, index) => {
           return (
@@ -128,6 +128,9 @@ const getStylesFromProps = ({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     marginLeft: theme.sizes.defaultHalf,
+  },
+  textLineHeight: {
+    lineHeight: 36,
   },
 })
 

--- a/src/components/dashboard/ClaimButton.js
+++ b/src/components/dashboard/ClaimButton.js
@@ -1,12 +1,12 @@
 import React from 'react'
-import { View, Platform } from 'react-native'
+import { Platform, View } from 'react-native'
 import { withStyles } from '../../lib/styles'
 import { weiToGd } from '../../lib/wallet/utils'
 import { CustomButton } from '../common'
 import BigGoodDollar from '../common/view/BigGoodDollar'
 import Text from '../common/view/Text'
-import Section from '../common/layout/Section'
 import { getDesignRelativeWidth } from '../../lib/utils/sizes'
+import Section from '../common/layout/Section'
 
 const ButtonAmountToClaim = ({ entitlement, isCitizen, styles }) => (
   <>
@@ -42,13 +42,14 @@ export const ButtonCountdown = ({ styles, nextClaim }) => (
     <Text style={styles.extraInfoCountdownTitle} fontWeight="bold">
       Your next daily claim:
     </Text>
-    <Section.Row grow style={styles.justifyCenter}>
+    <Section.Text>
       {nextClaim &&
         nextClaim.split('').map((value, index) => {
           return (
             <Text
               key={index}
               fontSize={36}
+              lineHeight={36}
               //fontFamily="RobotoSlab"
               fontFamily="Roboto"
               fontWeight="bold"
@@ -59,7 +60,7 @@ export const ButtonCountdown = ({ styles, nextClaim }) => (
             </Text>
           )
         })}
-    </Section.Row>
+    </Section.Text>
   </View>
 )
 
@@ -94,12 +95,14 @@ const getStylesFromProps = ({ theme }) => ({
   },
   minButtonHeight: {
     minHeight: 68,
+    width: '100%',
   },
   buttonCountdown: {
     backgroundColor: theme.colors.orange,
     flexDirection: 'column',
   },
   countdownContainer: {
+    display: 'flex',
     flexDirection: 'column',
   },
   tallCountDown: {

--- a/src/components/dashboard/ClaimButton.js
+++ b/src/components/dashboard/ClaimButton.js
@@ -9,7 +9,7 @@ import { getDesignRelativeWidth } from '../../lib/utils/sizes'
 import Section from '../common/layout/Section'
 
 const ButtonAmountToClaim = ({ entitlement, isCitizen, styles }) => (
-  <>
+  <View style={styles.countdownContainer}>
     <Text color="surface" fontWeight="medium">
       {`CLAIM YOUR SHARE - `}
     </Text>
@@ -32,9 +32,9 @@ const ButtonAmountToClaim = ({ entitlement, isCitizen, styles }) => (
         lineHeight: 19,
         marginVertical: 'auto',
       }}
-      style={isCitizen ? styles.amountInButtonCenter : styles.amountInButton}
+      style={isCitizen ? [styles.amountInButtonCenter, styles.justifyCenter] : styles.amountInButton}
     />
-  </>
+  </View>
 )
 
 export const ButtonCountdown = ({ styles, nextClaim }) => (


### PR DESCRIPTION
# Description

- Adjust styles on the Claim page.

# IoS
![Screen Shot 2020-02-26 at 10 11 49 AM](https://user-images.githubusercontent.com/59056508/75350902-06226200-5886-11ea-9c62-a43d30d2bc49.png)

# WEB
![Screen Shot 2020-02-26 at 10 52 26 AM](https://user-images.githubusercontent.com/59056508/75351015-3538d380-5886-11ea-82a5-fee26aa459a5.png)


Clarifications:
- Missing merge with custom button fixed for show the content of the claim button
- Not include Android fixed because it's a problem with custom button
