### PR TITLE
add: send events flow

### DIFF
--- a/src/components/dashboard/SendConfirmation.web.js
+++ b/src/components/dashboard/SendConfirmation.web.js
@@ -14,6 +14,7 @@ import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import BigGoodDollar from '../common/view/BigGoodDollar'
 import normalize from '../../lib/utils/normalizeText'
 import { useErrorDialog } from '../../lib/undux/utils/dialog'
+import { fireEvent } from '../../lib/analytics/analytics'
 import { SEND_TITLE } from './utils/sendReceiveFlow'
 
 export type ReceiveProps = {
@@ -29,8 +30,10 @@ const SendConfirmation = ({ screenProps, styles }: ReceiveProps) => {
   const { amount, reason, paymentLink } = screenState
 
   const shareAction = async () => {
+    let type = 'copy'
     if (isMobile && navigator.share) {
       try {
+        type = 'share'
         await navigator.share(paymentLink)
       } catch (e) {
         if (e.name !== 'AbortError') {
@@ -40,6 +43,7 @@ const SendConfirmation = ({ screenProps, styles }: ReceiveProps) => {
     } else {
       Clipboard.setString(paymentLink)
     }
+    fireEvent('SEND_CONFIRMATION_SHARE', { type })
   }
 
   return (

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -53,6 +53,12 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
 
       try {
         await Share.share(share)
+
+        //on non web we have the send confirmation which is skipped here, so we simulate the events
+        //so we have same funnel for mobile + web
+        fireEvent('SEND_CONFIRMATION', { type: 'link' })
+        fireEvent('SEND_CONFIRMATION_SHARE', { type: 'share' })
+
         setShared(true)
       } catch (e) {
         if (e.name !== 'AbortError') {


### PR DESCRIPTION
# Description

added two SEND_CONFIRMATION_SHARE event, once clicking on copy or sharing via native share
mock the SEND_CONFIRMATION event for mobile (where we skip the confirmation page)