### PR TITLE
(BUG) Redirecting to "Learn more" after clicking the "Contact support" button at the top

### DIFF
--- a/src/components/dashboard/FaceVerification/components/DeviceOrientationError.js
+++ b/src/components/dashboard/FaceVerification/components/DeviceOrientationError.js
@@ -6,6 +6,7 @@ import Separator from '../../../common/layout/Separator'
 import { CustomButton, Section, Wrapper } from '../../../common'
 import illustration from '../../../../assets/FRPortraitModeError.svg'
 
+import useOnPress from '../../../../lib/hooks/useOnPress'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { isMobileOnly } from '../../../../lib/utils/platform'
 import { withStyles } from '../../../../lib/styles'
@@ -14,29 +15,35 @@ if (Platform.OS === 'web') {
   Image.prefetch(illustration)
 }
 
-const DeviceOrientationError = ({ styles, displayTitle, onRetry }) => (
-  <Wrapper>
-    <View style={styles.topContainer}>
-      <Section style={styles.descriptionContainer} justifyContent="space-evenly">
-        <Section.Title fontWeight="medium" textTransform="none">
-          {displayTitle}
-          {',\nplease turn your camera\nto portrait mode'}
-        </Section.Title>
-        <Image source={illustration} resizeMode="contain" style={styles.errorImage} />
-        <Section style={styles.errorSection}>
-          <Separator width={2} />
-          <View style={styles.descriptionWrapper}>
-            <Text color="primary">{'It’s a nice landscape,\nbut we need to see\nyour face only in portrait mode'}</Text>
-          </View>
-          <Separator width={2} />
+const DeviceOrientationError = ({ styles, displayTitle, onRetry }) => {
+  const onRetryPress = useOnPress(onRetry)
+
+  return (
+    <Wrapper>
+      <View style={styles.topContainer}>
+        <Section style={styles.descriptionContainer} justifyContent="space-evenly">
+          <Section.Title fontWeight="medium" textTransform="none">
+            {displayTitle}
+            {',\nplease turn your camera\nto portrait mode'}
+          </Section.Title>
+          <Image source={illustration} resizeMode="contain" style={styles.errorImage} />
+          <Section style={styles.errorSection}>
+            <Separator width={2} />
+            <View style={styles.descriptionWrapper}>
+              <Text color="primary">
+                {'It’s a nice landscape,\nbut we need to see\nyour face only in portrait mode'}
+              </Text>
+            </View>
+            <Separator width={2} />
+          </Section>
         </Section>
-      </Section>
-      <View style={styles.action}>
-        <CustomButton onPress={onRetry}>PLEASE TRY AGAIN</CustomButton>
+        <View style={styles.action}>
+          <CustomButton onPress={onRetryPress}>PLEASE TRY AGAIN</CustomButton>
+        </View>
       </View>
-    </View>
-  </Wrapper>
-)
+    </Wrapper>
+  )
+}
 
 const getStylesFromProps = ({ theme }) => {
   return {

--- a/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
+++ b/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
@@ -6,46 +6,52 @@ import Separator from '../../../common/layout/Separator'
 import { CustomButton, Section, Wrapper } from '../../../common'
 import FaceVerificationErrorSmiley from '../../../common/animations/FaceVerificationErrorSmiley'
 
+import useOnPress from '../../../../lib/hooks/useOnPress'
 import { isMobileOnly } from '../../../../lib/utils/platform'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
 
-const DuplicateFoundError = ({ styles, displayTitle, onRetry }) => (
-  <Wrapper>
-    <View style={styles.topContainer}>
-      <Section style={styles.descriptionContainer} justifyContent="space-evenly">
-        <Section.Title fontWeight="medium" textTransform="none">
-          {displayTitle}
-          {',\nUnfortunately,\nWe found your twin...'}
-        </Section.Title>
-        <Section.Row justifyContent="space-evenly">
-          <View style={styles.halfIllustration}>
-            <FaceVerificationErrorSmiley />
-          </View>
-          <View style={styles.halfIllustration}>
-            <FaceVerificationErrorSmiley />
-          </View>
-        </Section.Row>
-        <Section style={styles.errorSection}>
-          <Separator width={2} />
-          <View style={styles.descriptionWrapper}>
-            <Text color="primary" fontWeight="bold">
-              You can open ONLY ONE account per person.
-            </Text>
-            <Text color="primary">If this is your only active account - please contact our support</Text>
-          </View>
-          <Separator width={2} />
+const DuplicateFoundError = ({ styles, displayTitle, onRetry, screenProps }) => {
+  const onRetryPress = useOnPress(onRetry)
+  const onContactSupport = useOnPress(() => screenProps.navigateTo('Support'), [screenProps])
+
+  return (
+    <Wrapper>
+      <View style={styles.topContainer}>
+        <Section style={styles.descriptionContainer} justifyContent="space-evenly">
+          <Section.Title fontWeight="medium" textTransform="none">
+            {displayTitle}
+            {',\nUnfortunately,\nWe found your twin...'}
+          </Section.Title>
+          <Section.Row justifyContent="space-evenly">
+            <View style={styles.halfIllustration}>
+              <FaceVerificationErrorSmiley />
+            </View>
+            <View style={styles.halfIllustration}>
+              <FaceVerificationErrorSmiley />
+            </View>
+          </Section.Row>
+          <Section style={styles.errorSection}>
+            <Separator width={2} />
+            <View style={styles.descriptionWrapper}>
+              <Text color="primary" fontWeight="bold">
+                You can open ONLY ONE account per person.
+              </Text>
+              <Text color="primary">If this is your only active account - please contact our support</Text>
+            </View>
+            <Separator width={2} />
+          </Section>
         </Section>
-      </Section>
-      <View style={styles.action}>
-        <CustomButton onPress={onRetry} mode="outlined" style={styles.actionsSpace}>
-          CONTACT SUPPORT
-        </CustomButton>
-        <CustomButton onPress={onRetry}>TRY AGAIN</CustomButton>
+        <View style={styles.action}>
+          <CustomButton onPress={onContactSupport} mode="outlined" style={styles.actionsSpace}>
+            CONTACT SUPPORT
+          </CustomButton>
+          <CustomButton onPress={onRetryPress}>TRY AGAIN</CustomButton>
+        </View>
       </View>
-    </View>
-  </Wrapper>
-)
+    </Wrapper>
+  )
+}
 
 const getStylesFromProps = ({ theme }) => {
   return {

--- a/src/components/dashboard/FaceVerification/components/GeneralError.js
+++ b/src/components/dashboard/FaceVerification/components/GeneralError.js
@@ -6,37 +6,42 @@ import Separator from '../../../common/layout/Separator'
 import { CustomButton, Section, Wrapper } from '../../../common'
 import FaceVerificationErrorSmiley from '../../../common/animations/FaceVerificationErrorSmiley'
 
+import useOnPress from '../../../../lib/hooks/useOnPress'
 import { withStyles } from '../../../../lib/styles'
 import { isBrowser, isMobileOnly } from '../../../../lib/utils/platform'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 
-const GeneralError = ({ styles, displayTitle, onRetry }) => (
-  <Wrapper>
-    <View style={styles.topContainer}>
-      <Section style={styles.descriptionContainer} justifyContent="space-evenly">
-        <Section.Title fontWeight="medium" textTransform="none">
-          {displayTitle}
-          {',\nSomething went wrong\non our side...'}
-        </Section.Title>
-        <View style={styles.illustration}>
-          <FaceVerificationErrorSmiley />
-        </View>
-        <Section style={styles.errorSection}>
-          <Separator width={2} />
-          <View style={styles.descriptionWrapper}>
-            <Text color="primary">
-              {"You see, it's not that easy\nto capture your beauty :)\nSo, let's give it another shot..."}
-            </Text>
+const GeneralError = ({ styles, displayTitle, onRetry }) => {
+  const onRetryPress = useOnPress(onRetry)
+
+  return (
+    <Wrapper>
+      <View style={styles.topContainer}>
+        <Section style={styles.descriptionContainer} justifyContent="space-evenly">
+          <Section.Title fontWeight="medium" textTransform="none">
+            {displayTitle}
+            {',\nSomething went wrong\non our side...'}
+          </Section.Title>
+          <View style={styles.illustration}>
+            <FaceVerificationErrorSmiley />
           </View>
-          <Separator width={2} />
+          <Section style={styles.errorSection}>
+            <Separator width={2} />
+            <View style={styles.descriptionWrapper}>
+              <Text color="primary">
+                {"You see, it's not that easy\nto capture your beauty :)\nSo, let's give it another shot..."}
+              </Text>
+            </View>
+            <Separator width={2} />
+          </Section>
         </Section>
-      </Section>
-      <View style={styles.action}>
-        <CustomButton onPress={onRetry}>PLEASE TRY AGAIN</CustomButton>
+        <View style={styles.action}>
+          <CustomButton onPress={onRetryPress}>PLEASE TRY AGAIN</CustomButton>
+        </View>
       </View>
-    </View>
-  </Wrapper>
-)
+    </Wrapper>
+  )
+}
 
 const getStylesFromProps = ({ theme }) => {
   return {

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -1,9 +1,10 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { Image, Platform, View } from 'react-native'
 
 import { CustomButton, Section, Wrapper } from '../../../common'
 
+import useOnPress from '../../../../lib/hooks/useOnPress'
 import { isMobileOnly } from '../../../../lib/utils/platform'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
@@ -14,8 +15,8 @@ if (Platform.OS === 'web') {
 }
 
 const UnrecoverableError = ({ styles, screenProps }) => {
-  const onContactSupport = useCallback(() => screenProps.navigateTo('Support'), [screenProps])
-  const onDismiss = useCallback(() => screenProps.goToRoot(), [screenProps])
+  const onContactSupport = useOnPress(() => screenProps.navigateTo('Support'), [screenProps])
+  const onDismiss = useOnPress(() => screenProps.goToRoot(), [screenProps])
 
   return (
     <Wrapper>

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DeviceOrientationError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DeviceOrientationError.js.snap
@@ -307,13 +307,15 @@ your face only in portrait mode
           }
         >
           <div
-            aria-disabled={true}
-            className="css-view-1dbjc4n"
-            disabled={true}
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
             onKeyDown={[Function]}
+            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
+            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -324,11 +326,15 @@ your face only in portrait mode
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
+                "touchAction": "manipulation",
               }
             }
+            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
@@ -343,13 +343,15 @@ We found your twin...
           }
         >
           <div
-            aria-disabled={true}
-            className="css-view-1dbjc4n"
-            disabled={true}
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
             onKeyDown={[Function]}
+            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
+            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -360,11 +362,15 @@ We found your twin...
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
+                "touchAction": "manipulation",
               }
             }
+            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"
@@ -509,13 +515,15 @@ We found your twin...
           }
         >
           <div
-            aria-disabled={true}
-            className="css-view-1dbjc4n"
-            disabled={true}
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
             onKeyDown={[Function]}
+            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
+            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -526,11 +534,15 @@ We found your twin...
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
+                "touchAction": "manipulation",
               }
             }
