### PR TITLE
(Bug) #1700 My profile/Edit profile - UI bugs

### DIFF
--- a/src/components/common/view/Avatar.js
+++ b/src/components/common/view/Avatar.js
@@ -16,7 +16,7 @@ import { withStyles } from '../../../lib/styles'
  */
 const CustomAvatar = ({ styles, style, source, onPress, size, imageSize, children, ...avatarProps }) => (
   <TouchableOpacity
-    activeOpacity={0.5}
+    activeOpacity={1}
     disabled={!onPress}
     onPress={onPress}
     style={[styles.avatarContainer, { width: size, height: size, borderRadius: size / 2 }, style]}

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -215,7 +215,7 @@ const getStylesFromProps = ({ theme }) => {
       position: 'absolute',
       width: 120,
       height: 60,
-      top: -3,
+      top: 0,
       right: -24,
       marginVertical: 0,
       display: 'flex',


### PR DESCRIPTION
# Description

Fix styles for userAvatar and EditProfile components.

About #1700 

# How Has This Been Tested?

Open Profile page
Click and hold on Profile avatar it shouldn't change its opacity.

Go to edit profile page on ios device
The save button shouldn't be cut at the top

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Profile Avatar | Save Button |
| --- | --- |
| ![2](https://user-images.githubusercontent.com/49862004/80721350-ca667b80-8b06-11ea-86c5-9e5109177de6.png) | ![1](https://user-images.githubusercontent.com/49862004/80721380-cfc3c600-8b06-11ea-8cdf-b8eb32dce416.png)|

