### PR TITLE
(Bug) #1797 Verify email the long email is displayed outside screen on edit profile page

### DIFF
--- a/src/components/profile/VerifyEdit.js
+++ b/src/components/profile/VerifyEdit.js
@@ -78,7 +78,7 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
           </View>
         </Section.Row>
         <Section.Row alignItems="center" justifyContent="center" style={[styles.row, styles.descriptionWrap]}>
-          <View style={styles.bottomContainer}>
+          <View style={[styles.bottomContainer, styles.width100p]}>
             <Text fontSize={14} lineHeight={16} fontFamily="Roboto" color="gray80Percent">
               {`A verification code will be sent to this ${sendToText}:`}
             </Text>
@@ -127,6 +127,9 @@ const getStylesFromProps = ({ theme }) => ({
   cancelButton: {
     width: '28%',
     fontSize: normalize(14),
+  },
+  width100p: {
+    width: '100%',
   },
 })
 

--- a/src/components/profile/__tests__/__snapshots__/VerifyEdit.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/VerifyEdit.js.snap
@@ -135,6 +135,11 @@ email again…
       >
         <div
           className="css-view-1dbjc4n"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
         >
           <div
             className="css-text-901oao"


### PR DESCRIPTION
# Description

fix width for text container in VerifyEdit.js

About #1797 

# How Has This Been Tested?

The long email will be split into 2 lines.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
<img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/81405210-e047f200-913f-11ea-9dcd-30558cc39308.png">
