### PR TITLE
(Bug) #1695 The "My profile" page is stuck a little while moving between profile pages

### DIFF
--- a/src/components/profile/ViewOrUploadAvatar.js
+++ b/src/components/profile/ViewOrUploadAvatar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import React, { useCallback } from 'react'
 import GDStore from '../../lib/undux/GDStore'
 import { CustomButton, Section, UserAvatar, Wrapper } from '../common'
 import { withStyles } from '../../lib/styles'
@@ -15,38 +15,49 @@ import CameraButton from './CameraButton'
 const log = logger.child({ from: 'ViewAvatar' })
 const TITLE = 'My Profile'
 
-const ViewOrUploadAvatar = props => {
-  const { styles } = props
+const ViewOrUploadAvatar = ({ styles, navigation, screenProps }) => {
   const store = GDStore.useStore()
   const profile = store.get('profile')
   const wrappedUserStorage = useWrappedUserStorage()
   const [showErrorDialog] = useErrorDialog()
 
-  const handleCameraPress = event => {
-    event.preventDefault()
-    props.navigation.navigate('EditAvatar')
-  }
+  const handleCameraPress = useCallback(
+    event => {
+      event.preventDefault()
+      navigation.navigate('EditAvatar')
+    },
+    [navigation]
+  )
 
-  const handleClosePress = event => {
-    event.preventDefault()
-    wrappedUserStorage.removeAvatar().catch(e => {
-      showErrorDialog('Could not delete image. Please try again.')
-      log.error('delete image failed:', e.message, e)
-    })
-  }
+  const handleClosePress = useCallback(
+    event => {
+      event.preventDefault()
 
-  const handleAddAvatar = avatar => {
-    fireEvent(PROFILE_IMAGE)
-    wrappedUserStorage.setAvatar(avatar).catch(e => {
-      showErrorDialog('Could not save image. Please try again.')
-      log.error('save image failed:', e.message, e)
-    })
-    props.navigation.navigate('EditAvatar')
-  }
+      wrappedUserStorage.removeAvatar().catch(e => {
+        showErrorDialog('Could not delete image. Please try again.')
+        log.error('delete image failed:', e.message, e)
+      })
+    },
+    [wrappedUserStorage]
+  )
 
-  const goToProfile = () => {
-    props.navigation.navigate('EditProfile')
-  }
+  const handleAddAvatar = useCallback(
+    avatar => {
+      fireEvent(PROFILE_IMAGE)
+
+      wrappedUserStorage.setAvatar(avatar).catch(e => {
+        showErrorDialog('Could not save image. Please try again.')
+        log.error('save image failed:', e.message, e)
+      })
+
+      navigation.navigate('EditAvatar')
+    },
+    [navigation, wrappedUserStorage]
+  )
+
+  const navigateBack = useCallback(() => {
+    screenProps.pop()
+  }, [navigation])
 
   return (
     <Wrapper>
@@ -74,7 +85,7 @@ const ViewOrUploadAvatar = props => {
             </>
           )}
         </Section.Stack>
-        <CustomButton style={styles.doneButton} onPress={goToProfile}>
+        <CustomButton style={styles.doneButton} onPress={navigateBack}>
           Done
         </CustomButton>
       </Section>


### PR DESCRIPTION
# Description

Implement correct navigation back in the ViewOrUploadAvatar component.

About #1695 

# How Has This Been Tested?

1) Open the "My profile" page from the dashboard
2) Click on the image profile icon
3) Click on the "Done" button
4) Repeat 2-3 steps a few times
5) Click on the back arrow button
6) user should be able to get back to the previous screen within one click on back button

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
