### PR TITLE
(BUG) #1879 The "Edit avatar" page isn't adaptable to size screen 

### DIFF
--- a/src/components/common/form/ImageCropper.web.js
+++ b/src/components/common/form/ImageCropper.web.js
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import Cropper from 'react-cropper'
 import 'cropperjs/dist/cropper.css'
 import './ImageCropper.css'
+import { getDesignRelativeHeight } from '../../../lib/utils/sizes'
 
 const ImageCropper = props => {
   const cropper = useRef()
@@ -10,7 +11,7 @@ const ImageCropper = props => {
     <Cropper
       ref={cropper}
       src={image}
-      style={{ height: 400, width: '100%' }}
+      style={{ height: getDesignRelativeHeight(400), width: '100%' }}
       dragMode="move"
       aspectRatio={1}
       guides={false}


### PR DESCRIPTION
# Description

Make ImageCropper adaptive by device height.

About #1879 

# How Has This Been Tested?

Open edit avatar page on a small device - it should be adaptive view.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
![1](https://user-images.githubusercontent.com/49862004/82436476-8da2fa00-9a9e-11ea-9a36-df4191463cfb.png)
