### PR TITLE
(Chore) Unload zoom on success

### DIFF
--- a/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
+++ b/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
@@ -65,7 +65,7 @@ export const unloadZoomSDK = async (logger = log) => {
     await ZoomSDK.unload()
 
     ZoomGlobalState.zoomSDKPreloaded = false
-    logger.debug('Zoom SDK is umloaded')
+    logger.debug('Zoom SDK is unloaded')
   } catch (exception) {
     const { message } = exception
 

--- a/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
+++ b/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
@@ -15,9 +15,9 @@ const ZoomGlobalState = {
 
 /**
  * ZoomSDK preloading helper
- * Preloads SDK and longs success/failiure stage
+ * Preloads SDK and longs success/failiure state
  *
- * @param {Object} logger Custom Pino logger chuld instance to use for logging
+ * @param {Object} logger Custom Pino logger child instance to use for logging
  * @returns {Promise}
  */
 export const preloadZoomSDK = async (logger = log) => {
@@ -42,6 +42,34 @@ export const preloadZoomSDK = async (logger = log) => {
     const { message } = exception
 
     logger.error('preloading zoom failed', message, exception)
+  }
+}
+
+/**
+ * ZoomSDK unloading helper
+ * Unloads SDK and longs success/failiure state
+ *
+ * @param {Object} logger Custom Pino logger child instance to use for logging
+ * @returns {Promise}
+ */
+export const unloadZoomSDK = async (logger = log) => {
+  const { zoomSDKPreloaded } = ZoomGlobalState
+
+  logger.debug('Unloading Zoom SDK')
+
+  try {
+    if (!zoomSDKPreloaded) {
+      return
+    }
+
+    await ZoomSDK.unload()
+
+    ZoomGlobalState.zoomSDKPreloaded = false
+    logger.debug('Zoom SDK is umloaded')
+  } catch (exception) {
+    const { message } = exception
+
+    logger.error('unloading zoom failed', message, exception)
   }
 }
 
@@ -91,8 +119,7 @@ export default ({ onInitialized = noop, onError = noop }) => {
           ZoomGlobalState.zoomUnrecoverableError = exception
 
           // unloading SDK to free resources
-          await ZoomSDK.unload()
-          ZoomGlobalState.zoomSDKPreloaded = false
+          await unloadZoomSDK()
         }
       }
 


### PR DESCRIPTION
# Description

We're unloading Zoom if some unrecoverable error happens (e.g. incompatible device or license expired). It would be good to unload Zoom for free resources once verification was successfull too 
# How Has This Been Tested?

"Zoom SDK is unloaded" debug message should appear once verification was successfull

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
