### PR TITLE
(BUG) #1880 The "Photo camera" and "Delete" icons are not working at once after the first click

### DIFF
--- a/src/components/profile/CameraButton.js
+++ b/src/components/profile/CameraButton.js
@@ -9,12 +9,13 @@ type CameraButtonProps = {
   style?: any,
 }
 
-const CameraButton = ({ handleCameraPress, styles, style }: CameraButtonProps) => (
+const CameraButton = ({ handleCameraPress, styles, style, containerStyle }: CameraButtonProps) => (
   <CircleButtonWrapper
     iconSize={22}
     iconName={'camera'}
     style={[styles.container, style]}
     onPress={handleCameraPress}
+    containerStyle={containerStyle}
   />
 )
 

--- a/src/components/profile/ViewOrUploadAvatar.js
+++ b/src/components/profile/ViewOrUploadAvatar.js
@@ -8,6 +8,7 @@ import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import InputFile from '../common/form/InputFile'
 import logger from '../../lib/logger/pino-logger'
 import { fireEvent, PROFILE_IMAGE } from '../../lib/analytics/analytics'
+import { getDesignRelativeWidth } from '../../lib/utils/sizes'
 import CircleButtonWrapper from './CircleButtonWrapper'
 import CameraButton from './CameraButton'
 
@@ -20,10 +21,18 @@ const ViewOrUploadAvatar = ({ styles, navigation, screenProps }) => {
   const wrappedUserStorage = useWrappedUserStorage()
   const [showErrorDialog] = useErrorDialog()
 
-  const handleCameraPress = useCallback(() => navigation.navigate('EditAvatar'), [navigation])
+  const handleCameraPress = useCallback(
+    event => {
+      event.preventDefault()
+      navigation.navigate('EditAvatar')
+    },
+    [navigation]
+  )
 
   const handleClosePress = useCallback(
     event => {
+      event.preventDefault()
+
       wrappedUserStorage.removeAvatar().catch(e => {
         showErrorDialog('Could not delete image. Please try again.')
         log.error('delete image failed:', e.message, e)
@@ -57,18 +66,23 @@ const ViewOrUploadAvatar = ({ styles, navigation, screenProps }) => {
           {profile.avatar ? (
             <>
               <CircleButtonWrapper
+                containerStyle={styles.closeButtonContainer}
                 style={styles.closeButton}
                 iconName={'trash'}
                 iconSize={22}
                 onPress={handleClosePress}
               />
-              <CameraButton style={styles.cameraButton} handleCameraPress={handleCameraPress} />
+              <CameraButton
+                containerStyle={styles.cameraButtonContainer}
+                style={styles.cameraButton}
+                handleCameraPress={handleCameraPress}
+              />
               <UserAvatar profile={profile} style={styles.avatar} size={272} />
             </>
           ) : (
             <>
               <InputFile onChange={handleAddAvatar}>
-                <CameraButton style={styles.cameraButtonNewImg} />
+                <CameraButton containerStyle={styles.cameraButtonNewImgContainer} style={styles.cameraButtonNewImg} />
               </InputFile>
               <InputFile onChange={handleAddAvatar}>
                 <UserAvatar profile={profile} size={272} />{' '}
@@ -92,7 +106,7 @@ ViewOrUploadAvatar.navigationOptions = {
 
 const getStylesFromProps = ({ theme }) => {
   const { defaultDouble, defaultQuadruple } = theme.sizes
-  const buttonGap = -42
+  const buttonGap = getDesignRelativeWidth(-30) / 2
 
   return {
     section: {
@@ -100,6 +114,9 @@ const getStylesFromProps = ({ theme }) => {
       position: 'relative',
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    cameraButtonContainer: {
+      zIndex: 1,
     },
     cameraButton: {
       left: 'auto',
@@ -109,12 +126,18 @@ const getStylesFromProps = ({ theme }) => {
       marginTop: defaultDouble,
       marginRight: buttonGap,
     },
+    cameraButtonNewImgContainer: {
+      zIndex: 1,
+    },
     cameraButtonNewImg: {
       left: 'auto',
       position: 'absolute',
       top: 1,
       right: 1,
       marginRight: buttonGap,
+    },
+    closeButtonContainer: {
+      zIndex: 1,
     },
     closeButton: {
       left: 1,

--- a/src/components/profile/ViewOrUploadAvatar.js
+++ b/src/components/profile/ViewOrUploadAvatar.js
@@ -8,7 +8,6 @@ import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import InputFile from '../common/form/InputFile'
 import logger from '../../lib/logger/pino-logger'
 import { fireEvent, PROFILE_IMAGE } from '../../lib/analytics/analytics'
-import { getDesignRelativeWidth } from '../../lib/utils/sizes'
 import CircleButtonWrapper from './CircleButtonWrapper'
 import CameraButton from './CameraButton'
 
@@ -21,18 +20,10 @@ const ViewOrUploadAvatar = ({ styles, navigation, screenProps }) => {
   const wrappedUserStorage = useWrappedUserStorage()
   const [showErrorDialog] = useErrorDialog()
 
-  const handleCameraPress = useCallback(
-    event => {
-      event.preventDefault()
-      navigation.navigate('EditAvatar')
-    },
-    [navigation]
-  )
+  const handleCameraPress = useCallback(() => navigation.navigate('EditAvatar'), [navigation])
 
   const handleClosePress = useCallback(
     event => {
-      event.preventDefault()
-
       wrappedUserStorage.removeAvatar().catch(e => {
         showErrorDialog('Could not delete image. Please try again.')
         log.error('delete image failed:', e.message, e)
@@ -101,7 +92,7 @@ ViewOrUploadAvatar.navigationOptions = {
 
 const getStylesFromProps = ({ theme }) => {
   const { defaultDouble, defaultQuadruple } = theme.sizes
-  const buttonGap = getDesignRelativeWidth(-30) / 2
+  const buttonGap = -42
 
   return {
     section: {

--- a/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
@@ -157,7 +157,7 @@ exports[`ViewAvatar matches snapshot 1`] = `
                   "height": "42px",
                   "justifyContent": "center",
                   "left": "auto",
-                  "marginRight": "-42.666666666666664px",
+                  "marginRight": "-42px",
                   "msFlexAlign": "center",
                   "msFlexPack": "center",
                   "msTouchAction": "manipulation",

--- a/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
@@ -122,6 +122,11 @@ exports[`ViewAvatar matches snapshot 1`] = `
         >
           <div
             className="css-view-1dbjc4n"
+            style={
+              Object {
+                "zIndex": 1,
+              }
+            }
           >
             <div
               className="css-view-1dbjc4n"
@@ -157,7 +162,7 @@ exports[`ViewAvatar matches snapshot 1`] = `
                   "height": "42px",
                   "justifyContent": "center",
                   "left": "auto",
-                  "marginRight": "-42px",
+                  "marginRight": "-42.666666666666664px",
                   "msFlexAlign": "center",
                   "msFlexPack": "center",
                   "msTouchAction": "manipulation",


### PR DESCRIPTION
# Description

Remove unnecessary prevent default. Increase margin to match the button size.

About #1880 

# How Has This Been Tested?

The camera and trash buttons should. be clickable immediately.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

Video: https://www.screencast.com/t/Fb5G9rnsS