### PR TITLE
(Bug) #1705 IOS: The pending/daily income pop-ups are displayed with a big icon

### DIFF
--- a/src/components/dashboard/FeedItems/FeedModalItem.js
+++ b/src/components/dashboard/FeedItems/FeedModalItem.js
@@ -82,7 +82,9 @@ const FeedModalItem = (props: FeedEventProps) => {
               <EventCounterParty style={styles.feedItem} textStyle={styles.feedItemText} feedItem={item} />
             )}
             {!eventSettings.withoutAvatar && (
-              <EventIcon type={itemType} style={styles.icon} showAnim={!topImageExists} />
+              <View style={styles.iconContainer}>
+                <EventIcon type={itemType} showAnim={!topImageExists} />
+              </View>
             )}
           </View>
           <View style={styles.messageContainer}>
@@ -121,6 +123,7 @@ const getStylesFromProps = ({ theme }) => {
     },
     feedItem: {
       paddingRight: 4,
+      marginRight: 'auto',
     },
     feedItemText: {
       fontSize: 22,
@@ -147,7 +150,9 @@ const getStylesFromProps = ({ theme }) => {
       marginRight: 7,
       width: 34,
     },
-    icon: {
+    iconContainer: {
+      height: 36,
+      width: 36,
       marginLeft: 'auto',
     },
     messageContainer: {

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedModalItem.js.snap
@@ -407,6 +407,7 @@ exports[`FeedModalItem - Invite matches snapshot 1`] = `
                         "fontSize": "16px",
                         "fontWeight": "normal",
                         "lineHeight": "22px",
+                        "marginRight": "auto",
                         "paddingRight": "4px",
                         "textAlign": "left",
                         "textDecoration": "none",
@@ -1197,6 +1198,7 @@ exports[`FeedModalItem - Message matches snapshot 1`] = `
                         "fontSize": "16px",
                         "fontWeight": "normal",
                         "lineHeight": "22px",
+                        "marginRight": "auto",
                         "paddingRight": "4px",
                         "textAlign": "left",
                         "textDecoration": "none",
@@ -1227,21 +1229,31 @@ exports[`FeedModalItem - Message matches snapshot 1`] = `
                     </span>
                   </div>
                   <div
-                    className="css-text-901oao"
-                    dir="auto"
+                    className="css-view-1dbjc4n"
                     style={
                       Object {
-                        "color": "rgba(159,106,157,1.00)",
-                        "fontFamily": "gooddollar",
-                        "fontSize": "34px",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "height": "36px",
                         "marginLeft": "auto",
-                        "marginRight": "1px",
+                        "width": "36px",
                       }
                     }
                   >
-                    
+                    <div
+                      className="css-text-901oao"
+                      dir="auto"
+                      style={
+                        Object {
+                          "color": "rgba(159,106,157,1.00)",
+                          "fontFamily": "gooddollar",
+                          "fontSize": "34px",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                          "marginRight": "1px",
+                        }
+                      }
+                    >
+                      
+                    </div>
                   </div>
                 </div>
                 <div
@@ -2115,6 +2127,7 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
                         "fontSize": "16px",
                         "fontWeight": "normal",
                         "lineHeight": "22px",
+                        "marginRight": "auto",
                         "paddingRight": "4px",
                         "textAlign": "left",
                         "textDecoration": "none",
@@ -2166,7 +2179,18 @@ exports[`FeedModalItem - Send matches snapshot 1`] = `
                   </div>
                   <div
                     className="css-view-1dbjc4n"
-                  />
+                    style={
+                      Object {
+                        "height": "36px",
+                        "marginLeft": "auto",
+                        "width": "36px",
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                    />
+                  </div>
                 </div>
                 <div
                   className="css-view-1dbjc4n"
@@ -3039,6 +3063,7 @@ exports[`FeedModalItem - Send with Error status matches snapshot 1`] = `
                         "fontSize": "16px",
                         "fontWeight": "normal",
                         "lineHeight": "22px",
+                        "marginRight": "auto",
                         "paddingRight": "4px",
                         "textAlign": "left",
                         "textDecoration": "none",
@@ -3090,7 +3115,18 @@ exports[`FeedModalItem - Send with Error status matches snapshot 1`] = `
                   </div>
                   <div
                     className="css-view-1dbjc4n"
-                  />
+                    style={
+                      Object {
+                        "height": "36px",
+                        "marginLeft": "auto",
+                        "width": "36px",
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                    />
+                  </div>
                 </div>
                 <div
                   className="css-view-1dbjc4n"
@@ -3930,6 +3966,7 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
                         "fontSize": "16px",
                         "fontWeight": "normal",
                         "lineHeight": "22px",
+                        "marginRight": "auto",
                         "paddingRight": "4px",
                         "textAlign": "left",
                         "textDecoration": "none",
@@ -3981,7 +4018,18 @@ exports[`FeedModalItem - Withdraw matches snapshot 1`] = `
                   </div>
                   <div
                     className="css-view-1dbjc4n"
-                  />
+                    style={
+                      Object {
+                        "height": "36px",
+                        "marginLeft": "auto",
+                        "width": "36px",
+                      }
+                    }
+                  >
+                    <div
+                      className="css-view-1dbjc4n"
+                    />
+                  </div>
                 </div>
                 <div
                   className="css-view-1dbjc4n"


### PR DESCRIPTION
# Description

Fix styles for small icons inside feed modal popup.

About #1705 

# How Has This Been Tested?

Try to open any feed modal popup - the small icons should be displayed correctly

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Browser | IOS |
| --- | --- |
| ![1705-Browser](https://user-images.githubusercontent.com/49862004/80788358-8e2c2d00-8b91-11ea-8bc4-0d54589e264a.png) | ![1705-IOS](https://user-images.githubusercontent.com/49862004/80788466-df3c2100-8b91-11ea-8d9c-60f7b9ea57a0.png) |