+            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/GeneralError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/GeneralError.js.snap
@@ -286,13 +286,15 @@ So, let's give it another shot...
           }
         >
           <div
-            aria-disabled={true}
-            className="css-view-1dbjc4n"
-            disabled={true}
+            className="css-cursor-18t94o4 css-view-1dbjc4n"
+            data-focusable={true}
+            disabled={false}
             onKeyDown={[Function]}
+            onKeyPress={[Function]}
             onKeyUp={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
+            onResponderRelease={[Function]}
             onResponderTerminate={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
@@ -303,11 +305,15 @@ So, let's give it another shot...
                 "borderBottomRightRadius": "50px",
                 "borderTopLeftRadius": "50px",
                 "borderTopRightRadius": "50px",
+                "cursor": "pointer",
+                "msTouchAction": "manipulation",
                 "overflowX": "hidden",
                 "overflowY": "hidden",
                 "position": "relative",
+                "touchAction": "manipulation",
               }
             }
+            tabIndex="0"
           >
             <div
               className="css-view-1dbjc4n"

--- a/src/lib/hooks/useOnPress.js
+++ b/src/lib/hooks/useOnPress.js
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-export default (callback, deps) => {
+export default (callback, deps = []) => {
   const memoizedCallback = useCallback(callback, deps)
 
   return useCallback(


### PR DESCRIPTION
# Description

Added useOnPress to prevent default onPress event behavior

About #1957 
# How Has This Been Tested?

1. Try to scan the face for another account by using a face that is already used
2. Scroll down to the "Contact support" button
3. Click the "Contact support" button at the top

You should be redirected to the "Support" page

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
