### PR TITLE
(Bug) #1840 The "Successful" animation is overlapped by header after saving edited profile

### DIFF
--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -1,8 +1,8 @@
 // @flow
 import React, { useCallback, useEffect, useState } from 'react'
 import { View } from 'react-native'
+import { isBrowser } from 'mobile-device-detect'
 import { debounce, isEqual, isEqualWith, merge, pickBy } from 'lodash'
-
 import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
 import GDStore from '../../lib/undux/GDStore'
@@ -213,10 +213,10 @@ const getStylesFromProps = ({ theme }) => {
   return {
     animatedSaveButton: {
       position: 'absolute',
-      width: 120,
-      height: 60,
-      top: 0,
-      right: -24,
+      width: isBrowser ? 110 : 100,
+      height: 50,
+      top: 17,
+      right: -10,
       marginVertical: 0,
       display: 'flex',
       justifyContent: 'flex-end',

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { useCallback, useEffect, useState } from 'react'
 import { View } from 'react-native'
-import { isBrowser } from 'mobile-device-detect'
 import { debounce, isEqual, isEqualWith, merge, pickBy } from 'lodash'
 import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
@@ -12,7 +11,7 @@ import { Section, UserAvatar, Wrapper } from '../common'
 import SaveButton from '../common/animations/SaveButton/SaveButton'
 import SaveButtonDisabled from '../common/animations/SaveButton/SaveButtonDisabled'
 import { fireEvent, PROFILE_UPDATE } from '../../lib/analytics/analytics'
-import { getDesignRelativeWidth } from '../../lib/utils/sizes'
+import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
 import CameraButton from './CameraButton'
 import ProfileDataTable from './ProfileDataTable'
 
@@ -213,9 +212,9 @@ const getStylesFromProps = ({ theme }) => {
   return {
     animatedSaveButton: {
       position: 'absolute',
-      width: isBrowser ? 110 : 100,
+      width: getDesignRelativeWidth(110),
       height: 50,
-      top: 17,
+      top: getDesignRelativeHeight(198),
       right: -10,
       marginVertical: 0,
       display: 'flex',


### PR DESCRIPTION
# Description

Fix position styles for save button on the edit profile page.

About #1840 

# How Has This Been Tested?

open edit profile page and press save button - see the animation. It shouldn't be cut.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video: https://www.screencast.com/t/G7ntbOysGHsY