### PR TITLE
(Bug) #1838 Edit profile: The user can't get the verification code on the email

### DIFF
--- a/src/components/profile/VerifyEditCode.js
+++ b/src/components/profile/VerifyEditCode.js
@@ -21,14 +21,14 @@ const VerifyEditCode = props => {
   switch (field) {
     case 'phone':
       fieldToSave = 'mobile'
-      retryFunctionName = 'sendNewOTP'
+      retryFunctionName = 'sendOTP'
       RenderComponent = SmsForm
       break
 
     case 'email':
     default:
       fieldToSave = 'email'
-      retryFunctionName = 'sendVerificationForNewEmail'
+      retryFunctionName = 'sendVerificationEmail'
       RenderComponent = EmailConfirmation
       break
   }


### PR DESCRIPTION
# Description

Fix resend function names

About #1838 

# How Has This Been Tested?

Resend email and phone number should work fine while editing it on the edit profile page.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
