### PR TITLE
(Bug) #1641 Receive flow - Copy link screen - Top Bar title should be "RECEIVE G$"

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -829,7 +829,11 @@ export default createStackNavigator({
   // UnsupportedDevice,
   SendQRSummary,
 
-  TransactionConfirmation,
+  TransactionConfirmation: {
+    screen: TransactionConfirmation,
+    path: ':action/TransactionConfirmation',
+    params: { action: ACTION_SEND },
+  },
 
   // PP: PrivacyPolicy,
   PrivacyArticle,

--- a/src/components/dashboard/ReceiveSummary.js
+++ b/src/components/dashboard/ReceiveSummary.js
@@ -4,8 +4,7 @@ import { View } from 'react-native'
 import { isMobile } from 'mobile-device-detect'
 import { Icon, Section, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
-import { BackButton, useScreenState } from '../appNavigation/stackNavigation'
-import { PushButton } from '../appNavigation/PushButton'
+import { BackButton, NextButton, useScreenState } from '../appNavigation/stackNavigation'
 import goodWallet from '../../lib/wallet/GoodWallet'
 import { generateCode } from '../../lib/share'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
@@ -36,9 +35,7 @@ const ReceiveAmount = ({ screenProps, styles }: ReceiveProps) => {
 
   const shareStringSource = [codeObject, amount, counterPartyDisplayName, fullName]
   const shareString = useMemo(
-    () => ({
-      paymentLink: (canShare ? generateReceiveShareObject : generateReceiveShareText)(...shareStringSource),
-    }),
+    () => (canShare ? generateReceiveShareObject : generateReceiveShareText)(...shareStringSource),
     [...shareStringSource, canShare, generateReceiveShareObject, generateReceiveShareText]
   )
 
@@ -128,9 +125,12 @@ const ReceiveAmount = ({ screenProps, styles }: ReceiveProps) => {
             </BackButton>
           </Section.Row>
           <Section.Stack grow={3}>
-            <PushButton routeName="TransactionConfirmation" screenProps={screenProps} params={shareString}>
-              Confirm
-            </PushButton>
+            <NextButton
+              screenProps={screenProps}
+              values={{ ...screenState, paymentLink: shareString }}
+              nextRoutes={screenState.nextRoutes}
+              label={'Confirm'}
+            />
           </Section.Stack>
         </Section.Row>
       </Section>

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -15,7 +15,7 @@ import TopBar from '../common/view/TopBar'
 import { withStyles } from '../../lib/styles'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import normalize from '../../lib/utils/normalizeText'
-import { ACTION_SEND_TO_ADDRESS, SEND_TITLE } from './utils/sendReceiveFlow'
+import { ACTION_SEND, ACTION_SEND_TO_ADDRESS, SEND_TITLE } from './utils/sendReceiveFlow'
 import SurveySend from './SurveySend'
 
 const log = logger.child({ from: 'SendLinkSummary' })
@@ -74,6 +74,7 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
               const desktopShareLink = generateSendShareText(...shareStringSource)
 
               push('TransactionConfirmation', {
+                action: ACTION_SEND,
                 paymentLink: desktopShareLink,
               })
             },
@@ -166,7 +167,7 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
       const desktopShareLink = generateSendShareText(paymentLink, ...shareStringStateDepSource)
 
       // Show confirmation
-      push('TransactionConfirmation', { paymentLink: desktopShareLink })
+      push('TransactionConfirmation', { paymentLink: desktopShareLink, action: ACTION_SEND })
     }
   }, [...shareStringStateDepSource, generateSendShareText, canShare, push])
 

--- a/src/components/dashboard/TransactionConfirmation.js
+++ b/src/components/dashboard/TransactionConfirmation.js
@@ -46,6 +46,10 @@ const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
 
   const handlePressDone = useCallback(() => goToRoot(), [goToRoot])
 
+  const secondTextPoint = useMemo(
+    () => (action === ACTION_SEND ? 'Share it with your recipient' : 'Share it with sender'),
+    [action]
+  )
   const thirdTextPoint = useMemo(
     () => (action === ACTION_SEND ? 'Recipient approves request' : 'Sender approves request'),
     [action]
@@ -65,7 +69,7 @@ const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
             </Section.Text>
             <Section.Text {...instructionsTextProps}>
               <Section.Text {...instructionsTextNumberProps}>{'2. '}</Section.Text>
-              Share it with your recipient
+              {secondTextPoint}
             </Section.Text>
             <Section.Text {...instructionsTextProps}>
               <Section.Text {...instructionsTextNumberProps}>{'3. '}</Section.Text>

--- a/src/components/dashboard/TransactionConfirmation.js
+++ b/src/components/dashboard/TransactionConfirmation.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import { Image, View } from 'react-native'
 import { useScreenState } from '../appNavigation/stackNavigation'
 import useNativeSharing from '../../lib/hooks/useNativeSharing'
@@ -46,14 +46,8 @@ const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
 
   const handlePressDone = useCallback(() => goToRoot(), [goToRoot])
 
-  const secondTextPoint = useMemo(
-    () => (action === ACTION_SEND ? 'Share it with your recipient' : 'Share it with sender'),
-    [action]
-  )
-  const thirdTextPoint = useMemo(
-    () => (action === ACTION_SEND ? 'Recipient approves request' : 'Sender approves request'),
-    [action]
-  )
+  const secondTextPoint = action === ACTION_SEND ? 'Share it with your recipient' : 'Share it with sender'
+  const thirdTextPoint = action === ACTION_SEND ? 'Recipient approves request' : 'Sender approves request'
 
   return (
     <Wrapper>

--- a/src/components/dashboard/TransactionConfirmation.js
+++ b/src/components/dashboard/TransactionConfirmation.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Image, View } from 'react-native'
 import { useScreenState } from '../appNavigation/stackNavigation'
 import useNativeSharing from '../../lib/hooks/useNativeSharing'
@@ -11,7 +11,7 @@ import { withStyles } from '../../lib/styles'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
 import { fireEvent } from '../../lib/analytics/analytics'
 import ConfirmTransactionSVG from '../../assets/confirmTransaction.svg'
-import { SEND_TITLE } from './utils/sendReceiveFlow'
+import { ACTION_RECEIVE, ACTION_SEND, PARAM_ACTION, RECEIVE_TITLE, SEND_TITLE } from './utils/sendReceiveFlow'
 
 export type ReceiveProps = {
   screenProps: any,
@@ -33,11 +33,11 @@ const instructionsTextNumberProps = {
   fontWeight: 'bold',
 }
 
-const SendConfirmation = ({ screenProps, styles }: ReceiveProps) => {
+const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
   const { canShare } = useNativeSharing()
   const [screenState] = useScreenState(screenProps)
   const { goToRoot } = screenProps
-  const { paymentLink } = screenState
+  const { paymentLink, action } = screenState
 
   const handlePressConfirm = useCallback(
     () => fireEvent('SEND_CONFIRMATION_SHARE', { type: canShare ? 'share' : 'copy' }),
@@ -45,6 +45,11 @@ const SendConfirmation = ({ screenProps, styles }: ReceiveProps) => {
   )
 
   const handlePressDone = useCallback(() => goToRoot(), [goToRoot])
+
+  const thirdTextPoint = useMemo(
+    () => (action === ACTION_SEND ? 'Recipient approves request' : 'Sender approves request'),
+    [action]
+  )
 
   return (
     <Wrapper>
@@ -64,7 +69,7 @@ const SendConfirmation = ({ screenProps, styles }: ReceiveProps) => {
             </Section.Text>
             <Section.Text {...instructionsTextProps}>
               <Section.Text {...instructionsTextNumberProps}>{'3. '}</Section.Text>
-              Recipient approves request
+              {thirdTextPoint}
             </Section.Text>
             <Section.Text {...instructionsTextProps}>
               <Section.Text {...instructionsTextNumberProps}>{'4. '}</Section.Text>
@@ -122,9 +127,13 @@ const getStylesFromProps = ({ theme }) => ({
   },
 })
 
-SendConfirmation.navigationOptions = {
-  title: SEND_TITLE,
-  backButtonHidden: true,
+TransactionConfirmation.navigationOptions = ({ navigation }) => {
+  const action = navigation.getParam(PARAM_ACTION)
+
+  return {
+    title: action === ACTION_RECEIVE ? RECEIVE_TITLE : SEND_TITLE,
+    backButtonHidden: true,
+  }
 }
 
-export default withStyles(getStylesFromProps)(SendConfirmation)
+export default withStyles(getStylesFromProps)(TransactionConfirmation)

--- a/src/components/dashboard/__tests__/__snapshots__/TransactionConfirmation.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/TransactionConfirmation.js.snap
@@ -266,7 +266,7 @@ exports[`SendConfirmation matches snapshot 1`] = `
             >
               3. 
             </span>
-            Recipient approves request
+            Sender approves request
           </div>
           <div
             className="css-text-901oao"

--- a/src/components/dashboard/__tests__/__snapshots__/TransactionConfirmation.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/TransactionConfirmation.js.snap
@@ -226,7 +226,7 @@ exports[`SendConfirmation matches snapshot 1`] = `
             >
               2. 
             </span>
-            Share it with your recipient
+            Share it with sender
           </div>
           <div
             className="css-text-901oao"


### PR DESCRIPTION
# Description

Fix test of title and text on TransactionConfirmation screen depends on current flow (Send/Receive).

About #1641 

# How Has This Been Tested?

Go through send flow to the last TransactionConfirmation screen and see the title (should start with 'send') and 3rd text point - the text should start with 'Recipient'.

Go through Receive (Request Specific Amount) flow to the last TransactionConfirmation screen and see the title (should start with 'Receive') and 3rd text point - the text should start with 'Sender'.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video: https://drive.google.com/a/nordwhale.com/file/d/1h1Pk9hPg7EYEfguBwZ7J6Cmg3Zhv-h22/view?usp=drivesdk