### PR TITLE
Fix Android

### DIFF
--- a/src/components/splash/Splash.js
+++ b/src/components/splash/Splash.js
@@ -21,7 +21,8 @@ const Splash = ({ animation }) => (
       <WavesBackground>
         {animation ? (
           <>
-            <AnimationsLogo /> <Section.Text style={styles.version} fontSize={22}>{`V${Config.version}`}</Section.Text>
+            <AnimationsLogo />
+            <Section.Text style={styles.version} fontSize={22}>{`V${Config.version}`}</Section.Text>
           </>
         ) : (
           <Section.Stack style={styles.content} grow justifyContent="center">


### PR DESCRIPTION
React Native detects spaces as text. As that space is not wrapped inside a <Text />, android crashes.