### PR TITLE
(BUG) #1916 The error message is displayed every time during login or reloading page

### DIFF
--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -1,7 +1,21 @@
 //@flow
 import { AsyncStorage } from 'react-native'
 import Mutex from 'await-mutex'
-import { find, flatten, get, isEqual, keys, maxBy, memoize, merge, orderBy, takeWhile, toPairs, values } from 'lodash'
+import {
+  find,
+  flatten,
+  get,
+  isEqual,
+  isNull,
+  keys,
+  maxBy,
+  memoize,
+  merge,
+  orderBy,
+  takeWhile,
+  toPairs,
+  values,
+} from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 import moment from 'moment'
 import Gun from 'gun'
@@ -1669,10 +1683,10 @@ export class UserStorage {
         const { address, initiator, initiatorType, value, displayName, message } = this._extractData(event)
         const withdrawStatus = this._extractWithdrawStatus(withdrawCode, otplStatus, status, type)
         const displayType = this._extractDisplayType(type, withdrawStatus, status)
-        logger.debug('formatEvent:', event.id, { initiatorType, initiator, address })
-        const profileNode = this._extractProfileToShow(initiatorType, initiator, address)
+        logger.debug('formatEvent: initiator data', event.id, { initiatorType, initiator, address })
+        const profileNode = (await this._extractProfileToShow(initiatorType, initiator, address)) || {}
         const [avatar, fullName] = await Promise.all([
-          this._extractAvatar(type, withdrawStatus, profileNode, address).catch(e => {
+          this._extractAvatar(type, withdrawStatus, profileNode.gunProfile, address).catch(e => {
             logger.warn('formatEvent: failed extractAvatar', e.message, e, {
               type,
               withdrawStatus,
@@ -1681,20 +1695,26 @@ export class UserStorage {
             })
             return undefined
           }),
-          this._extractFullName(customName, profileNode, initiatorType, initiator, type, address, displayName).catch(
-            e => {
-              logger.warn('formatEvent: failed extractFullName', e.message, e, {
-                customName,
-                profileNode,
-                initiatorType,
-                initiator,
-                type,
-                address,
-                displayName,
-              })
-              return undefined
-            }
-          ),
+          this._extractFullName(
+            customName,
+            profileNode.gunProfile,
+            initiatorType,
+            initiator,
+            type,
+            address,
+            displayName
+          ).catch(e => {
+            logger.warn('formatEvent: failed extractFullName', e.message, e, {
+              customName,
+              profileNode: profileNode.gunProfile,
+              initiatorType,
+              initiator,
+              type,
+              address,
+              displayName,
+            })
+            return undefined
+          }),
         ])
 
         return {
@@ -1777,16 +1797,23 @@ export class UserStorage {
     return `${type}${sufix}`
   }
 
-  _extractProfileToShow(initiatorType, initiator, address): Gun {
-    const getProfile = (group, value) =>
-      this.gun
-        .get(group)
-        .get(value)
-        .get('profile')
+  async _extractProfileToShow(initiatorType, initiator, address): Gun {
+    const getProfile = async (group, value) => {
+      // Need to verify if user deleted, otherwise the gun will stuck here and feed wont be displayed
+      // The group will contain null value in case user was deleted
+      const gunGroupIndexValue = this.gun.get(group).get(value)
+      const groupValue = await gunGroupIndexValue.then()
+
+      if (!isNull(groupValue)) {
+        return {
+          gunProfile: gunGroupIndexValue.get('profile'),
+        }
+      }
+    }
 
     const searchField = initiatorType && `by${initiatorType}`
-    const byIndex = searchField && getProfile(`users/${searchField}`, initiator)
-    const byAddress = address && getProfile(`users/bywalletAddress`, address)
+    const byIndex = searchField && (await getProfile(`users/${searchField}`, initiator))
+    const byAddress = address && (await getProfile(`users/bywalletAddress`, address))
 
     // const [profileByIndex, profileByAddress] = await Promise.all([byIndex, byAddress])
 


### PR DESCRIPTION
# Description

Refactor retrieving feed event initiator profile node functionality. Check whether the group value in gun is not null - otherwise, it means the initiator account was deleted.

About #1916 

# How Has This Been Tested?

Send some G$ from account 1 to account 2. Delete any of those accounts - the feed events should be displayed for an existing account.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
