### PR TITLE
(Bug) #1726 TypeError: Cannot read property 'get' of null

### DIFF
--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -101,6 +101,10 @@ const AppSwitch = (props: LoadingProps) => {
    * @returns {Promise<void>}
    */
   const initialize = async () => {
+    if (!assertStore(gdstore, log, 'FAiled to initialize login/citizen status')) {
+      return
+    }
+
     //after dynamic routes update, if user arrived here, then he is already loggedin
     //initialize the citizen status and wallet status
     const { isLoggedInCitizen, isLoggedIn } = await Promise.all([getLoginState(), updateWalletStatus(gdstore)]).then(

--- a/src/components/common/view/AddWebApp.web.js
+++ b/src/components/common/view/AddWebApp.web.js
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { AsyncStorage, Image, View } from 'react-native'
 import { isMobile, isMobileSafari } from 'mobile-device-detect'
 import moment from 'moment'
-import SimpleStore from '../../../lib/undux/SimpleStore'
+import SimpleStore, { assertStore } from '../../../lib/undux/SimpleStore'
 import { useDialog } from '../../../lib/undux/utils/dialog'
 import {
   ADDTOHOME,
@@ -105,8 +105,20 @@ const ExplanationDialog = withStyles(mapStylesToProps)(({ styles }) => {
 const AddWebApp = props => {
   const store = SimpleStore.useStore()
   const [showDialog] = useDialog()
-  const { show, showAddWebAppDialog } = store.get('addWebApp')
-  const installPrompt = store.get('installPrompt')
+  const [show, setShow] = useState(false)
+  const [showAddWebAppDialog, setShowAddWebAppDialog] = useState(false)
+  const [installPrompt, setInstallPrompt] = useState(false)
+
+  const fetchStoreData = useCallback(() => {
+    if (assertStore(store, log, 'Failed to fetch show status to display AddWebApp modal')) {
+      const { show: _show, showAddWebAppDialog: _showAddWebAppDialog } = store.get('addWebApp')
+      const _installPrompt = store.get('installPrompt')
+
+      setShow(_show)
+      setShowAddWebAppDialog(_showAddWebAppDialog)
+      setInstallPrompt(_installPrompt)
+    }
+  }, [store, setShow, setShowAddWebAppDialog, setInstallPrompt])
 
   const showExplanationDialog = () => {
     // const magicLinkCode = userStorage.getMagicLink()
@@ -228,6 +240,11 @@ const AddWebApp = props => {
       showInitialDialog()
     }
   }
+
+  useEffect(() => {
+    fetchStoreData()
+  }, [store])
+
   useEffect(() => {
     checkShowDialog()
   }, [installPrompt, show])

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -9,7 +9,7 @@ import { delay } from '../../lib/utils/async'
 import normalize from '../../lib/utils/normalizeText'
 import GDStore from '../../lib/undux/GDStore'
 import API from '../../lib/API/api'
-import SimpleStore from '../../lib/undux/SimpleStore'
+import SimpleStore, { assertStoreSnapshot } from '../../lib/undux/SimpleStore'
 import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { PAGE_SIZE } from '../../lib/undux/utils/feed'
 import { executeWithdraw, prepareDataWithdraw } from '../../lib/undux/utils/withdraw'
@@ -256,6 +256,10 @@ const Dashboard = props => {
   }, [gdstore, animValue])
 
   const showDelayed = useCallback(() => {
+    if (!assertStoreSnapshot(store, log, 'Failed to show AddWebApp modal')) {
+      return
+    }
+
     const id = setTimeout(() => {
       //wait until not loading and not showing other modal (see use effect)
       //mark as displayed

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -9,7 +9,7 @@ import { delay } from '../../lib/utils/async'
 import normalize from '../../lib/utils/normalizeText'
 import GDStore from '../../lib/undux/GDStore'
 import API from '../../lib/API/api'
-import SimpleStore, { assertStoreSnapshot } from '../../lib/undux/SimpleStore'
+import SimpleStore, { assertStore } from '../../lib/undux/SimpleStore'
 import { useDialog, useErrorDialog } from '../../lib/undux/utils/dialog'
 import { PAGE_SIZE } from '../../lib/undux/utils/feed'
 import { executeWithdraw, prepareDataWithdraw } from '../../lib/undux/utils/withdraw'
@@ -256,7 +256,7 @@ const Dashboard = props => {
   }, [gdstore, animValue])
 
   const showDelayed = useCallback(() => {
-    if (!assertStoreSnapshot(store, log, 'Failed to show AddWebApp modal')) {
+    if (!assertStore(store, log, 'Failed to show AddWebApp modal')) {
       return
     }
 

--- a/src/lib/undux/SimpleStore.js
+++ b/src/lib/undux/SimpleStore.js
@@ -131,7 +131,7 @@ const storeAssertion = (condition, logger, message) => {
   }
 
   if (assertionFailed) {
-    log.warn('updateAll failed', 'Received store is null')
+    log.warn('updateAll failed', 'Received store is null', message)
   }
 
   return !assertionFailed


### PR DESCRIPTION
# Description

Use assertStore fn for storage usages in AppSwitch.js and Dashboard.js. Show custom message in the console within error message about the null store.

About #1726 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
