### PR TITLE
(Bug) #1704 Profile - Edit: Phone input field not loaded well

### DIFF
--- a/src/components/profile/PhoneInput.css
+++ b/src/components/profile/PhoneInput.css
@@ -1,4 +1,6 @@
-.react-phone-number-input {
+@import url('~react-phone-number-input/style.css');
+
+.edit_profile_phone_input .react-phone-number-input {
   width: 100% !important;
   padding: 2px !important;
   border-radius: 24px;
@@ -6,7 +8,7 @@
   flex-grow: 1;
 }
 
-.react-phone-number-input__input {
+.edit_profile_phone_input .react-phone-number-input__input {
   height: 36px;
   background: transparent;
   border-width: 0;
@@ -16,27 +18,27 @@
   color: #000;
 }
 
-.react-phone-number-input__input.react-phone-number-input__input--invalid {
+.edit_profile_phone_input .react-phone-number-input__input.react-phone-number-input__input--invalid {
   color: #fa6c77;
 }
 
-.react-phone-number-input__icon {
+.edit_profile_phone_input .react-phone-number-input__icon {
   border-radius: 2px;
 }
 
-.react-phone-number-input__country--native {
+.edit_profile_phone_input .react-phone-number-input__country--native {
   margin: auto 3px;
 }
 
-.react-phone-number-input__row .react-phone-number-input__input {
+.edit_profile_phone_input .react-phone-number-input__row .react-phone-number-input__input {
   border-bottom: 0 !important;
 }
 
-.react-phone-number-input__input:-webkit-autofill {
+.edit_profile_phone_input .react-phone-number-input__input:-webkit-autofill {
   box-shadow: none;
 }
 
-.react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error,
-.react-phone-number-input__error {
+.edit_profile_phone_input .react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error,
+.edit_profile_phone_input .react-phone-number-input__error {
   display: none !important;
 }

--- a/src/components/profile/ProfileDataTable.js
+++ b/src/components/profile/ProfileDataTable.js
@@ -4,7 +4,6 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import PhoneInput from 'react-phone-number-input'
 import { noop } from 'lodash'
 import { parsePhoneNumberFromString } from 'libphonenumber-js'
-import './ProfileDataTablePhoneInput.css'
 import useCountryFlagUrl from '../../lib/hooks/useCountryFlagUrl'
 import Icon from '../common/view/Icon'
 import InputRounded from '../common/form/InputRounded'
@@ -96,7 +95,7 @@ const ProfileDataTable = ({
         <Section.Row>
           {editable ? (
             <Section.Stack grow>
-              <Section.Row>
+              <Section.Row className="edit_profile_phone_input">
                 <PhoneInput
                   error={errors.mobile && errors.mobile !== ''}
                   id="signup_phone"

--- a/src/components/profile/ProfileDataTablePhoneInput.css
+++ b/src/components/profile/ProfileDataTablePhoneInput.css
@@ -1,5 +1,0 @@
-@import url('~react-phone-number-input/style.css');
-
-.react-phone-number-input {
-  padding: 12px 2px !important;
-}

--- a/src/components/profile/__tests__/__snapshots__/ProfileDataTable.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/ProfileDataTable.js.snap
@@ -797,7 +797,7 @@ exports[`ProfileDataTable matches snapshot editable 1`] = `
             }
           >
             <div
-              className="css-view-1dbjc4n"
+              className="edit_profile_phone_input edit_profile_phone_input css-view-1dbjc4n"
               style={
                 Object {
                   "WebkitAlignItems": "center",
@@ -2860,7 +2860,7 @@ exports[`ProfileDataTable matches snapshot editable with errors 1`] = `
             }
           >
             <div
-              className="css-view-1dbjc4n"
+              className="edit_profile_phone_input edit_profile_phone_input css-view-1dbjc4n"
               style={
                 Object {
                   "WebkitAlignItems": "center",

--- a/src/components/signup/PhoneForm.css
+++ b/src/components/signup/PhoneForm.css
@@ -1,23 +1,23 @@
 @import url('~react-phone-number-input/style.css');
 
-.react-phone-number-input {
+.signup_phone_input .react-phone-number-input {
   width: 100% !important;
   border: none !important;
   border-radius: 0 !important;
 }
 
-.react-phone-number-input > .react-phone-number-input__row {
+.signup_phone_input .react-phone-number-input > .react-phone-number-input__row {
   margin-bottom: 8px;
 }
 
-.react-phone-number-input
+.signup_phone_input .react-phone-number-input
   > .react-phone-number-input__row
   > .react-phone-number-input__input.react-phone-number-input__phone {
   border-bottom: 1px solid rgb(0, 0, 0) !important;
   margin-bottom: 8px;
 }
 
-.react-phone-number-input
+.signup_phone_input .react-phone-number-input
   > .react-phone-number-input__row
   > .react-phone-number-input__input.react-phone-number-input__phone.react-phone-number-input__input--invalid {
   border-bottom: 1px solid #fa6c77 !important;
@@ -25,11 +25,11 @@
   border-color: #fa6c77;
 }
 
-.react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error {
+.signup_phone_input .react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error {
   display: none;
 }
 
-.react-phone-number-input__icon {
+.signup_phone_input .react-phone-number-input__icon {
   border: 0;
   border-radius: 2px;
   width: 1.85em;

--- a/src/components/signup/PhoneForm.web.js
+++ b/src/components/signup/PhoneForm.web.js
@@ -119,7 +119,7 @@ class PhoneForm extends React.Component<Props, State> {
                 {`${getFirstWord(fullName)},\nenter your phone number\nso we can verify its you`}
               </Section.Title>
             </Section.Row>
-            <Section.Stack justifyContent="center" style={styles.column}>
+            <Section.Stack className="signup_phone_input" justifyContent="center" style={styles.column}>
               <PhoneInput
                 id={key + '_input'}
                 value={this.state.mobile}

--- a/src/components/signup/__tests__/__snapshots__/PhoneForm.web.js.snap
+++ b/src/components/signup/__tests__/__snapshots__/PhoneForm.web.js.snap
@@ -179,7 +179,7 @@ so we can verify its you
               </div>
             </div>
             <div
-              className="css-view-1dbjc4n"
+              className="signup_phone_input signup_phone_input css-view-1dbjc4n"
               style={
                 Object {
                   "WebkitAlignItems": "stretch",


### PR DESCRIPTION
# Description

Add specific classes for different phone input style variants. Remove unnecessary CSS file and move its content to another usable CSS file.

About #1704 

# How Has This Been Tested?

The phone input styles should be loaded correctly each time.

P. S.
It could be reproduced in case you register a new account and go to edit profile without page reload.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
