### PR TITLE
(Bug) #1965 Image is displayed off screen on the we found your twin screen

### DIFF
--- a/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
+++ b/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
@@ -7,7 +7,7 @@ import { CustomButton, Section, Wrapper } from '../../../common'
 import FaceVerificationErrorSmiley from '../../../common/animations/FaceVerificationErrorSmiley'
 
 import useOnPress from '../../../../lib/hooks/useOnPress'
-import { isBrowser, isMobileOnly } from '../../../../lib/utils/platform'
+import { isMobileOnly } from '../../../../lib/utils/platform'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
 
@@ -77,7 +77,7 @@ const getStylesFromProps = ({ theme }) => {
     halfIllustration: {
       marginTop: isMobileOnly ? getDesignRelativeHeight(32) : 0,
       marginBottom: isMobileOnly ? getDesignRelativeHeight(40) : 0,
-      width: getDesignRelativeWidth(isBrowser ? 200 : 100),
+      width: getDesignRelativeWidth(130, false),
       marginRight: 0,
       marginLeft: 0,
     },

--- a/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
+++ b/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
@@ -7,7 +7,7 @@ import { CustomButton, Section, Wrapper } from '../../../common'
 import FaceVerificationErrorSmiley from '../../../common/animations/FaceVerificationErrorSmiley'
 
 import useOnPress from '../../../../lib/hooks/useOnPress'
-import { isMobileOnly } from '../../../../lib/utils/platform'
+import { isBrowser, isMobileOnly } from '../../../../lib/utils/platform'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
 
@@ -77,7 +77,7 @@ const getStylesFromProps = ({ theme }) => {
     halfIllustration: {
       marginTop: isMobileOnly ? getDesignRelativeHeight(32) : 0,
       marginBottom: isMobileOnly ? getDesignRelativeHeight(40) : 0,
-      width: getDesignRelativeWidth(100, false),
+      width: getDesignRelativeWidth(isBrowser ? 200 : 100),
       marginRight: 0,
       marginLeft: 0,
     },

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
@@ -163,7 +163,7 @@ We found your twin...
                 "marginLeft": "0px",
                 "marginRight": "0px",
                 "marginTop": "0px",
-                "width": "284.44444444444446px",
+                "width": "200px",
               }
             }
           >
@@ -184,7 +184,7 @@ We found your twin...
                 "marginLeft": "0px",
                 "marginRight": "0px",
                 "marginTop": "0px",
-                "width": "284.44444444444446px",
+                "width": "200px",
               }
             }
           >

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
@@ -163,7 +163,7 @@ We found your twin...
                 "marginLeft": "0px",
                 "marginRight": "0px",
                 "marginTop": "0px",
-                "width": "200px",
+                "width": "171.52777777777777px",
               }
             }
           >
@@ -184,7 +184,7 @@ We found your twin...
                 "marginLeft": "0px",
                 "marginRight": "0px",
                 "marginTop": "0px",
-                "width": "200px",
+                "width": "171.52777777777777px",
               }
             }
           >

--- a/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
+++ b/src/components/profile/__tests__/__snapshots__/ViewOrUploadAvatar.js.snap
@@ -162,7 +162,7 @@ exports[`ViewAvatar matches snapshot 1`] = `
                   "height": "42px",
                   "justifyContent": "center",
                   "left": "auto",
-                  "marginRight": "-42.666666666666664px",
+                  "marginRight": "-19.791666666666664px",
                   "msFlexAlign": "center",
                   "msFlexPack": "center",
                   "msTouchAction": "manipulation",

--- a/src/lib/utils/__tests__/sizes.js
+++ b/src/lib/utils/__tests__/sizes.js
@@ -2,8 +2,8 @@ const sizesWithMock = args => {
   const { screenHeight, screenWidth, isPortrait } = args || {}
   jest.doMock('../Orientation', () => {
     return {
-      getScreenHeight: () => screenHeight || 616,
-      getScreenWidth: () => screenWidth || 360,
+      getMaxDeviceHeight: () => screenHeight || 616,
+      getMaxDeviceWidth: () => screenWidth || 360,
       isPortrait: () => (isPortrait === undefined ? true : isPortrait),
     }
   })

--- a/src/lib/utils/sizes.js
+++ b/src/lib/utils/sizes.js
@@ -1,4 +1,4 @@
-import { getScreenHeight, getScreenWidth, isPortrait } from './Orientation'
+import { getMaxDeviceHeight, getMaxDeviceWidth, isPortrait } from './Orientation'
 
 /**
  * Receives a size matching the designs baseSize and converts to dp on the current device
@@ -22,7 +22,7 @@ const DESIGN_WIDTH = 360
  * @param {boolean} isMax: should or shouldnt use Math.min
  */
 export const getDesignRelativeWidth = (width, isMax = true) => {
-  const screenWidth = isPortrait() ? getScreenWidth() : getScreenHeight()
+  const screenWidth = isPortrait() ? getMaxDeviceWidth() : getMaxDeviceHeight()
   return getDesignRelativeSize(width, isMax, DESIGN_WIDTH, screenWidth)
 }
 
@@ -34,6 +34,6 @@ const DESIGN_HEIGHT = 640 - 24
  * @param {boolean} isMax: should or shouldnt use Math.min
  */
 export const getDesignRelativeHeight = (height, isMax = true) => {
-  const screenHeight = isPortrait() ? getScreenHeight() : getScreenWidth()
+  const screenHeight = isPortrait() ? getMaxDeviceHeight() : getMaxDeviceWidth()
   return getDesignRelativeSize(height, isMax, DESIGN_HEIGHT, screenHeight)
 }


### PR DESCRIPTION
# Description

Fix duplicate error image size for desktops.

About #1965 

# How Has This Been Tested?

See FV Duplicate error screen.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:

| |
| --- |
| <img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/84912355-09a25900-b0c2-11ea-9654-075ded008949.png"> |
