### PR TITLE
(Bug) #1524 the claim animations displays broken on i phones

### DIFF
--- a/src/components/common/animations/JumpingPeople/index.js
+++ b/src/components/common/animations/JumpingPeople/index.js
@@ -1,8 +1,11 @@
 import React from 'react'
 import Lottie from 'lottie-react-native'
 import { Platform, View } from 'react-native'
+import { isMobileOnly } from 'mobile-device-detect'
 
+import { getDesignRelativeHeight } from '../../../../lib/utils/sizes'
 import animationData from './data.json'
+
 const styles = {
   android: {
     width: '100%',
@@ -16,8 +19,7 @@ const styles = {
   },
   web: {
     width: '100%',
-    position: 'absolute',
-    marginTop: -270,
+    marginBottom: isMobileOnly ? getDesignRelativeHeight(5) : -getDesignRelativeHeight(20),
   },
 }
 const stylesBlock = {
@@ -32,6 +34,8 @@ const stylesBlock = {
   web: {
     width: '100%',
     height: 100,
+    justifyContent: 'flex-end',
+    marginTop: isMobileOnly ? 0 : getDesignRelativeHeight(50),
   },
 }
 class JumpingPeople extends React.Component {

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -275,7 +275,7 @@ const Claim = props => {
           </Section.Row>
         </Section.Stack>
         <Section.Stack style={styles.extraInfo}>
-          <AnimationsJumpingPeople isCitizen={isCitizen} />
+          <AnimationsJumpingPeople />
           {isCitizen && state.entitlement > 0 ? (
             <ClaimAnimatedButton
               amount={state.entitlement}
@@ -289,7 +289,6 @@ const Claim = props => {
               loading={loading}
             />
           )}
-          <View style={styles.space} />
           <Section.Row style={styles.extraInfoStats}>
             <Text style={styles.extraInfoWrapper}>
               <Section.Text fontWeight="bold">{numeral(state.claimedToday.people).format('0a')} </Section.Text>

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -440,7 +440,12 @@ exports[`Claim matches snapshot 1`] = `
           className="css-view-1dbjc4n"
           style={
             Object {
+              "WebkitBoxPack": "end",
+              "WebkitJustifyContent": "flex-end",
               "height": "100px",
+              "justifyContent": "flex-end",
+              "marginTop": "50px",
+              "msFlexPack": "end",
               "width": "100%",
             }
           }
@@ -449,8 +454,7 @@ exports[`Claim matches snapshot 1`] = `
             className="css-view-1dbjc4n"
             style={
               Object {
-                "marginTop": "-270px",
-                "position": "absolute",
+                "marginBottom": "-20px",
                 "width": "100%",
               }
             }
@@ -708,14 +712,6 @@ exports[`Claim matches snapshot 1`] = `
             </div>
           </div>
         </div>
-        <div
-          className="css-view-1dbjc4n"
-          style={
-            Object {
-              "height": "16px",
-            }
-          }
-        />
         <div
           className="css-view-1dbjc4n"
           style={


### PR DESCRIPTION
# Description

Changes styles for Claim screen to correctly position JumpingPeople animation.

About #1524 

# How Has This Been Tested?

Go to claim screen - see changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Browser | Simulators |
| --- | --- |
| <img width="472" alt="1" src="https://user-images.githubusercontent.com/49862004/77413078-7a89eb80-6dc7-11ea-912f-ccc7100ed790.png"> | ![2](https://user-images.githubusercontent.com/49862004/77413094-7fe73600-6dc7-11ea-84fb-799e8d772080.png) |

