### PR TITLE
(Bug) #1814 Send confirmation is not immediate

### DIFF
--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -119,10 +119,9 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
     }
   }, [setLoading, address, amount, reason, showDialog, showErrorDialog])
 
-  const sendViaLink = useCallback(async () => {
+  const sendViaLink = useCallback(() => {
     try {
-      setLoading(true)
-      let paymentLink = await getLink()
+      const paymentLink = getLink()
 
       const desktopShareLink = (canShare ? generateSendShareObject : generateSendShareText)(
         paymentLink,
@@ -141,7 +140,7 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
    * Generates link to send and call send email/sms action
    * @throws Error if link cannot be send
    */
-  const getLink = useCallback(async () => {
+  const getLink = useCallback(() => {
     if (link) {
       return link
     }
@@ -194,38 +193,29 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
     if (generateLinkResponse) {
       const { txPromise, paymentLink } = generateLinkResponse
 
-      const promiseRes = await txPromise
-        .then(() => ({ ok: 1 }))
-        .catch(e => {
-          log.error('generateLinkAndSend:', e.message, e)
+      txPromise.catch(e => {
+        log.error('generateLinkAndSend:', e.message, e)
 
-          showErrorDialog('Link generation failed. Please try again', '', {
-            buttons: [
-              {
-                text: 'Try again',
-                onPress: dismiss => {
-                  handleConfirm()
-                  hideDialog()
-                },
+        showErrorDialog('Link generation failed. Please try again', '', {
+          buttons: [
+            {
+              text: 'Try again',
+              onPress: () => {
+                hideDialog()
+                screenProps.navigateTo('SendLinkSummary', { amount, reason, counterPartyDisplayName })
               },
-            ],
-            onDismiss: () => {
-              goToRoot()
             },
-          })
-
-          return {
-            ok: 0,
-          }
+          ],
+          onDismiss: () => {
+            goToRoot()
+          },
         })
+      })
 
-      if (promiseRes && promiseRes.ok) {
-        setLink(paymentLink)
-
-        return paymentLink
-      }
+      setLink(paymentLink)
+      return paymentLink
     }
-  }, [amount, reason, counterPartyDisplayName, survey, showErrorDialog, setLink, link, goToRoot])
+  }, [screenProps, survey, showErrorDialog, setLink, link, goToRoot])
 
   return (
     <Wrapper>


### PR DESCRIPTION
Fixes send payment link to be immediate

# Description

1. Don't awaiting txPromise, just .catch'ing it async, showing an error popup (as before)(
2. Bon when 'Try again' pressed, we're redirecting back (as the Share screen is now shown, after the link was immediately generated) to the send confirmation screen passing initial incoming data (amount and reason) 

About #1814  (link your issue here)

# How Has This Been Tested?

- modify transactionEvent in the code to be invalid
- generate payment link
- you should pass on share screen, but then error popup should appear
- when you're pressing on 'retry' you should be redirected back, your last reason & amount entered should be kept

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
