### PR TITLE
(Bug) #1708 The magiclink info screen shows sometimes while signing up with Torus

### DIFF
--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -68,7 +68,6 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
 
   const [regMethod, setRegMethod] = useState(REGISTRATION_METHOD_SELF_CUSTODY)
   const isRegMethodSelfCustody = regMethod === REGISTRATION_METHOD_SELF_CUSTODY
-  const skipEmailOrMagicLink = !isRegMethodSelfCustody && Config.torusEnabled
 
   const initialState: SignupState = {
     ...getUserModel({
@@ -77,11 +76,9 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
       mobile: '',
     }),
     smsValidated: false,
-    isEmailConfirmed: skipEmailOrMagicLink || !!w3UserFromProps.email,
     jwt: '',
     skipEmail: !!w3UserFromProps.email || !!torusUserFromProps.email,
     skipEmailConfirmation: Config.skipEmailVerification || !!w3UserFromProps.email,
-    skipMagicLinkInfo: skipEmailOrMagicLink,
     w3Token,
   }
 
@@ -227,9 +224,6 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
   }
 
   const onMount = async () => {
-    checkTorusLogin()
-    verifyStartRoute()
-
     // Recognize registration method (page refresh case included)
     const initialRegMethod = await AsyncStorage.getItem(GD_INITIAL_REG_METHOD)
     const _regMethod = initialRegMethod
@@ -237,6 +231,17 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
       : get(navigation, 'state.routes[1].params.regMethod', REGISTRATION_METHOD_SELF_CUSTODY)
     setRegMethod(_regMethod)
     AsyncStorage.setItem(GD_INITIAL_REG_METHOD, _regMethod)
+    const skipEmailConfirmOrMagicLink = _regMethod !== REGISTRATION_METHOD_SELF_CUSTODY && Config.torusEnabled
+
+    // set regMethod sensitive variables into state
+    setState({
+      ...state,
+      skipMagicLinkInfo: skipEmailConfirmOrMagicLink,
+      isEmailConfirmed: skipEmailConfirmOrMagicLink || !!w3UserFromProps.email,
+    })
+
+    checkTorusLogin()
+    verifyStartRoute()
 
     //get user country code for phone
     //read user data from w3 if needed
@@ -285,6 +290,7 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
 
     setReady(ready)
   }
+
   useEffect(() => {
     onMount()
   }, [])
@@ -386,6 +392,7 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
       setLoading(false)
     }
   }
+
   function getNextRoute(routes, routeIndex, state) {
     let nextRoute = routes[routeIndex + 1]
 


### PR DESCRIPTION
# Description

Reproduced locally.
Initialize the regMethod variable in SignupState container correctly. Set regMethod sensitive data to the state after fetching it from params or AsyncStorage. The regMethod was always 'selfCustody' at the first fn run - so skipMagicLinkInfo was always false.

About #1708 

# How Has This Been Tested?

The MagicLinkInfo screen shouldn't be displayed in the case of the torus login used.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
