### PR TITLE
(Bug) #1646 Payment link withdrawn multiple times

### DIFF
--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -63,7 +63,7 @@ const handleLinks = async () => {
         delete params.web3
       }
       let path = window.location.pathname.slice(1)
-      path = path.length === 0 ? 'AppNavigation/Dashboard' : path
+      path = path.length === 0 ? 'AppNavigation/Dashboard/Home' : path
       if ((params && Object.keys(params).length > 0) || path.indexOf('Marketplace') >= 0) {
         const dest = { path, params }
         log.debug('Saving destination url', dest)


### PR DESCRIPTION
# Description

Declare the exact route where the 'destinationPath' params should be applied instead of the parent route (Dashboard). We need to apply params only for the Home route.

About #1646 

# How Has This Been Tested?

Get send the payment link.
Being logged out paste it to your browser address line.
Then go through the registration process.
After you reach the Dashboard - the payment link should be automatically withdrawn and the payment link should be removed from the browser address line.
The g to Claim screen and get back to the Dashboard - the payment link should not be restored anymore and you should not see error withdraw popup.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video: https://drive.google.com/a/nordwhale.com/file/d/1B9rnLPgaxZP_DeuHJpuYP6dJX0qBM-dN/view?usp=drivesdk