### PR TITLE
(Bug) #2061 zoom face verification takes long time to load

### DIFF
--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -28,6 +28,12 @@ export const ZoomSDK = new class {
    */
   criticalPreloadException = null
 
+  /**
+   * @var {Promise}
+   * @private
+   */
+  preloadPromise = null
+
   constructor(sdk, store, logger) {
     // setting a the directory path for other ZoOm Resources.
     sdk.setResourceDirectory(`${ZOOM_PUBLIC_PATH}/resources`)
@@ -43,8 +49,23 @@ export const ZoomSDK = new class {
     this.logger = logger
   }
 
-  // eslint-disable-next-line require-await
-  async preload() {
+  /**
+   * Start zoom sdk preloading and save promise object to the class property
+   *
+   * @private
+   */
+  preload() {
+    this.preloadPromise = this._preloadCore()
+
+    return this.preloadPromise
+  }
+
+  /**
+   * The preload functionality
+   *
+   * @private
+   */
+  async _preloadCore() {
     const { sdk, criticalPreloadException } = this
     const { ZoomPreloadResult } = sdk
 
@@ -60,9 +81,13 @@ export const ZoomSDK = new class {
     }
   }
 
-  // eslint-disable-next-line require-await
   async initialize(licenseKey, preload = true) {
-    const { sdk, logger, criticalPreloadException } = this
+    const { sdk, logger, criticalPreloadException, preloadPromise } = this
+
+    // waiting for Zoom preload to be finished before starting initialization
+    if (preloadPromise) {
+      await preloadPromise
+    }
 
     // checking the last retrieved status code
     // if Zoom was already initialized successfully,

--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -68,7 +68,7 @@ export const ZoomSDK = new class {
     // if Zoom was already initialized successfully,
     // then resolving immediately
     if (ZoomSDKStatus.Initialized === sdk.getStatus()) {
-      return
+      return true
     }
 
     try {

--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -206,7 +206,7 @@ export const ZoomSDK = new class {
           isCriticalError = message.startsWith('65391')
           break
         case 'TypeError':
-          isCriticalError = filename.includes('zoom/resources')
+          isCriticalError = filename.includes('zoom/resources') || filename.includes('lib/zoom')
           break
         default:
           isCriticalError = false

--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -53,27 +53,27 @@ export const ZoomSDK = new class {
    * Start zoom sdk preloading and save promise object to the class property
    *
    */
-  preload() {
+  async preload() {
     const { sdk, criticalPreloadException } = this
     const { ZoomPreloadResult } = sdk
-    
+
     // re-throw critical exception (e.g.65391) if happened during last preload
     if (criticalPreloadException) {
       throw criticalPreloadException
     }
-    
+
     if (!this.preloadCall) {
       const sdkCall = this.wrapCall(resolver => sdk.preload(resolver))
-      
-      this.preloadCall = sdkCall.finally(() => this.preloadCall = null)      
+
+      this.preloadCall = sdkCall.finally(() => (this.preloadCall = null))
     }
 
     const preloadResult = await this.preloadCall
-    
+
     if (preloadResult !== ZoomPreloadResult.Success) {
       throw new Error(`Couldn't preload Zoom SDK`)
     }
-  }  
+  }
 
   async initialize(licenseKey, preload = true) {
     const { sdk, logger, criticalPreloadException } = this
@@ -299,11 +299,11 @@ export const ZoomSDK = new class {
   // eslint-disable-next-line require-await
   async ensureZoomIsntPreloading() {
     const { preloadCall } = this
-    
+
     if (!preloadCall) {
       return
     }
-    
+
     return preloadCall.catch(noop)
   }
 }(ZoomAuthentication.ZoomSDK, store, logger.child({ from: 'ZoomSDK' }))

--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -223,7 +223,7 @@ export const ZoomSDK = new class {
           isCriticalError = message.startsWith('65391')
           break
         case 'TypeError':
-          isCriticalError = filename.includes('zoom/resources') || filename.includes('lib/zoom')
+          isCriticalError = ['zoom/resources', 'lib/zoom'].some(path => filename.includes(path))
           break
         default:
           isCriticalError = false


### PR DESCRIPTION
# Description

- strictly return true in case the zoom sdk is initialized in Zoom SDK.js - returning undefined caused the unexpected behavior.
- add another lib/zoom error verification to recognize whether preload succeded or not
- await preload method to be resolved before starting to initialize zoom SDK - to prevent error occurring every time user refreshes the /FaceVerification route

About #2061 

# How Has This Been Tested?

Go through FV flow. The re-verify button presses should work fine.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
