### PR TITLE
(Bug) Redirect to the "Learn more" screen after clicking the "Claim" button at the bottom

### DIFF
--- a/src/components/dashboard/FaceVerification/screens/IntroScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/IntroScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { View } from 'react-native'
 import { isIOS, isMobileSafari } from 'mobile-device-detect'
 import GDStore from '../../../../lib/undux/GDStore'
@@ -11,33 +11,38 @@ import { getFirstWord } from '../../../../lib/utils/getFirstWord'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
 import FaceVerificationSmiley from '../../../common/animations/FaceVerificationSmiley'
+import useMountedState from '../../../../lib/hooks/useMountedState'
 import { isBrowser } from '../../../../lib/utils/platform'
 
 const log = logger.child({ from: 'FaceVerificationIntro' })
 
-const IntroScreen = props => {
+const IntroScreen = ({ styles, screenProps }) => {
   const store = GDStore.useStore()
+  const mountedStateRef = useMountedState()
   const { fullName } = store.get('profile')
-  const { styles } = props
 
-  const isUnsupported = isIOS && isMobileSafari === false
-  const isValid = props.screenProps.screenState && props.screenProps.screenState.isValid
+  const isValid = screenProps.screenState && screenProps.screenState.isValid
   log.debug({ isIOS, isMobileSafari })
-
-  if (isUnsupported) {
-    props.screenProps.navigateTo('FaceVerificationUnsupported', { reason: 'isNotMobileSafari' })
-  }
 
   useEffect(() => {
     if (isValid) {
-      props.screenProps.pop({ isValid: true })
+      screenProps.pop({ isValid: true })
     } else {
       fireEvent('FR_Intro')
     }
   }, [isValid])
 
-  const gotoPrivacyArticle = () => props.screenProps.push('PrivacyArticle')
-  const gotoFR = () => props.screenProps.navigateTo('FaceVerification')
+  const gotoPrivacyArticle = useCallback(() => {
+    if (mountedStateRef.current) {
+      screenProps.push('PrivacyArticle')
+    }
+  }, [screenProps])
+
+  const gotoFR = useCallback(() => {
+    if (mountedStateRef.current) {
+      screenProps.navigateTo('FaceVerification')
+    }
+  }, [screenProps])
 
   return (
     <Wrapper>

--- a/src/components/dashboard/FaceVerification/sdk/UICustomization.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/UICustomization.web.js
@@ -49,9 +49,16 @@ const {
 
 const { element } = initialLoadingAnimationCustomization
 
-// disabling camera permissions help screen
-// (as we have own ErrorScreen with corresponding message)
-UICustomization.enableCameraPermissionsHelpScreen = false
+assignIn(UICustomization, {
+  // disabling camera permissions help screen
+  // (as we have own ErrorScreen with corresponding message)
+  enableCameraPermissionsHelpScreen: false,
+
+  // making Zoom a bit tolerant to the user actions during verification
+  // now any keyboard / focus event won't cancel session due to the context switch
+  // the session should cancels only when app/browser tab switched
+  enableHotKeyProtection: false,
+})
 
 // customizing 'Camera initializing' indicator
 // rendering our animated loading spinner inside Zoom's spinner


### PR DESCRIPTION
# Description

The reason of the bug is overlapping between claim button and learn more link on the FR Intro page
I've added useMountedState and now i'm checking is FRintro still mounted before execute button handlers

Also one small adjustment was added to the Zoom - i've found one interesting customization flag and i hop it could make it more tolerant to the user actions during verification (it could solve a part of the issues QA teams have with Zoom) 

About #1927  (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
