### PR TITLE
#1785 torus email can be empty

### DIFF
--- a/src/components/auth/AuthTorus.js
+++ b/src/components/auth/AuthTorus.js
@@ -83,9 +83,10 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
       let replacing = false
 
       try {
-        if (config.env === 'test') {
+        if (['development', 'test'].includes(config.env)) {
           torusUser = await AsyncStorage.getItem('TorusTestUser').then(JSON.parse)
-        } else {
+        }
+        if (torusUser === undefined) {
           switch (provider) {
             case 'facebook':
               torusUser = await torusSDK.triggerLogin('facebook', 'facebook-gooddollar')

--- a/src/components/signup/SignupState.js
+++ b/src/components/signup/SignupState.js
@@ -79,8 +79,7 @@ const Signup = ({ navigation }: { navigation: any, screenProps: any }) => {
   const [regMethod] = useState(_regMethod)
   const [torusProvider] = useState(_torusProvider)
   const isRegMethodSelfCustody = regMethod === REGISTRATION_METHOD_SELF_CUSTODY
-  const isW3User = w3UserFromProps.email
-  const skipEmail = isRegMethodSelfCustody === false || isW3User
+  const skipEmail = !!w3UserFromProps.email || !!torusUserFromProps.email
 
   const initialState: SignupState = {
     ...getUserModel({


### PR DESCRIPTION
# Description

changed the skipEmail condition to check if email received from torus/w3 is non empty

About #1785


# How Has This Been Tested?
copy credentials of some torusUser (modify private key so you are not signed in)
delete email field or set it empty string
open console do localStorage.setItem('TorusTestUser',torusUser)
press login with facebook/google
it will take you through the signup process and ask for email
