### PR TITLE
(Chore) #1743 Error: AbortError: Share canceled

### DIFF
--- a/src/components/common/buttons/ShareButton.js
+++ b/src/components/common/buttons/ShareButton.js
@@ -1,9 +1,7 @@
 // @flow
 import React, { useCallback, useEffect } from 'react'
-import { Share } from 'react-native'
 import logger from '../../../lib/logger/pino-logger'
 import useNativeSharing from '../../../lib/hooks/useNativeSharing'
-import { useErrorDialog } from '../../../lib/undux/utils/dialog'
 import CustomButton from './CustomButton'
 import CopyButton from './CopyButton'
 
@@ -17,30 +15,24 @@ type ShareButtonProps = {
 const log = logger.child({ from: 'ShareButton' })
 
 const ShareButton = ({ share, onPressDone, actionText, ...buttonProps }: ShareButtonProps) => {
-  const [showErrorDialog] = useErrorDialog()
-  const { canShare } = useNativeSharing()
+  const { canShare, shareAction } = useNativeSharing()
 
   useEffect(() => {
     log.info('getPaymentLink', { share })
   }, [])
 
-  const shareAction = useCallback(async () => {
-    try {
-      await Share.share(share)
-    } catch (e) {
-      if (e.name !== 'AbortError') {
-        showErrorDialog('Sorry, there was an error sharing you link. Please try again later.')
-      }
-    }
-  }, [showErrorDialog])
+  const shareHandler = useCallback(() => {
+    shareAction(share)
+  }, [shareAction, share])
 
   if (canShare) {
     return (
-      <CustomButton onPress={shareAction} {...buttonProps}>
+      <CustomButton onPress={shareHandler} {...buttonProps}>
         {actionText}
       </CustomButton>
     )
   }
+
   return (
     <CopyButton toCopy={share.url} onPressDone={onPressDone} {...buttonProps}>
       {actionText}

--- a/src/components/dashboard/Receive.js
+++ b/src/components/dashboard/Receive.js
@@ -1,12 +1,11 @@
 // @flow
 import React, { useCallback, useMemo } from 'react'
-import { PixelRatio, Share, View } from 'react-native'
+import { PixelRatio, View } from 'react-native'
 import { isBrowser, isMobileOnlyWeb } from '../../lib/utils/platform'
 import { getMaxDeviceHeight } from '../../lib/utils/Orientation'
 import useNativeSharing from '../../lib/hooks/useNativeSharing'
 import { fireEvent } from '../../lib/analytics/analytics'
 import GDStore from '../../lib/undux/GDStore'
-import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import goodWallet from '../../lib/wallet/GoodWallet'
 import { PushButton } from '../appNavigation/PushButton'
 import { CopyButton, CustomButton, QRCode, ReceiveToAddressButton, ScanQRButton, Section, Wrapper } from '../common'
@@ -28,8 +27,7 @@ const SHARE_TEXT = 'Receive via wallet link'
 const Receive = ({ screenProps, styles }: ReceiveProps) => {
   const profile = GDStore.useStore().get('profile')
   const { account, networkId } = goodWallet
-  const [showErrorDialog] = useErrorDialog()
-  const { canShare, generateCode, generateReceiveShareObject } = useNativeSharing()
+  const { canShare, generateCode, generateReceiveShareObject, shareAction } = useNativeSharing()
   const amount = 0
   const reason = ''
   const codeObj = useMemo(() => generateCode(account, networkId, amount, reason), [account, networkId, amount, reason])
@@ -38,17 +36,12 @@ const Receive = ({ screenProps, styles }: ReceiveProps) => {
     profile.fullName,
     amount,
   ])
+
   const shareLink = useMemo(() => share.message + ' ' + share.url, [share])
-  const shareAction = useCallback(async () => {
-    try {
-      fireEvent('RECEIVE_DONE', { type: 'wallet' })
-      await Share.share(share)
-    } catch (e) {
-      if (e.name !== 'AbortError') {
-        showErrorDialog(e)
-      }
-    }
-  }, [showErrorDialog, share])
+
+  const shareHandler = useCallback(() => {
+    shareAction(share)
+  }, [shareAction, share])
 
   const onPressScanQRButton = useCallback(() => screenProps.push('ReceiveByQR'), [screenProps])
 
@@ -92,7 +85,7 @@ const Receive = ({ screenProps, styles }: ReceiveProps) => {
           </PushButton>
           <View style={styles.space} />
           {canShare ? (
-            <CustomButton onPress={shareAction}>{SHARE_TEXT}</CustomButton>
+            <CustomButton onPress={shareHandler}>{SHARE_TEXT}</CustomButton>
           ) : (
             <CopyButton
               style={styles.shareButton}

--- a/src/components/dashboard/Receive.js
+++ b/src/components/dashboard/Receive.js
@@ -39,15 +39,16 @@ const Receive = ({ screenProps, styles }: ReceiveProps) => {
 
   const shareLink = useMemo(() => share.message + ' ' + share.url, [share])
 
+  const fireReceiveDoneEvent = useCallback(() => fireEvent('RECEIVE_DONE', { type: 'wallet' }), [])
+
   const shareHandler = useCallback(() => {
     shareAction(share)
+    fireReceiveDoneEvent()
   }, [shareAction, share])
 
   const onPressScanQRButton = useCallback(() => screenProps.push('ReceiveByQR'), [screenProps])
 
   const onPressReceiveToAddressButton = useCallback(() => screenProps.push('ReceiveToAddress'), [screenProps])
-
-  const onPressCopyButton = () => fireEvent('RECEIVE_DONE', { type: 'wallet' })
 
   return (
     <Wrapper>
@@ -90,7 +91,7 @@ const Receive = ({ screenProps, styles }: ReceiveProps) => {
             <CopyButton
               style={styles.shareButton}
               toCopy={shareLink}
-              onPress={onPressCopyButton}
+              onPress={fireReceiveDoneEvent}
               onPressDone={screenProps.goToRoot}
             >
               {SHARE_TEXT}

--- a/src/components/dashboard/ReceiveConfirmation.js
+++ b/src/components/dashboard/ReceiveConfirmation.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { useCallback, useMemo } from 'react'
-import { Share } from 'react-native'
 import { fireEvent } from '../../lib/analytics/analytics'
 import Clipboard from '../../lib/utils/Clipboard'
 import GDStore from '../../lib/undux/GDStore'
@@ -14,7 +13,6 @@ import useNativeSharing from '../../lib/hooks/useNativeSharing'
 
 import { useScreenState } from '../appNavigation/stackNavigation'
 import { withStyles } from '../../lib/styles'
-import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import { navigationOptions } from './utils/sendReceiveFlow'
 
 export type ReceiveProps = {
@@ -25,9 +23,15 @@ export type ReceiveProps = {
 
 const ReceiveConfirmation = ({ screenProps, styles }: ReceiveProps) => {
   const profile = GDStore.useStore().get('profile')
-  const [showErrorDialog] = useErrorDialog()
   const [screenState] = useScreenState(screenProps)
-  const { canShare, generateReceiveShareObject, generateReceiveShareText, generateShareLink } = useNativeSharing()
+  const { goToRoot, push } = screenProps
+  const {
+    canShare,
+    shareAction,
+    generateReceiveShareObject,
+    generateReceiveShareText,
+    generateShareLink,
+  } = useNativeSharing()
   const { amount, code, reason, counterPartyDisplayName } = screenState
 
   const share = useMemo(() => {
@@ -41,32 +45,22 @@ const ReceiveConfirmation = ({ screenProps, styles }: ReceiveProps) => {
     return generateShareLink('receive', code)
   }, [code, generateShareLink])
 
-  const shareActionPressHandler = useCallback(async () => {
-    let executeShare
-
+  const sharePressHandler = useCallback(() => {
     if (canShare) {
-      executeShare = Share.share
+      shareAction(share)
     } else {
-      executeShare = Clipboard.setString
+      Clipboard.setString(share)
     }
+  }, [canShare, share, shareAction])
 
-    try {
-      await executeShare(share)
-    } catch (e) {
-      if (e.name !== 'AbortError') {
-        showErrorDialog('Sorry, there was an error sharing you link. Please try again later.')
-      }
-    }
-  }, [canShare, showErrorDialog])
-
-  const shareActionDonePressHandler = useCallback(() => {
+  const shareDonePressHandler = useCallback(() => {
     fireEvent('RECEIVE_DONE', { type: 'link' })
-    screenProps.goToRoot()
-  }, [screenProps])
+    goToRoot()
+  }, [goToRoot])
 
   return (
     <Wrapper>
-      <TopBar push={screenProps.push} />
+      <TopBar push={push} />
       <Section justifyContent="space-between" grow>
         <Section.Stack justifyContent="space-evenly" grow>
           <Section.Stack style={styles.qrCode}>
@@ -86,10 +80,7 @@ const ReceiveConfirmation = ({ screenProps, styles }: ReceiveProps) => {
           </Section.Stack>
         </Section.Stack>
         <Section.Stack>
-          <ShareLinkReceiveAnimationButton
-            onPress={shareActionPressHandler}
-            onPressDone={shareActionDonePressHandler}
-          />
+          <ShareLinkReceiveAnimationButton onPress={sharePressHandler} onPressDone={shareDonePressHandler} />
         </Section.Stack>
       </Section>
     </Wrapper>

--- a/src/components/dashboard/TransactionConfirmation.js
+++ b/src/components/dashboard/TransactionConfirmation.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useCallback, useMemo } from 'react'
-import { Image, Share, View } from 'react-native'
+import { Image, View } from 'react-native'
 import { useScreenState } from '../appNavigation/stackNavigation'
 import useNativeSharing from '../../lib/hooks/useNativeSharing'
 import Section from '../common/layout/Section'
@@ -36,7 +36,7 @@ const instructionsTextNumberProps = {
 }
 
 const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
-  const { canShare } = useNativeSharing()
+  const { canShare, shareAction } = useNativeSharing()
   const { goToRoot } = screenProps
   const [screenState] = useScreenState(screenProps)
   const { paymentLink, action } = screenState
@@ -45,7 +45,7 @@ const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
     let type = 'share'
 
     if (canShare) {
-      Share.share(paymentLink)
+      shareAction(paymentLink)
       goToRoot()
     } else {
       type = 'copy'
@@ -53,7 +53,7 @@ const TransactionConfirmation = ({ screenProps, styles }: ReceiveProps) => {
     }
 
     fireEvent('SEND_CONFIRMATION_SHARE', { type })
-  }, [canShare, paymentLink, goToRoot])
+  }, [canShare, paymentLink, goToRoot, shareAction])
 
   const secondTextPoint = action === ACTION_SEND ? 'Share it with your recipient' : 'Share it with sender'
   const thirdTextPoint = action === ACTION_SEND ? 'Recipient approves request' : 'Sender approves request'

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -22,7 +22,7 @@ const Config = {
   market: process.env.REACT_APP_MARKET === 'true' || isEToro,
   marketUrl: process.env.REACT_APP_MARKET_URL || 'https://etoro.paperclip.co',
   torusEnabled: process.env.REACT_APP_USE_TORUS === 'true',
-  enableSelfCustody: process.env.REACT_APP_ENABLE_SELF_CUSTODY === 'true',
+  enableSelfCustody: process.env.REACT_APP_ENABLE_SELF_CUSTODY === 'true' || true,
   googleClientId: process.env.REACT_APP_GOOGLE_CLIENT_ID,
   facebookAppId: process.env.REACT_APP_FACEBOOK_APP_ID,
   enableInvites: process.env.REACT_APP_ENABLE_INVITES !== 'false' || isEToro, // true by default

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -22,7 +22,7 @@ const Config = {
   market: process.env.REACT_APP_MARKET === 'true' || isEToro,
   marketUrl: process.env.REACT_APP_MARKET_URL || 'https://etoro.paperclip.co',
   torusEnabled: process.env.REACT_APP_USE_TORUS === 'true',
-  enableSelfCustody: process.env.REACT_APP_ENABLE_SELF_CUSTODY === 'true' || true,
+  enableSelfCustody: process.env.REACT_APP_ENABLE_SELF_CUSTODY === 'true',
   googleClientId: process.env.REACT_APP_GOOGLE_CLIENT_ID,
   facebookAppId: process.env.REACT_APP_FACEBOOK_APP_ID,
   enableInvites: process.env.REACT_APP_ENABLE_INVITES !== 'false' || isEToro, // true by default

--- a/src/lib/hooks/useNativeSharing.js
+++ b/src/lib/hooks/useNativeSharing.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import canShare from '../../lib/utils/canShare'
 import {
   generateCode,
@@ -6,11 +7,22 @@ import {
   generateSendShareObject,
   generateSendShareText,
   generateShareLink,
-} from '../../lib/share'
+  shareAction as importedShareAction,
+} from '../../lib/share/index'
+import { useErrorDialog } from '../undux/utils/dialog'
 
 const _canShare = canShare()
 
 export default () => {
+  const [showErrorDialog] = useErrorDialog()
+
+  const _shareAction = useCallback(
+    (shareObj, customErrorMessage) => {
+      importedShareAction(shareObj, showErrorDialog, customErrorMessage)
+    },
+    [showErrorDialog]
+  )
+
   return {
     canShare: _canShare,
     generateReceiveShareObject,
@@ -19,5 +31,6 @@ export default () => {
     generateSendShareObject,
     generateSendShareText,
     generateShareLink,
+    shareAction: _shareAction,
   }
 }

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { Share } from 'react-native'
 import { fromPairs, isEmpty } from 'lodash'
 import { decode, encode, isMNID } from 'mnid'
 import isURL from 'validator/lib/isURL'
@@ -231,4 +232,18 @@ export function generateShareLink(action: ActionType = 'receive', params: {} = {
   }
 
   return encodeURI(`${destination}${queryParams}`)
+}
+
+export function shareAction(shareObj, showErrorDialog, customErrorMessage) {
+  try {
+    Share.share(shareObj)
+  } catch (e) {
+    if (e.name !== 'AbortError') {
+      showErrorDialog(customErrorMessage || 'Sorry, there was an error sharing you link. Please try again later.')
+
+      log.error('Native share failed', e.message, e, {
+        shareObj,
+      })
+    }
+  }
 }


### PR DESCRIPTION
# Description

Move shareAction fn to useNativeShare hook and use it in places where Share.share took place.

About #1743 

# How Has This Been Tested?

The 'AbortError: Share canceled' error messages shouldn't be logged to the sentry.io. All copy to clipboard and share (mobile) functionality should work well.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
