### PR TITLE
(Bug) #2295 FV zoom error message is undefined

### DIFF
--- a/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/ZoomSDK.web.js
@@ -245,6 +245,7 @@ export const ZoomSDK = new class {
       return await subscriber.asPromise()
     } catch (exception) {
       if (ZoomSessionStatus.PreloadNotCompleted === exception.code) {
+        this.criticalPreloadException = exception
         return this.showReloadPopup()
       }
 


### PR DESCRIPTION
# Description

Set a critical preload error object in case it occurs during the face verification process.

About #2295 

# How Has This Been Tested?

Zoom verification failed: Cannot read property 'message' of null shouldn't occur during the FV process and shouldn't appear on sentry.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
