### PR TITLE
(Bug) #1777 The text is displayed behind the icon and breaks the border in the "14-day claim" card

### DIFF
--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -152,15 +152,11 @@ const FeedText = withStyles(getFeedTextStyles)(({ styles, feed, isSmallDevice })
     //if readMore is exactly false we dont show anything
     result = ''
   } else {
-    switch (feed.type) {
-      default:
-        result = (
-          <Text numberOfLines={1} color="gray80Percent" fontSize={10} textTransform="capitalize" style={styles.message}>
-            {feed.data.message}
-          </Text>
-        )
-        break
-    }
+    result = (
+      <Text numberOfLines={1} color="gray80Percent" fontSize={10} textTransform="capitalize" style={styles.message}>
+        {feed.data.message}
+      </Text>
+    )
   }
 
   return result

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -243,7 +243,7 @@ export const longUseOfClaims = {
   data: {
     customName: 'Woohoo! You’ve made it!', //title in modal
     subtitle: 'Woohoo! You’ve made it!',
-    readMore: 'Congrats! You claimed G$ for 14 days',
+    smallReadMore: 'Congrats! You claimed G$ for 14 days',
     receiptData: {
       from: '0x0000000000000000000000000000000000000000',
     },
@@ -1587,7 +1587,17 @@ export class UserStorage {
 
     try {
       const { data, type, date, id, status, createdDate, animationExecuted, action } = event
-      const { sender, preReasonText, reason, code: withdrawCode, otplStatus, customName, subtitle, readMore } = data
+      const {
+        sender,
+        preReasonText,
+        reason,
+        code: withdrawCode,
+        otplStatus,
+        customName,
+        subtitle,
+        readMore,
+        smallReadMore,
+      } = data
 
       const { address, initiator, initiatorType, value, displayName, message } = this._extractData(event)
       const withdrawStatus = this._extractWithdrawStatus(withdrawCode, otplStatus, status, type)
@@ -1638,7 +1648,7 @@ export class UserStorage {
           },
           amount: value,
           preMessageText: preReasonText,
-          message: reason || message,
+          message: smallReadMore || reason || message,
           subtitle,
           readMore,
           withdrawCode,


### PR DESCRIPTION
# Description

Add option to use small read more text. Make read more text for '14 days claim' card small.

About #1777 

# How Has This Been Tested?

14 days claim card read more text should be small.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
<img width="473" alt="1" src="https://user-images.githubusercontent.com/49862004/82317419-e4dd9780-99d6-11ea-9f5d-dd86a5f514e4.png">
