### PR TITLE
(Bug) #1726 TypeError: Cannot read property 'get' of null

### DIFF
--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -18,6 +18,7 @@ import useAppState from '../../lib/hooks/useAppState'
 import Splash from '../splash/Splash'
 import config from '../../config/config'
 import { delay } from '../../lib/utils/async'
+import { assertStore } from '../../lib/undux/SimpleStore'
 
 type LoadingProps = {
   navigation: any,
@@ -196,6 +197,11 @@ const AppSwitch = (props: LoadingProps) => {
     if (config.enableInvites !== true) {
       return
     }
+
+    if (!assertStore(gdstore, log, 'checkBonusInterval failed')) {
+      return
+    }
+
     const lastTimeBonusCheck = await userStorage.userProperties.get('lastBonusCheckDate')
     const isUserWhitelisted = gdstore.get('isLoggedInCitizen') || (await goodWallet.isCitizen())
 


### PR DESCRIPTION
# Description

After some investigation, I think the issue occurred in AppSwithch checkBonusInterval function. So I added the assetStore verification for gdstore. 

About #1726 

# How Has This Been Tested?

There shouldn't be such error posted to the sentry.io

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
