### PR TITLE
(Bug) #1801 The recipient can't get the G$ via a link from sender

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -216,7 +216,8 @@ const Dashboard = props => {
   }
 
   const handleAppLinks = () => {
-    const anyParams = extractQueryParams(window.location.href)
+    const decodedHref = decodeURI(window.location.href)
+    const anyParams = extractQueryParams(decodedHref)
 
     log.debug('handle links effect dashboard', { anyParams })
 


### PR DESCRIPTION
# Description

Decode browser address line before fetching its params to fetch the exact sender code.

About #1801 

# How Has This Been Tested?

Send G$ link should work fine. The error shouldn't appear for a receiver while applying the withdrawal link.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
