### PR TITLE
(Bug) #2022 The blank page is displayed instead of Splash Screen after reloading the page

### DIFF
--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -17,7 +17,7 @@ log.debug({ Config })
 
 // import Router from './SignupRouter'
 let SignupRouter = React.lazy(async () => {
-  initAnalytics()
+  await initAnalytics()
 
   const [module] = await Promise.all([
     retryImport(() => import(/* webpackChunkName: "signuprouter" */ './SignupRouter')),

--- a/src/init.js
+++ b/src/init.js
@@ -26,7 +26,7 @@ export const init = () => {
       // set userStorage to simple storage
       setUserStorage(userStorage)
 
-      initAnalytics()
+      await initAnalytics()
       log.debug('analytics has been initialized')
       await identifyWithSignedInUser(goodWallet, userStorage)
       log.debug('analytics has been identified with the user signed in')

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -50,7 +50,7 @@ const FS = global.FS
 const BugSnag = global.bugsnagClient
 const Mautic = global.mt
 const Rollbar = global.Rollbar
-const Amplitude = invoke(global, 'amplitude.getInstance')
+let Amplitude = invoke(global, 'amplitude.getInstance')
 
 const log = logger.child({ from: 'analytics' })
 const { sentryDSN, amplitudeKey, rollbarKey, version, env, network } = Config
@@ -74,6 +74,7 @@ const analyticsLoaded = async () => {
 
   // we could add other conditions here
   if (!isAmplitudeEnabled || (updatedInstance && updatedInstance.Identify)) {
+    Amplitude = updatedInstance
     return
   }
 

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -50,23 +50,23 @@ const FS = global.FS
 const BugSnag = global.bugsnagClient
 const Mautic = global.mt
 const Rollbar = global.Rollbar
-let Amplitude = invoke(global, 'amplitude.getInstance')
+let Amplitude
 
 const log = logger.child({ from: 'analytics' })
 const { sentryDSN, amplitudeKey, rollbarKey, version, env, network } = Config
 
 const isSentryEnabled = !!sentryDSN
 const isRollbarEnabled = !!(Rollbar && rollbarKey)
-const isAmplitudeEnabled = !!(Amplitude && amplitudeKey)
+const isAmplitudeEnabled = !!(global.amplitude && amplitudeKey)
 
 /** @private */
 const analyticsLoaded = async () => {
   const nextTick = window.requestIdleCallback || setTimeout
-  const updatedInstance = invoke(global, 'amplitude.getInstance')
 
   // add another verifications if required
 
   // checking whether the amplitude is loaded
+  const updatedInstance = invoke(global, 'amplitude.getInstance')
   if (!isAmplitudeEnabled || (updatedInstance && updatedInstance.Identify)) {
     Amplitude = updatedInstance
     return

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -62,6 +62,12 @@ const isAmplitudeEnabled = !!(Amplitude && amplitudeKey)
 /** @private */
 const analyticsLoaded = () =>
   new Promise(resolve => {
+    log.info('Amplitude.Identify 1', {
+      amplitude: global.amplitude,
+      isAmplitudeEnabled,
+      Amplitude,
+      identify: Amplitude && Amplitude.Identify,
+    })
     const nextTick = window.requestIdleCallback || setTimeout
     const checkAvailability = () => {
       log.info('Amplitude.Identify', {
@@ -70,12 +76,18 @@ const analyticsLoaded = () =>
         Amplitude,
         identify: Amplitude && Amplitude.Identify,
       })
-      if (!isAmplitudeEnabled && isFunction(Amplitude.Identify)) {
+      if (!isAmplitudeEnabled || isFunction(Amplitude.Identify)) {
         resolve()
         return
       }
       nextTick(checkAvailability)
     }
+    log.info('Amplitude.Identify 2', {
+      amplitude: global.amplitude,
+      isAmplitudeEnabled,
+      Amplitude,
+      identify: Amplitude && Amplitude.Identify,
+    })
     checkAvailability()
   })
 

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -62,17 +62,11 @@ const isAmplitudeEnabled = !!(Amplitude && amplitudeKey)
 /** @private */
 const analyticsLoaded = async () => {
   const nextTick = window.requestIdleCallback || setTimeout
-
   const updatedInstance = invoke(global, 'amplitude.getInstance')
 
-  log.info('test amplitude', {
-    amplitude: global.amplitude,
-    amplitudeInstance: global.amplitude.getInstance(),
-    updatedInstance,
-    isAmplitudeEnabled,
-  })
+  // add another verifications if required
 
-  // we could add other conditions here
+  // checking whether the amplitude is loaded
   if (!isAmplitudeEnabled || (updatedInstance && updatedInstance.Identify)) {
     Amplitude = updatedInstance
     return

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -60,36 +60,17 @@ const isRollbarEnabled = !!(Rollbar && rollbarKey)
 const isAmplitudeEnabled = !!(Amplitude && amplitudeKey)
 
 /** @private */
-const analyticsLoaded = () =>
-  new Promise(resolve => {
-    log.info('Amplitude.Identify 1', {
-      amplitude: global.amplitude,
-      isAmplitudeEnabled,
-      Amplitude,
-      identify: Amplitude && Amplitude.Identify,
-    })
-    const nextTick = window.requestIdleCallback || setTimeout
-    const checkAvailability = () => {
-      log.info('Amplitude.Identify', {
-        amplitude: global.amplitude,
-        isAmplitudeEnabled,
-        Amplitude,
-        identify: Amplitude && Amplitude.Identify,
-      })
-      if (!isAmplitudeEnabled || isFunction(Amplitude.Identify)) {
-        resolve()
-        return
-      }
-      nextTick(checkAvailability)
-    }
-    log.info('Amplitude.Identify 2', {
-      amplitude: global.amplitude,
-      isAmplitudeEnabled,
-      Amplitude,
-      identify: Amplitude && Amplitude.Identify,
-    })
-    checkAvailability()
-  })
+const analyticsLoaded = async () => {
+  const nextTick = window.requestIdleCallback || setTimeout
+
+  // we could add other conditions here
+  if (!isAmplitudeEnabled || isFunction(Amplitude.Identify)) {
+    return
+  }
+
+  await new Promise(resolve => nextTick(resolve))
+  await analyticsLoaded()
+}
 
 export const initAnalytics = async () => {
   await analyticsLoaded()

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -60,17 +60,24 @@ const isRollbarEnabled = !!(Rollbar && rollbarKey)
 const isAmplitudeEnabled = !!(Amplitude && amplitudeKey)
 
 /** @private */
-const analyticsLoaded = async () => {
-  const nextTick = window.requestIdleCallback || setTimeout
-
-  // we could add other conditions here
-  if (!isAmplitudeEnabled || isFunction(Amplitude.Identify)) {
-    return
-  }
-
-  await new Promise(resolve => nextTick(resolve))
-  await analyticsLoaded()
-}
+const analyticsLoaded = () =>
+  new Promise(resolve => {
+    const nextTick = window.requestIdleCallback || setTimeout
+    const checkAvailability = () => {
+      log.info('Amplitude.Identify', {
+        amplitude: global.amplitude,
+        isAmplitudeEnabled,
+        Amplitude,
+        identify: Amplitude && Amplitude.Identify,
+      })
+      if (!isAmplitudeEnabled && isFunction(Amplitude.Identify)) {
+        resolve()
+        return
+      }
+      nextTick(checkAvailability)
+    }
+    checkAvailability()
+  })
 
 export const initAnalytics = async () => {
   await analyticsLoaded()

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -61,11 +61,11 @@ const isAmplitudeEnabled = !!(global.amplitude && amplitudeKey)
 
 /** @private */
 const analyticsLoaded = async () => {
-  const nextTick = window.requestIdleCallback || setTimeout
+  const nextTick = global.requestIdleCallback || setTimeout
 
   // add another verifications if required
 
-  // checking whether the amplitude is loaded
+  // checking whether all required amplitude functionality is loaded
   const updatedInstance = invoke(global, 'amplitude.getInstance')
   if (!isAmplitudeEnabled || (updatedInstance && updatedInstance.Identify)) {
     Amplitude = updatedInstance


### PR DESCRIPTION
# Description

Wait for 'amplitude.Identify' will be loaded to the global object before using it.

About #2022 

# How Has This Been Tested?

The app shouldn't crash when refreshing the page on Android devices.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
