### PR TITLE
2238 dont rerender gdstore

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,14 +3,12 @@ import { isMobile } from 'mobile-device-detect'
 import React, { memo, useCallback, useEffect, useState } from 'react'
 import { Platform, SafeAreaView, StyleSheet } from 'react-native'
 import PaperProvider from 'react-native-paper/src/core/Provider'
-import InternetConnection from './components/common/connectionDialog/internetConnection'
 import './lib/gundb/gundb'
 import { theme } from './components/theme/styles'
 import SimpleStore, { setInitFunctions } from './lib/undux/SimpleStore'
 import RouterSelector from './RouterSelector.web'
 import LoadingIndicator from './components/common/view/LoadingIndicator'
 import SplashDesktop from './components/splash/SplashDesktop'
-import Splash from './components/splash/Splash'
 import isWebApp from './lib/utils/isWebApp'
 import logger from './lib/logger/pino-logger'
 import { SimpleStoreDialog } from './components/common/dialogs/CustomDialog'
@@ -18,21 +16,16 @@ import Config from './config/config'
 import * as serviceWorker from './serviceWorker'
 const log = logger.child({ from: 'App' })
 let serviceWorkerRegistred = false
-const DisconnectedSplash = () => <Splash animation={false} />
 
 const SplashOrRouter = memo(({ store }) => {
   const isLoggedIn = !!store.get('isLoggedIn')
   const [showDesktopSplash, setShowDesktopSplash] = useState(Config.showSplashDesktop && isLoggedIn === false)
   const dismissDesktopSplash = useCallback(() => setShowDesktopSplash(false), [setShowDesktopSplash])
 
-  return (
-    <InternetConnection onDisconnect={DisconnectedSplash} isLoggedIn={isLoggedIn}>
-      {!isMobile && showDesktopSplash ? (
-        <SplashDesktop onContinue={dismissDesktopSplash} urlForQR={window.location.href} />
-      ) : (
-        <RouterSelector />
-      )}
-    </InternetConnection>
+  return !isMobile && showDesktopSplash ? (
+    <SplashDesktop onContinue={dismissDesktopSplash} urlForQR={window.location.href} />
+  ) : (
+    <RouterSelector />
   )
 })
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -14,6 +14,10 @@ import GDStore from './lib/undux/GDStore'
 import { fireEventFromNavigation } from './lib/analytics/analytics'
 import AddWebApp from './components/common/view/AddWebApp'
 import isWebApp from './lib/utils/isWebApp'
+import InternetConnection from './components/common/connectionDialog/internetConnection'
+import Splash from './components/splash/Splash'
+
+const DisconnectedSplash = () => <Splash animation={false} />
 
 const AppNavigator = createNavigator(
   AppSwitch,
@@ -43,10 +47,12 @@ const onRouteChange = (prevNav, nav, route) => {
 const Router = () => {
   return (
     <GDStore.Container>
-      {!isWebApp && <AddWebApp />}
-      <Portal.Host>
-        <WebRouter onNavigationStateChange={onRouteChange} />
-      </Portal.Host>
+      <InternetConnection onDisconnect={DisconnectedSplash} isLoggedIn={true}>
+        {!isWebApp && <AddWebApp />}
+        <Portal.Host>
+          <WebRouter onNavigationStateChange={onRouteChange} />
+        </Portal.Host>
+      </InternetConnection>
     </GDStore.Container>
   )
 }

--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -15,10 +15,14 @@ import { DESTINATION_PATH } from './lib/constants/localStorage'
 import { delay } from './lib/utils/async'
 import retryImport from './lib/utils/retryImport'
 import { extractQueryParams } from './lib/share/index'
+import InternetConnection from './components/common/connectionDialog/internetConnection'
+
 import logger from './lib/logger/pino-logger'
 import { fireEvent, initAnalytics, SIGNIN_FAILED, SIGNIN_SUCCESS } from './lib/analytics/analytics'
 
 const log = logger.child({ from: 'RouterSelector' })
+
+const DisconnectedSplash = () => <Splash animation={false} />
 
 /**
  * handle in-app links for unsigned users such as magiclink and paymentlinks
@@ -111,7 +115,13 @@ const NestedRouter = memo(({ isLoggedIn }) => {
     log.debug('RouterSelector Rendered', { isLoggedIn })
   }, [isLoggedIn])
 
-  return isLoggedIn ? <AppRouter /> : <SignupRouter />
+  return isLoggedIn ? (
+    <AppRouter />
+  ) : (
+    <InternetConnection onDisconnect={DisconnectedSplash} isLoggedIn={isLoggedIn}>
+      <SignupRouter />
+    </InternetConnection>
+  )
 })
 
 const RouterSelector = () => {


### PR DESCRIPTION
about #2238 

This move internet connection  below GD store so it won't be re-rendered in case of network issue
I assume it will solve the null issues, but its only an  assumption

TODO:
in case of the main app router if network connection dialog is shown, the spinner isn't seen, maybe it's a css issue