### PR TITLE
(Feature) #2198 collect try again later FV errors and report to amplitude + sentry

### DIFF
--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -28,12 +28,13 @@ if (Platform.OS === 'web') {
 
 const UnrecoverableError = ({ styles, exception, attemptErrMessages, screenProps }) => {
   const [, hideDialog, showErrorDialog] = useDialog()
+  const { navigateTo, goToRoot, push } = screenProps
 
   const sdkStatus = get(exception, 'code')
   const isLicenseIssue = [InvalidDeviceLicenseKeyIdentifier, LicenseExpiredOrInvalid].includes(sdkStatus)
 
-  const onContactSupport = useOnPress(() => screenProps.navigateTo('Support'), [screenProps])
-  const onDismiss = useOnPress(() => screenProps.goToRoot(), [screenProps])
+  const onContactSupport = useOnPress(() => navigateTo('Support'), [navigateTo])
+  const onDismiss = useOnPress(() => goToRoot(), [goToRoot])
 
   useEffect(() => {
     if (!isLicenseIssue) {
@@ -46,7 +47,7 @@ const UnrecoverableError = ({ styles, exception, attemptErrMessages, screenProps
       attemptErrMessages,
       dialogShown: true,
     })
-    showSupportDialog(showErrorDialog, hideDialog, screenProps.push, 'Face Verification disabled')
+    showSupportDialog(showErrorDialog, hideDialog, push, 'Face Verification disabled')
   }, [])
 
   if (isLicenseIssue) {

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -5,8 +5,6 @@ import { get } from 'lodash'
 import { CustomButton, Section, Wrapper } from '../../../common'
 import { showSupportDialog } from '../../../common/dialogs/showSupportDialog'
 
-import { MAX_ATTEMPTS_ALLOWED } from '../hooks/useVerificationAttempts'
-
 import { useDialog } from '../../../../lib/undux/utils/dialog'
 import useOnPress from '../../../../lib/hooks/useOnPress'
 import { isMobileOnly } from '../../../../lib/utils/platform'
@@ -39,20 +37,13 @@ const UnrecoverableError = ({ styles, exception, attemptsHistory, screenProps })
   useEffect(() => {
     const { message } = exception
 
-    // logging that unrecoverable error screen shown
-    log.error(
-      `FaceVerification still failing after ${MAX_ATTEMPTS_ALLOWED} attempts - "Try again later" screen shown:`,
-      message,
-      exception,
-      { dialogShown: isLicenseIssue },
-    )
-
     // if it's not an license issue - we don't have to show dialog
     if (!isLicenseIssue) {
       return
     }
 
     // if user is not in whitelist and we do not do faceverification then this is an error
+    log.error('FaceVerification failed due to the license issue', message, exception, { dialogShown: true })
     showSupportDialog(showErrorDialog, hideDialog, push, 'Face Verification disabled')
   }, [])
 

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -26,7 +26,7 @@ if (Platform.OS === 'web') {
   Image.prefetch(illustration)
 }
 
-const UnrecoverableError = ({ styles, exception, screenProps }) => {
+const UnrecoverableError = ({ styles, exception, attemptErrMessages, screenProps }) => {
   const [, hideDialog, showErrorDialog] = useDialog()
 
   const sdkStatus = get(exception, 'code')
@@ -42,7 +42,10 @@ const UnrecoverableError = ({ styles, exception, screenProps }) => {
     }
 
     // if user is not in whitelist and we do not do faceverification then this is an error
-    log.error('FaceVerification failed', '', exception, { dialogShown: true })
+    log.error('FaceVerification failed - try again later fired:', exception.message, exception, {
+      attemptErrMessages,
+      dialogShown: true,
+    })
     showSupportDialog(showErrorDialog, hideDialog, screenProps.push, 'Face Verification disabled')
   }, [])
 

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -37,8 +37,10 @@ const UnrecoverableError = ({ styles, exception, attemptErrMessages, screenProps
   const onDismiss = useOnPress(() => goToRoot(), [goToRoot])
 
   useEffect(() => {
+    // logging error every time unrecoverable error screen shown to send failed attempt messages to the sentry, amplitude
     log.error('FaceVerification failed - try again later fired:', exception.message, exception, {
       attemptErrMessages,
+      isLicenseIssue,
       dialogShown: isLicenseIssue,
     })
 

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -37,16 +37,17 @@ const UnrecoverableError = ({ styles, exception, attemptErrMessages, screenProps
   const onDismiss = useOnPress(() => goToRoot(), [goToRoot])
 
   useEffect(() => {
+    log.error('FaceVerification failed - try again later fired:', exception.message, exception, {
+      attemptErrMessages,
+      dialogShown: isLicenseIssue,
+    })
+
     if (!isLicenseIssue) {
-      fireEvent(FV_TRYAGAINLATER)
+      fireEvent(FV_TRYAGAINLATER, { attemptErrMessages })
       return
     }
 
     // if user is not in whitelist and we do not do faceverification then this is an error
-    log.error('FaceVerification failed - try again later fired:', exception.message, exception, {
-      attemptErrMessages,
-      dialogShown: true,
-    })
     showSupportDialog(showErrorDialog, hideDialog, push, 'Face Verification disabled')
   }, [])
 

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -68,11 +68,11 @@ export default () => {
 
   // returns isReachedMaxAttempts flag, resets it once got
   const isReachedMaxAttempts = useCallback(() => {
-    if (isReachedMaxAttempts) {
+    if (reachedMaxAttempts) {
       setReachedMaxAttempts(true)
     }
 
-    return isReachedMaxAttempts
+    return reachedMaxAttempts
   }, [reachedMaxAttempts, setReachedMaxAttempts])
 
   return {

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -5,14 +5,24 @@ import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
 export default () => {
   const store = GDStore.useStore()
   const verificationAttempts = store.get('verificationAttempts')
-  const [setVerificationAttempts] = useCurriedSetters(['verificationAttempts'])
-
-  const trackNewAttempt = useCallback(() => setVerificationAttempts(verificationAttempts + 1), [
-    setVerificationAttempts,
-    verificationAttempts,
+  const verificationAttemptErrMessages = store.get('verificationAttemptErrMessages')
+  const [setVerificationAttempts, setVerificationAttemptErrMessages] = useCurriedSetters([
+    'verificationAttempts',
+    'verificationAttemptErrMessages',
   ])
 
-  const resetAttempts = useCallback(() => setVerificationAttempts(0), [setVerificationAttempts])
+  const trackNewAttempt = useCallback(
+    errorMessage => {
+      setVerificationAttempts(verificationAttempts + 1)
+      setVerificationAttemptErrMessages([...verificationAttemptErrMessages, errorMessage])
+    },
+    [setVerificationAttempts, verificationAttempts, setVerificationAttemptErrMessages, verificationAttemptErrMessages],
+  )
 
-  return [verificationAttempts, trackNewAttempt, resetAttempts]
+  const resetAttempts = useCallback(() => {
+    setVerificationAttempts(0)
+    setVerificationAttemptErrMessages([])
+  }, [setVerificationAttempts, setVerificationAttemptErrMessages])
+
+  return [verificationAttempts, trackNewAttempt, resetAttempts, verificationAttemptErrMessages]
 }

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -4,25 +4,22 @@ import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
 
 export default () => {
   const store = GDStore.useStore()
-  const verificationAttempts = store.get('verificationAttempts')
-  const verificationAttemptErrMessages = store.get('verificationAttemptErrMessages')
-  const [setVerificationAttempts, setVerificationAttemptErrMessages] = useCurriedSetters([
-    'verificationAttempts',
-    'verificationAttemptErrMessages',
-  ])
+  const attemptsCount = store.get('attemptsCount')
+  const attemptsHistory = store.get('attemptsHistory')
+  const [setAttemptsCount, setAttemptsHistory] = useCurriedSetters(['attemptsCount', 'attemptsHistory'])
 
-  const trackNewAttempt = useCallback(
-    errorMessage => {
-      setVerificationAttempts(verificationAttempts + 1)
-      setVerificationAttemptErrMessages([...verificationAttemptErrMessages, errorMessage])
+  const trackAttempt = useCallback(
+    exception => {
+      setAttemptsCount(attemptsCount + 1)
+      setAttemptsHistory([...attemptsHistory, exception])
     },
-    [setVerificationAttempts, verificationAttempts, setVerificationAttemptErrMessages, verificationAttemptErrMessages],
+    [setAttemptsCount, attemptsCount, setAttemptsHistory, attemptsHistory],
   )
 
   const resetAttempts = useCallback(() => {
-    setVerificationAttempts(0)
-    setVerificationAttemptErrMessages([])
-  }, [setVerificationAttempts, setVerificationAttemptErrMessages])
+    setAttemptsCount(0)
+    setAttemptsHistory([])
+  }, [setAttemptsCount, setAttemptsHistory])
 
-  return [verificationAttempts, trackNewAttempt, resetAttempts, verificationAttemptErrMessages]
+  return { attemptsCount, trackAttempt, resetAttempts, attemptsHistory }
 }

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -1,27 +1,85 @@
 import { useCallback } from 'react'
+import { map } from 'lodash'
 
 import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
+import { fireEvent, FV_TRYAGAINLATER } from '../../../../lib/analytics/analytics'
+import logger from '../../../../lib/logger/pino-logger'
 
-export const MAX_RETRIES_ALLOWED = 3
+export const MAX_ATTEMPTS_ALLOWED = 3
+const log = logger.child({ from: 'useVerificationAttempts' })
 
 export default () => {
   const store = GDStore.useStore()
-  const attemptsCount = store.get('attemptsCount')
-  const attemptsHistory = store.get('attemptsHistory')
-  const [setAttemptsCount, setAttemptsHistory] = useCurriedSetters(['attemptsCount', 'attemptsHistory'])
+  const attemptsCount = store.get('attemptsCount') || 0
+  const attemptsHistory = store.get('attemptsHistory') || []
+  const reachedMaxAttempts = store.get('reachedMaxAttempts') || false
+
+  const [setAttemptsCount, setAttemptsHistory, setReachedMaxAttempts] = useCurriedSetters([
+    'attemptsCount',
+    'attemptsHistory',
+    'reachedMaxAttempts',
+  ])
 
   const trackAttempt = useCallback(
     exception => {
-      setAttemptsCount(attemptsCount + 1)
-      setAttemptsHistory([...attemptsHistory, exception])
+      const { message } = exception
+
+      // prepare updated count & history
+      const updatedCount = attemptsCount + 1
+      const updatedHistory = [...attemptsHistory, exception]
+
+      // if we still not reached MAX_ATTEMPTS_ALLOWED - just add to the historu
+      if (updatedCount < MAX_ATTEMPTS_ALLOWED) {
+        setAttemptsCount(updatedCount)
+        setAttemptsHistory(updatedHistory)
+        return
+      }
+
+      // otherwise
+
+      // 1. convert history to the array of messages
+      const attemptsErrorMessages = map(updatedHistory, 'message')
+
+      // 2. reset history in the store
+      resetAttempts()
+
+      // 3. log for debug purposes
+      log.error(
+        `FaceVerification still failing after ${MAX_ATTEMPTS_ALLOWED} attempts - FV_TRYAGAINLATER fired:`,
+        message,
+        exception,
+        { attemptsErrorMessages },
+      )
+
+      // 4. fire event and send error messages to the Amplitude
+      fireEvent(FV_TRYAGAINLATER, { attemptsErrorMessages })
+
+      // 5. set "reached max attempts" flag in the store
+      setReachedMaxAttempts(true)
     },
-    [setAttemptsCount, attemptsCount, setAttemptsHistory, attemptsHistory],
+    [setAttemptsCount, attemptsCount, setAttemptsHistory, attemptsHistory, setReachedMaxAttempts],
   )
 
   const resetAttempts = useCallback(() => {
     setAttemptsCount(0)
     setAttemptsHistory([])
-  }, [setAttemptsCount, setAttemptsHistory])
+    setReachedMaxAttempts(false)
+  }, [setAttemptsCount, setAttemptsHistory, setReachedMaxAttempts])
 
-  return { attemptsCount, trackAttempt, resetAttempts, attemptsHistory }
+  // returns isReachedMaxAttempts flag, resets it once got
+  const isReachedMaxAttempts = useCallback(() => {
+    if (isReachedMaxAttempts) {
+      setReachedMaxAttempts(true)
+    }
+
+    return isReachedMaxAttempts
+  }, [reachedMaxAttempts, setReachedMaxAttempts])
+
+  return {
+    trackAttempt,
+    resetAttempts,
+    attemptsCount,
+    attemptsHistory,
+    isReachedMaxAttempts,
+  }
 }

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 
 import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
 
+export const MAX_RETRIES_ALLOWED = 3
+
 export default () => {
   const store = GDStore.useStore()
   const attemptsCount = store.get('attemptsCount')

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -12,7 +12,7 @@ import useVerificationAttempts from '../hooks/useVerificationAttempts'
 
 import { getFirstWord } from '../../../../lib/utils/getFirstWord'
 
-const MAX_RETRIES_ALLOWED = 2
+const MAX_RETRIES_ALLOWED = 3
 
 const ErrorScreen = ({ styles, screenProps }) => {
   const store = GDStore.useStore()

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -57,7 +57,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
     // (when "something went wrong on our side")
     // if there will be a Human errors (like DeviceOrientation or Permission errors)
     // it will be skip and do not consider as failed attempt
-    if (!isGeneralError && kindOfTheIssue !== 'DeviceOrientationError') {
+    if (!isGeneralError && kindOfTheIssue !== 'DuplicateFoundError') {
       return
     }
 

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -53,20 +53,28 @@ const ErrorScreen = ({ styles, screenProps }) => {
   }, [kindOfTheIssue, resetAttempts])
 
   useEffect(() => {
-    if (!isGeneralError) {
+    // tracking attempt here as we should track only "general" error
+    // (when "something went wrong on our side")
+    // if there will be a Human errors (like DeviceOrientation or Permission errors)
+    // it will be skip and do not consider as failed attempt
+    if (!isGeneralError && kindOfTheIssue !== 'DeviceOrientationError') {
       return
     }
 
-    // tracking attempt here as we should track only "general" error
-    // (when "something went wrong on our side")
+    // tracking all attempts except the last one
+    // after the last FV fail the unrecoverable error screen will be displayed
     if (verificationAttemptsRef.current < MAX_RETRIES_ALLOWED) {
+      // track attempt and save its message
       trackNewAttempt(exception.message)
       return
     }
 
+    // reset/clear saved attempts count and messages
     resetAttempts()
   }, [])
 
+  // the last failed attempt won't be tracked
+  // so concating saved attempt messages with the latest received and pass to unrecoverable component
   const attemptErrMessages = useMemo(() => verificationAttemptErrMessages.concat(exception.message), [
     verificationAttemptErrMessages,
     exception,

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -20,7 +20,12 @@ const ErrorScreen = ({ styles, screenProps }) => {
   const kindOfTheIssue = get(exception, 'name')
   const isGeneralError = !kindOfTheIssue || !(kindOfTheIssue in ErrorScreen.kindOfTheIssue)
 
-  const [verificationAttempts, trackNewAttempt, resetAttempts] = useVerificationAttempts()
+  const [
+    verificationAttempts,
+    trackNewAttempt,
+    resetAttempts,
+    verificationAttemptErrMessages,
+  ] = useVerificationAttempts()
 
   // storing first received attempts count into the ref to avoid component re-updated after attempt tracked
   const verificationAttemptsRef = useRef(verificationAttempts)
@@ -55,11 +60,17 @@ const ErrorScreen = ({ styles, screenProps }) => {
 
     // tracking attempt here as we should track only "general" error
     // (when "something went wrong on our side")
-    trackNewAttempt()
+    trackNewAttempt(exception.message)
   }, [])
 
   return (
-    <ErrorViewComponent onRetry={onRetry} displayTitle={displayTitle} screenProps={screenProps} exception={exception} />
+    <ErrorViewComponent
+      onRetry={onRetry}
+      displayTitle={displayTitle}
+      screenProps={screenProps}
+      exception={exception}
+      attemptErrMessages={verificationAttemptErrMessages}
+    />
   )
 }
 

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -20,15 +20,10 @@ const ErrorScreen = ({ styles, screenProps }) => {
   const kindOfTheIssue = get(exception, 'name')
   const isGeneralError = !kindOfTheIssue || !(kindOfTheIssue in ErrorScreen.kindOfTheIssue)
 
-  const [
-    verificationAttempts,
-    trackNewAttempt,
-    resetAttempts,
-    verificationAttemptErrMessages,
-  ] = useVerificationAttempts()
+  const { attemptsCount, trackAttempt, resetAttempts, attemptsHistory } = useVerificationAttempts()
 
   // storing first received attempts count into the ref to avoid component re-updated after attempt tracked
-  const verificationAttemptsRef = useRef(verificationAttempts)
+  const verificationAttemptsRef = useRef(attemptsCount)
 
   const displayTitle = useMemo(() => {
     const { fullName } = store.get('profile')
@@ -50,7 +45,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
     return GeneralError
 
     // isGeneralError depends from kindOfTheIssue so we could omit it in the deps list
-  }, [kindOfTheIssue, resetAttempts])
+  }, [kindOfTheIssue])
 
   useEffect(() => {
     // tracking attempt here as we should track only "general" error
@@ -65,7 +60,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
     // after the last FV fail the unrecoverable error screen will be displayed
     if (verificationAttemptsRef.current < MAX_RETRIES_ALLOWED) {
       // track attempt and save its message
-      trackNewAttempt(exception.message)
+      trackAttempt(exception)
       return
     }
 
@@ -75,10 +70,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
 
   // the last failed attempt won't be tracked
   // so concating saved attempt messages with the latest received and pass to unrecoverable component
-  const attemptErrMessages = useMemo(() => verificationAttemptErrMessages.concat(exception.message), [
-    verificationAttemptErrMessages,
-    exception,
-  ])
+  const attemptErrMessages = useMemo(() => attemptsHistory.concat([exception]), [attemptsHistory, exception])
 
   return (
     <ErrorViewComponent

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -44,7 +44,6 @@ const ErrorScreen = ({ styles, screenProps }) => {
     }
 
     if (verificationAttemptsRef.current >= MAX_RETRIES_ALLOWED) {
-      resetAttempts()
       return UnrecoverableError
     }
 
@@ -60,8 +59,18 @@ const ErrorScreen = ({ styles, screenProps }) => {
 
     // tracking attempt here as we should track only "general" error
     // (when "something went wrong on our side")
-    trackNewAttempt(exception.message)
+    if (verificationAttemptsRef.current < MAX_RETRIES_ALLOWED) {
+      trackNewAttempt(exception.message)
+      return
+    }
+
+    resetAttempts()
   }, [])
+
+  const attemptErrMessages = useMemo(() => verificationAttemptErrMessages.concat(exception.message), [
+    verificationAttemptErrMessages,
+    exception,
+  ])
 
   return (
     <ErrorViewComponent
@@ -69,7 +78,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
       displayTitle={displayTitle}
       screenProps={screenProps}
       exception={exception}
-      attemptErrMessages={verificationAttemptErrMessages}
+      attemptErrMessages={attemptErrMessages}
     />
   )
 }

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -8,11 +8,9 @@ import GeneralError from '../components/GeneralError'
 import UnrecoverableError from '../components/UnrecoverableError'
 
 import GDStore from '../../../../lib/undux/GDStore'
-import useVerificationAttempts from '../hooks/useVerificationAttempts'
+import useVerificationAttempts, { MAX_RETRIES_ALLOWED } from '../hooks/useVerificationAttempts'
 
 import { getFirstWord } from '../../../../lib/utils/getFirstWord'
-
-const MAX_RETRIES_ALLOWED = 3
 
 const ErrorScreen = ({ styles, screenProps }) => {
   const store = GDStore.useStore()

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -71,7 +71,7 @@ const ErrorScreen = ({ styles, screenProps }) => {
       displayTitle={displayTitle}
       screenProps={screenProps}
       exception={exception}
-      attemptErrMessages={attemptsHistory}
+      attemptsHistory={attemptsHistory}
     />
   )
 }

--- a/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
@@ -24,7 +24,7 @@ const log = logger.child({ from: 'FaceVerification' })
 const FaceVerification = ({ screenProps }) => {
   const [showLoading, hideLoading] = useLoadingIndicator()
   const [setIsCitizen] = useCurriedSetters(['isLoggedInCitizen'])
-  const [, , resetAttempts] = useVerificationAttempts()
+  const { resetAttempts } = useVerificationAttempts()
 
   // Redirects to the error screen, passing exception
   // object and allowing to show/hide retry button (hides it by default)

--- a/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
@@ -24,7 +24,7 @@ const log = logger.child({ from: 'FaceVerification' })
 const FaceVerification = ({ screenProps }) => {
   const [showLoading, hideLoading] = useLoadingIndicator()
   const [setIsCitizen] = useCurriedSetters(['isLoggedInCitizen'])
-  const { resetAttempts } = useVerificationAttempts()
+  const { trackAttempt, resetAttempts } = useVerificationAttempts()
 
   // Redirects to the error screen, passing exception
   // object and allowing to show/hide retry button (hides it by default)
@@ -51,6 +51,7 @@ const FaceVerification = ({ screenProps }) => {
   }, [])
 
   const retryHandler = useCallback(eventData => {
+    trackAttempt(eventData.reason)
     fireEvent(FV_TRYAGAIN_ZOOM, eventData)
   }, [])
 

--- a/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
@@ -83,17 +83,19 @@ const FaceVerification = ({ screenProps }) => {
   const exceptionHandler = useCallback(
     exception => {
       const { name } = exception
+      const cancelled = 'UserCancelled'
 
-      // If user has cancelled face verification by own
+      // 1. if not a user cancelled case - tracking attempt
+      if (cancelled !== name) {
+        trackAttempt(exception)
+      }
+
+      // 2. If user has cancelled face verification by own
       // decision - redirecting back to the into screen
-      if (['UserCancelled', 'ForegroundLoosedError'].includes(name)) {
+      if ([cancelled, 'ForegroundLoosedError'].includes(name)) {
         screenProps.navigateTo('FaceVerificationIntro')
         return
       }
-
-      // otherwise:
-      // 1. tracking error
-      trackAttempt(exception)
 
       // 2. handling error (showing corresponding error screen)
       showErrorScreen(exception)

--- a/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
@@ -52,8 +52,8 @@ const FaceVerification = ({ screenProps }) => {
 
   const retryHandler = useCallback(
     eventData => {
-      trackAttempt(eventData.reason)
       fireEvent(FV_TRYAGAIN_ZOOM, eventData)
+      trackAttempt(eventData.reason)
     },
     [trackAttempt],
   )

--- a/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/VerificationScreen.js
@@ -55,7 +55,7 @@ const FaceVerification = ({ screenProps }) => {
     eventData => {
       const exception = eventData.reason
 
-      // tracking all lovenes exceptions exceptions except
+      // tracking all liveness exceptions except
       // the last one required to show 'try again lagter'
       if (attemptsCount < MAX_RETRIES_ALLOWED) {
         trackAttempt(exception)

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -304,7 +304,7 @@ const patchLogger = () => {
   logger.error = (...args) => {
     const { Unexpected, Network, Human } = ExceptionCategory
     const [logContext, logMessage, eMsg = '', errorObj, extra = {}] = args
-    let { dialogShown, category = Unexpected } = extra
+    let { dialogShown, category = Unexpected, ...context } = extra
     let errorToPassIntoLog = errorObj
     let categoryToPassIntoLog = category
 
@@ -329,6 +329,7 @@ const patchLogger = () => {
         eMsg,
         dialogShown,
         category: categoryToPassIntoLog,
+        context,
       }
 
       if (isFSEnabled) {
@@ -351,7 +352,7 @@ const patchLogger = () => {
         errorObj,
         logContext,
         eMsg,
-        extra,
+        context,
       },
       {
         dialogShown,

--- a/src/lib/undux/GDStore.js
+++ b/src/lib/undux/GDStore.js
@@ -48,6 +48,7 @@ const initialState: State = {
     ready: false,
   },
   verificationAttempts: 0,
+  verificationAttemptErrMessages: [],
   isLoggedInCitizen: false,
   isLoggedIn: false,
   profile: {},

--- a/src/lib/undux/GDStore.js
+++ b/src/lib/undux/GDStore.js
@@ -51,6 +51,7 @@ const initialState: State = {
   },
   attemptsCount: 0,
   attemptsHistory: [],
+  reachedMaxAttempts: false,
   isLoggedInCitizen: false,
   isLoggedIn: false,
   profile: {},

--- a/src/lib/undux/GDStore.js
+++ b/src/lib/undux/GDStore.js
@@ -27,7 +27,8 @@ type Account = {
   }
  */
 export type State = {
-  verificationAttempts: number,
+  attemptsCount: number,
+  attemptsHistory: Array,
   balanceUpdate: boolean,
   account: Account,
   destinationPath: string,
@@ -47,8 +48,8 @@ const initialState: State = {
     entitlement: undefined,
     ready: false,
   },
-  verificationAttempts: 0,
-  verificationAttemptErrMessages: [],
+  attemptsCount: 0,
+  attemptsHistory: [],
   isLoggedInCitizen: false,
   isLoggedIn: false,
   profile: {},

--- a/src/lib/undux/GDStore.js
+++ b/src/lib/undux/GDStore.js
@@ -28,7 +28,8 @@ type Account = {
  */
 export type State = {
   attemptsCount: number,
-  attemptsHistory: Array,
+  attemptsHistory: string[],
+  reachedMaxAttempts: boolean,
   balanceUpdate: boolean,
   account: Account,
   destinationPath: string,


### PR DESCRIPTION
# Description

Save history of 'try again' FV errors in the undux storage and send it to the sentry+Amplitude when 'try again later' dialog shown with log.error() being called.

About #2198 

# How Has This Been Tested?

Start the FaveVerification process, but don't pass it - just wait for a minute and it will fail with 'Session canceled due to timeout' error.
Repeat it 2 more times.
After 3rd time you will see 'retry again later' popup - then search in the console for 'try again later fired' string. The printed object should contain 'attemptErrMessages' property which value is an array with attempt error messages history (3 items).

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
