### PR TITLE
() #2181 G$ claim amount: need to add Thousands Separators

### DIFF
--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -13,7 +13,7 @@ import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import wrapper from '../../lib/undux/utils/wrapper'
 import { openLink } from '../../lib/utils/linking'
-import { formatWithCommaSeparator, formatWithSIPrefix } from '../../lib/utils/formatNumber'
+import { formatWithThousandsSeparator, formatWithSIPrefix } from '../../lib/utils/formatNumber'
 import API from '../../lib/API/api'
 import { weiToGd } from '../../lib/wallet/utils'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
@@ -293,7 +293,7 @@ const Claim = props => {
 
   const handleFaceVerification = () => screenProps.push('FaceVerificationIntro', { from: 'Claim' })
 
-  const claimAmountFormatter = useCallback(value => formatWithCommaSeparator(weiToGd(value)), [])
+  const claimAmountFormatter = useCallback(value => formatWithThousandsSeparator(weiToGd(value)), [])
 
   return (
     <WrapperClaim>

--- a/src/components/dashboard/Claim.js
+++ b/src/components/dashboard/Claim.js
@@ -13,7 +13,7 @@ import SimpleStore from '../../lib/undux/SimpleStore'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import wrapper from '../../lib/undux/utils/wrapper'
 import { openLink } from '../../lib/utils/linking'
-import { formatWithSIPrefix } from '../../lib/utils/formatNumber'
+import { formatWithCommaSeparator, formatWithSIPrefix } from '../../lib/utils/formatNumber'
 import API from '../../lib/API/api'
 import { weiToGd } from '../../lib/wallet/utils'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
@@ -293,6 +293,8 @@ const Claim = props => {
 
   const handleFaceVerification = () => screenProps.push('FaceVerificationIntro', { from: 'Claim' })
 
+  const claimAmountFormatter = useCallback(value => formatWithCommaSeparator(weiToGd(value)), [])
+
   return (
     <WrapperClaim>
       <Section.Stack style={styles.mainContainer} justifyContent="space-between">
@@ -306,7 +308,7 @@ const Claim = props => {
                 <Section.Text color="#0C263D" style={styles.amountBlockTitle} fontWeight="bold" fontFamily="Roboto">
                   <BigGoodDollar
                     number={entitlement}
-                    formatter={weiToGd}
+                    formatter={claimAmountFormatter}
                     fontFamily="Roboto"
                     bigNumberProps={{
                       fontFamily: 'Roboto',

--- a/src/lib/utils/formatNumber.js
+++ b/src/lib/utils/formatNumber.js
@@ -12,3 +12,7 @@ export const formatWithSIPrefix = (number, customFormat = null) => {
     .format(format)
     .toUpperCase()
 }
+
+export const formatWithCommaSeparator = number => {
+  return numeral(number).format('0[,]0.00')
+}

--- a/src/lib/utils/formatNumber.js
+++ b/src/lib/utils/formatNumber.js
@@ -13,6 +13,6 @@ export const formatWithSIPrefix = (number, customFormat = null) => {
     .toUpperCase()
 }
 
-export const formatWithCommaSeparator = number => {
+export const formatWithThousandsSeparator = number => {
   return numeral(number).format('0[,]0.00')
 }


### PR DESCRIPTION
# Description

Added numeral formatter for claim amount to be with a thousand comma separator.

About #2181 

# How Has This Been Tested?

Open claim page - see the comma-separated amount at the top

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
<img width="475" alt="3" src="https://user-images.githubusercontent.com/49862004/88055965-7b117380-cb68-11ea-8068-7cb0ce625d9c.png">
