### PR TITLE
(Bug) #1873 The numeric keyboard is narrowed after entering the value on the "How much?" page

### DIFF
--- a/src/components/common/view/AmountInput.js
+++ b/src/components/common/view/AmountInput.js
@@ -69,7 +69,7 @@ const mapPropsToStyles = ({ theme }) => {
       flex: 1,
     },
     section: {
-      marginTop: 'auto',
+      marginTop: getDesignRelativeHeight(34, false),
     },
     container: {
       minHeight: getDesignRelativeHeight(180),

--- a/src/components/common/view/__tests__/__snapshots__/AmountInput.js.snap
+++ b/src/components/common/view/__tests__/__snapshots__/AmountInput.js.snap
@@ -122,7 +122,7 @@ exports[`AmountInput matches snapshot 1`] = `
                 "fontSize": "32px",
                 "fontWeight": "bold",
                 "letterSpacing": "1.2px",
-                "marginTop": "auto",
+                "marginTop": "42.38961038961039px",
                 "msTouchAction": "manipulation",
                 "paddingBottom": "4px",
                 "paddingLeft": "32px",

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -1,8 +1,5 @@
 // @flow
 import React, { useCallback, useEffect } from 'react'
-import { Keyboard } from 'react-native-web'
-import { delay } from 'rxjs/operators'
-import { isAndroidNative, isAndroidWeb } from '../../lib/utils/platform'
 import InputText from '../common/form/InputText'
 import { ScanQRButton, Section, SendToAddressButton, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
@@ -28,6 +25,7 @@ const getError = value => {
 const Who = (props: AmountProps) => {
   const { screenProps, styles } = props
   const [screenState, setScreenState] = useScreenState(screenProps)
+  const { push } = screenProps
   const { params } = props.navigation.state
   const isReceive = params && params.action === ACTION_RECEIVE
   const { counterPartyDisplayName } = screenState
@@ -39,43 +37,22 @@ const Who = (props: AmountProps) => {
     setScreenState({ counterPartyDisplayName: state.value })
   }, [state.value])
 
-  const handlePressQR = useCallback(() => screenProps.push('SendByQR'), [screenProps])
+  const handlePressQR = useCallback(() => push('SendByQR'), [push])
 
   const handlePressSendToAddress = useCallback(
     () =>
-      screenProps &&
-      screenProps.push('SendToAddress', {
+      push('SendToAddress', {
         nextRoutes: ['Amount', 'Reason', 'SendLinkSummary'],
         params: { action: ACTION_SEND_TO_ADDRESS },
       }),
-    [screenProps]
+    [push]
   )
 
-  const canContinue = useCallback(async () => {
-    // =====
-    // await for android keyboard to be closed before redirecting to the next step
-    if (isAndroidNative) {
-      await new Promise(res => {
-        Keyboard.addListener('keyboardDidHide', res)
-        Keyboard.dismiss()
-      })
-    }
-
-    if (isAndroidWeb) {
-      await new Promise(res => {
-        delay(300)
-        res()
-      })
-    }
-
-    // =====
-
-    return state.isValid
-  }, [state])
+  const canContinue = useCallback(() => state.isValid, [state])
 
   return (
     <Wrapper>
-      <TopBar push={screenProps.push}>
+      <TopBar push={push}>
         {!isReceive && <ScanQRButton onPress={handlePressQR} />}
         {!isReceive && <SendToAddressButton onPress={handlePressSendToAddress} />}
       </TopBar>

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -1,6 +1,8 @@
 // @flow
 import React, { useCallback, useEffect } from 'react'
-import { Keyboard } from 'react-native'
+import { Keyboard } from 'react-native-web'
+import { delay } from 'rxjs/operators'
+import { isAndroidNative, isAndroidWeb } from '../../lib/utils/platform'
 import InputText from '../common/form/InputText'
 import { ScanQRButton, Section, SendToAddressButton, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
@@ -50,7 +52,23 @@ const Who = (props: AmountProps) => {
   )
 
   const canContinue = useCallback(async () => {
-    await Keyboard.dismiss()
+    // =====
+    // await for android keyboard to be closed before redirecting to the next step
+    if (isAndroidNative) {
+      await new Promise(res => {
+        Keyboard.addListener('keyboardDidHide', res)
+        Keyboard.dismiss()
+      })
+    }
+
+    if (isAndroidWeb) {
+      await new Promise(res => {
+        delay(300)
+        res()
+      })
+    }
+
+    // =====
 
     return state.isValid
   }, [state])

--- a/src/components/dashboard/Who.js
+++ b/src/components/dashboard/Who.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useCallback, useEffect } from 'react'
-
+import { Keyboard } from 'react-native'
 import InputText from '../common/form/InputText'
 import { ScanQRButton, Section, SendToAddressButton, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
@@ -49,6 +49,12 @@ const Who = (props: AmountProps) => {
     [screenProps]
   )
 
+  const canContinue = useCallback(async () => {
+    await Keyboard.dismiss()
+
+    return state.isValid
+  }, [state])
+
   return (
     <Wrapper>
       <TopBar push={screenProps.push}>
@@ -79,7 +85,7 @@ const Who = (props: AmountProps) => {
               {...props}
               nextRoutes={screenState.nextRoutes}
               values={{ params, counterPartyDisplayName: state.value }}
-              canContinue={() => state.isValid}
+              canContinue={canContinue}
               label={state.value || !isReceive ? 'Next' : 'Skip'}
               disabled={!state.isValid}
             />

--- a/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Amount.js.snap
@@ -352,7 +352,7 @@ exports[`Amount matches snapshot 1`] = `
                       "fontSize": "32px",
                       "fontWeight": "bold",
                       "letterSpacing": "1.2px",
-                      "marginTop": "auto",
+                      "marginTop": "42.38961038961039px",
                       "msTouchAction": "manipulation",
                       "paddingBottom": "4px",
                       "paddingLeft": "32px",


### PR DESCRIPTION
# Description

Await for the keyboard to be closed on android devices before redirecting to the next step while trying to send/receive G$. It prevents the next step screen to be resized what causes the unexpected layout changes. The android resizes the layout while keyboard is opened/closed.

About #1873 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
