### PR TITLE
(Feature) #1707 Processing payment dialog should stay until user press YAY

### DIFF
--- a/src/components/common/dialogs/CustomDialog.js
+++ b/src/components/common/dialogs/CustomDialog.js
@@ -97,12 +97,12 @@ const CustomDialog = ({
           {showButtons ? (
             <View style={buttonsContainerStyle || styles.buttonsContainer}>
               {buttons ? (
-                buttons.map(({ onPress = dismiss => dismiss(), style, ...buttonProps }, index) => (
+                buttons.map(({ onPress = dismiss => dismiss(), style, disabled, ...buttonProps }, index) => (
                   <CustomButton
                     {...buttonProps}
                     onPress={() => onPress(onDismiss)}
                     style={[{ marginLeft: 10 }, style]}
-                    disabled={loading}
+                    disabled={disabled || loading}
                     loading={loading}
                     key={index}
                   >

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -40,6 +40,7 @@ import useDeleteAccountDialog from '../../lib/hooks/useDeleteAccountDialog'
 import useAppState from '../../lib/hooks/useAppState'
 import config from '../../config/config'
 import LoadingIcon from '../common/modal/LoadingIcon'
+import SuccessIcon from '../common/modal/SuccessIcon'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import { theme as _theme } from '../theme/styles'
 import unknownProfile from '../../assets/unknownProfile.svg'
@@ -495,18 +496,37 @@ const Dashboard = props => {
           title: 'Processing Payment Link...',
           image: <LoadingIcon />,
           message: 'please wait while processing...',
-          buttons: [{ text: 'YAY!', style: styles.disabledButton }],
+          buttons: [
+            {
+              text: 'YAY!',
+              style: styles.disabledButton,
+              disabled: true,
+            },
+          ],
         })
+
         const { status, transactionHash } = await executeWithdraw(
           store,
           paymentParams.paymentCode,
           paymentParams.reason
         )
+
         if (transactionHash) {
           fireEvent('WITHDRAW')
           hideDialog()
+          showDialog({
+            title: 'Payment Link Processed Successfully',
+            image: <SuccessIcon />,
+            message: "You received G$'s!",
+            buttons: [
+              {
+                text: 'YAY!',
+              },
+            ],
+          })
           return
         }
+
         switch (status) {
           case WITHDRAW_STATUS_COMPLETE:
             showErrorDialog('Payment already withdrawn or canceled by sender')


### PR DESCRIPTION
# Description

Show success icon and activate yay button on txhash received for payment popup

About #1707 

# How Has This Been Tested?

Open app with send (withdraw) payment link
The yay button should. be activated and success icon displayed on txhash received.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video: https://drive.google.com/a/nordwhale.com/file/d/1_OZ5R5bxAUgXeWphGKzQfcO_4HNJIgpV/view?usp=drivesdk