### PR TITLE
(Bug) #1890 The shape of mobile number isn't highlighted in red if the entered number is invalid

### DIFF
--- a/src/components/profile/PhoneInput.css
+++ b/src/components/profile/PhoneInput.css
@@ -8,6 +8,10 @@
   flex-grow: 1;
 }
 
+.edit_profile_phone_input .react-phone-number-input--invalid {
+  border-color: #fa6c77;
+}
+
 .edit_profile_phone_input .react-phone-number-input__input {
   height: 36px;
   background: transparent;


### PR DESCRIPTION
# Description

Fix phone input errored border color.

About #1890 

# How Has This Been Tested?

Got to edit profile
Set the invalid value for phone field
See border color of the phone input

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
<img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/82562310-a33b2100-9b7d-11ea-9bba-9664cf469461.png">
