### PR TITLE
(Bug) #1672 Cards icons when switching icons from animation to static ones theres a change in their position

### DIFF
--- a/src/components/common/animations/Feed/Base.js
+++ b/src/components/common/animations/Feed/Base.js
@@ -10,11 +10,23 @@ class FeedInfo extends AnimationBase {
   }
 
   onMount() {
-    const { delay = 0 } = this.props
+    const { delay = 0, showAnim } = this.props
+    const { isWeb } = this.state
 
     this.anim.onComplete = this.onAnimationFinishHandler
 
-    setTimeout(() => this.anim.play(), delay)
+    if (showAnim) {
+      // play animation
+      setTimeout(() => this.anim.play(), delay)
+    } else if (isWeb) {
+      // web show static image
+      const lastFrame = Number(this.animationData.op) - 1
+      this.anim.goToAndStop(lastFrame, true)
+    } else {
+      // react native app show static image
+      const lastFrame = Number(this.animationData.op) - 1
+      this.anim.play(lastFrame - 1, lastFrame)
+    }
   }
 
   onAnimationFinishHandler = () => {

--- a/src/components/dashboard/Claim/__tests__/__snapshots__/PhaseOne.js.snap
+++ b/src/components/dashboard/Claim/__tests__/__snapshots__/PhaseOne.js.snap
@@ -782,7 +782,6 @@ UBI on a global scale.
           }
         >
           1
-           
         </span>
         <span
           className="css-text-901oao css-textHasAncestor-16my406"

--- a/src/components/dashboard/FeedItems/EventIcon.js
+++ b/src/components/dashboard/FeedItems/EventIcon.js
@@ -6,11 +6,12 @@ import getEventSettingsByType from './EventSettingsByType'
 const EventIcon = ({ onAnimationFinish, showAnim = true, delay, type, theme, styles, style, animStyle, size = 34 }) => {
   const meta = getEventSettingsByType(theme, type)
 
-  if (showAnim && meta.component) {
+  if (meta.component) {
     const AnimComponent = meta.component
 
-    return <AnimComponent style={animStyle} delay={delay} onFinish={onAnimationFinish} />
+    return <AnimComponent style={animStyle} showAnim={showAnim} delay={delay} onFinish={onAnimationFinish} />
   }
+
   return <Icon color={meta.color} size={size} name={meta.name} style={[styles.eventIcon, style ? style : {}]} />
 }
 

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
@@ -2165,22 +2165,8 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
                     </span>
                   </div>
                   <div
-                    className="css-text-901oao"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(250,108,119,1.00)",
-                        "fontFamily": "gooddollar",
-                        "fontSize": "34px",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                        "marginLeft": "auto",
-                        "marginRight": "1px",
-                      }
-                    }
-                  >
-                    
-                  </div>
+                    className="css-view-1dbjc4n"
+                  />
                 </div>
                 <div
                   className="css-view-1dbjc4n"
@@ -3103,22 +3089,8 @@ exports[`FeedModalItem - Send with Error status matches snapshot 1`] = `
                     </span>
                   </div>
                   <div
-                    className="css-text-901oao"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(250,108,119,1.00)",
-                        "fontFamily": "gooddollar",
-                        "fontSize": "34px",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                        "marginLeft": "auto",
-                        "marginRight": "1px",
-                      }
-                    }
-                  >
-                    
-                  </div>
+                    className="css-view-1dbjc4n"
+                  />
                 </div>
                 <div
                   className="css-view-1dbjc4n"
@@ -4008,22 +3980,8 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
                     </span>
                   </div>
                   <div
-                    className="css-text-901oao"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(0,195,174,1.00)",
-                        "fontFamily": "gooddollar",
-                        "fontSize": "34px",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                        "marginLeft": "auto",
-                        "marginRight": "1px",
-                      }
-                    }
-                  >
-                    
-                  </div>
+                    className="css-view-1dbjc4n"
+                  />
                 </div>
                 <div
                   className="css-view-1dbjc4n"

--- a/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Claim.js.snap
@@ -823,7 +823,6 @@ UBI on a global scale.
               }
             >
               0
-               
             </span>
             <span
               className="css-text-901oao css-textHasAncestor-16my406"

--- a/src/lib/gundb/__tests__/UserStorage.js
+++ b/src/lib/gundb/__tests__/UserStorage.js
@@ -10,6 +10,7 @@ import {
   getReceiveDataFromReceipt,
   hanukaBonusStartsMessage,
   inviteFriendsMessage,
+  longUseOfClaims,
   startClaiming,
   startSpending,
   type TransactionEvent,
@@ -18,7 +19,6 @@ import {
 } from '../UserStorageClass'
 import UserPropertiesClass from '../UserPropertiesClass'
 import { getUserModel } from '../UserModel'
-import { longUseOfClaims } from '../../../components/dashboard/Claim/events'
 import update from '../../updates'
 import { addUser } from './__util__/index'
 

--- a/src/lib/share/__tests__/generateReceiveShareObject.js
+++ b/src/lib/share/__tests__/generateReceiveShareObject.js
@@ -5,7 +5,7 @@ describe('generateReceiveShareObject', () => {
   it(`should return an object for receipt with code, amount, to and from`, () => {
     // Given
     const title = 'Sending G$ via GoodDollar App'
-    const message = "Joe Bloggs, You've got a request from John Doe for 1 G$. To Transfer open:"
+    const message = "Joe Bloggs, You've got a request from John Doe for 1 G$. To approve transfer open:"
 
     // When
     const shareObject = generateReceiveShareObject({ amount: '123' }, 100, 'Joe Bloggs', 'John Doe')

--- a/src/lib/share/__tests__/generateReceiveShareObject.js
+++ b/src/lib/share/__tests__/generateReceiveShareObject.js
@@ -19,7 +19,7 @@ describe('generateReceiveShareObject', () => {
   it(`should return an object for receipt with code, to and from`, () => {
     // Given
     const title = 'Sending G$ via GoodDollar App'
-    const message = "Joe Bloggs, You've got a request from John Doe. To Transfer open:"
+    const message = "Joe Bloggs, You've got a request from John Doe. To approve transfer open:"
 
     // When
     const shareObject = generateReceiveShareObject({ amount: '123' }, 0, 'Joe Bloggs', 'John Doe')
@@ -33,7 +33,7 @@ describe('generateReceiveShareObject', () => {
   it(`should return an object for receipt with code, amount and from`, () => {
     // Given
     const title = 'Sending G$ via GoodDollar App'
-    const message = "You've got a request from John Doe for 1 G$. To Transfer open:"
+    const message = "You've got a request from John Doe for 1 G$. To approve transfer open:"
 
     // When
     const shareObject = generateReceiveShareObject({ amount: '123' }, '100', '', 'John Doe')
@@ -47,7 +47,7 @@ describe('generateReceiveShareObject', () => {
   it(`should return an object for receipt with code and from`, () => {
     // Given
     const title = 'Sending G$ via GoodDollar App'
-    const message = "You've got a request from John Doe. To Transfer open:"
+    const message = "You've got a request from John Doe. To approve transfer open:"
 
     // When
     const shareObject = generateReceiveShareObject({ amount: '123' }, 0, '', 'John Doe')


### PR DESCRIPTION
# Description

Fix the way of displaying animation when the animated state is false - show the last frame if the animation is not needed.

About #1672 

# How Has This Been Tested?

Open dahsboard
type 'userStorage.addAllCardsTest()' in console or claim G$ to create new feed card - see the icon - it shouldn't change/jump.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
