### PR TITLE
(Bug) #1404 feed animation doesnt have round edges on ios

### DIFF
--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -123,7 +123,6 @@ const getStylesFromProps = ({ theme }) => ({
     borderRadius: theme.feedItems.borderRadius,
     flexDirection: 'row',
     marginTop: theme.sizes.default,
-    overflow: 'hidden',
     shadowColor: theme.colors.text,
     shadowOffset: {
       width: 0,
@@ -137,6 +136,8 @@ const getStylesFromProps = ({ theme }) => ({
     shadowRadius: 4,
   },
   rowContent: {
+    borderRadius: theme.feedItems.borderRadius,
+    overflow: 'hidden',
     alignItems: 'center',
     backgroundColor: theme.feedItems.itemBackgroundColor,
     flex: 1,


### PR DESCRIPTION
# Description

Fix styles of feed card to show shadow correctly for ios devices.

About #1404 

# How Has This Been Tested?

On ios device:
Open app
Open dashboard
See feed load animation - the cards should have shadow and the corners of the cards should be rounded, not sharp.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
![1](https://user-images.githubusercontent.com/49862004/75975047-81b48c80-5ee0-11ea-80d4-6c8c21b9d606.png)
