### PR TITLE
(Chore) Connect fullstory session url to user props sent with events

### DIFF
--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -17,7 +17,7 @@ log.debug({ Config })
 
 // import Router from './SignupRouter'
 let SignupRouter = React.lazy(async () => {
-  initAnalytics()
+  await initAnalytics()
 
   const [module] = await Promise.all([
     retryImport(() => import(/* webpackChunkName: "signuprouter" */ './SignupRouter')),

--- a/src/init.js
+++ b/src/init.js
@@ -26,7 +26,7 @@ export const init = () => {
       // set userStorage to simple storage
       setUserStorage(userStorage)
 
-      initAnalytics()
+      await initAnalytics()
       log.debug('analytics has been initialized')
       await identifyWithSignedInUser(goodWallet, userStorage)
       log.debug('analytics has been identified with the user signed in')


### PR DESCRIPTION
# Description

1. removed current app url from event props
2. added FS session url instead 
3. added function awaiting FS ready
4. initial FS session url is saving now to the Amplitude user properties 
4. added function awaiting Amplitude is ready (it's my proposal how we could try to solve #2022 )

About #1866 


# How Has This Been Tested?

1. Deploy onto gooddev
2. Navigate app. Get some errors in the console (e.g. start FR and cancel)
3. Go to Amplitude dashboard
4. Find the logs of your activity (by email)
5. Check user properties. `sessionUrl` prop should be added
6. Check your new error events. `sessionUrlAtTime` should be added to each one

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
