### PR TITLE
(Bug) #2196 zoom fails to load shows endless spinner and not an error screen

### DIFF
--- a/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
+++ b/src/components/dashboard/FaceVerification/hooks/useZoomSDK.js
@@ -14,7 +14,6 @@ const ZoomGlobalState = {
   zoomSDKPreloaded: false,
   zoomSDKPreloadFailed: false,
   zoomUnrecoverableError: null,
-  zoomLastInitializeStatus: null,
 }
 
 /**
@@ -112,7 +111,7 @@ export default ({ onInitialized = noop, onError = noop }) => {
   // this callback should be ran once, so we're using refs
   // to access actual initialization / error callbacks
   useEffect(() => {
-    const { zoomSDKPreloadFailed, zoomUnrecoverableError, zoomLastInitializeStatus } = ZoomGlobalState
+    const { zoomSDKPreloadFailed, zoomUnrecoverableError } = ZoomGlobalState
     const { zoomLicenseKey, zoomLicenseText, zoomEncryptionKey } = Config
 
     // Helper for handle exceptions
@@ -135,12 +134,8 @@ export default ({ onInitialized = noop, onError = noop }) => {
           await preloadZoomSDK()
         }
 
-        // if the previous initialize error was DeviceOrientationError - then zoomSDK already initialized
-        // extended condition if required
-        if (zoomLastInitializeStatus !== 'DeviceOrientationError') {
-          // Initializing ZoOm
-          await ZoomSDK.initialize(zoomLicenseKey, zoomLicenseText, zoomEncryptionKey)
-        }
+        // Initializing ZoOm
+        await ZoomSDK.initialize(zoomLicenseKey, zoomLicenseText, zoomEncryptionKey)
 
         // Executing onInitialized callback
         onInitializedRef.current()
@@ -153,7 +148,6 @@ export default ({ onInitialized = noop, onError = noop }) => {
 
         if (kindOfTheIssue) {
           exception.name = kindOfTheIssue
-          ZoomGlobalState.zoomLastInitializeStatus = kindOfTheIssue
         }
 
         // if some unrecoverable error happens

--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -91,7 +91,7 @@ export const ZoomSDK = new class {
     switch (sdkStatus) {
       case Initialized:
       case DeviceInLandscapeMode:
-        // we dont need to invoke initialize again if some non-unrecoverable errors occurred eslint-disable-line
+        // we dont need to invoke initialize again if some non-unrecoverable errors occurred
         this.configureLocalization()
         return true
 

--- a/src/components/dashboard/FaceVerification/utils/kindOfTheIssue.js
+++ b/src/components/dashboard/FaceVerification/utils/kindOfTheIssue.js
@@ -111,6 +111,8 @@ const kindOfSDKIssuesMap = mapValues(
 
       // The provided public encryption key is missing or invalid.
       'EncryptionKeyInvalid',
+
+      'IFrameNotAllowedWithoutPermission',
     ],
   },
   statusTransformer(ZoomSDKStatus),


### PR DESCRIPTION
# Description

Add condition for zoom SDK initialization. If the orientation error occurred during zoom SDK initialization - it means that SDK initialized successfully but the user holds a device in a landscape position - so no need to initialize zoom SDK again.

About #2196 


# How Has This Been Tested?

Try to initialize perform FV in landscape position. You should see orientation error every time until orientation will be changed to a portrait position. There shouldn't be infinite loaders after the second attempt.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
