### PR TITLE
(Bug) #2334 Fullstory session url is not logged in sentry

### DIFF
--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -345,7 +345,11 @@ const patchLogger = () => {
     const [logContext, logMessage, eMsg = '', errorObj, extra = {}] = args
     let { dialogShown, category = Unexpected, ...context } = extra
     let categoryToPassIntoLog = category
-    let sessionUrlAtTime = fullStoryState.ready && isFSEnabled ? FS.getCurrentSessionURL(true) : undefined
+    let sessionUrlAtTime = undefined
+    
+    if (fullStoryState.ready && isFSEnabled) {
+      sessionUrlAtTime = FS.getCurrentSessionURL(true)
+    }
 
     if (
       categoryToPassIntoLog === Unexpected &&

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -134,15 +134,6 @@ export const initAnalytics = async () => {
     identity.append('phase', String(phase))
     Amplitude.setVersionName(version)
     Amplitude.identify(identity)
-
-    if (isFSEnabled) {
-      fullStoryState.onReady(() => {
-        const sessionUrl = FS.getCurrentSessionURL()
-
-        // set session URL to user props once FS & Amplitude both initialized
-        Amplitude.setUserProperties({ sessionUrl })
-      })
-    }
   }
 
   if (isSentryEnabled) {
@@ -345,8 +336,8 @@ const patchLogger = () => {
     const [logContext, logMessage, eMsg = '', errorObj, extra = {}] = args
     let { dialogShown, category = Unexpected, ...context } = extra
     let categoryToPassIntoLog = category
-    let sessionUrlAtTime = undefined
-    
+    let sessionUrlAtTime
+
     if (fullStoryState.ready && isFSEnabled) {
       sessionUrlAtTime = FS.getCurrentSessionURL(true)
     }

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -345,6 +345,7 @@ const patchLogger = () => {
     const [logContext, logMessage, eMsg = '', errorObj, extra = {}] = args
     let { dialogShown, category = Unexpected, ...context } = extra
     let categoryToPassIntoLog = category
+    let sessionUrlAtTime = fullStoryState.ready && isFSEnabled ? FS.getCurrentSessionURL(true) : undefined
 
     if (
       categoryToPassIntoLog === Unexpected &&
@@ -362,12 +363,7 @@ const patchLogger = () => {
         dialogShown,
         category: categoryToPassIntoLog,
         context,
-      }
-
-      if (fullStoryState.ready && isFSEnabled) {
-        const sessionUrlAtTime = FS.getCurrentSessionURL(true)
-
-        Object.assign(logPayload, { sessionUrlAtTime })
+        sessionUrlAtTime,
       }
 
       debounceFireEvent(ERROR_LOG, logPayload)
@@ -393,6 +389,7 @@ const patchLogger = () => {
           logContext,
           eMsg,
           context,
+          sessionUrlAtTime,
         },
         {
           dialogShown,


### PR DESCRIPTION
# Description

- add FS session url to be sent to the sentry

About #2334 

# How Has This Been Tested?

FS session url should be sent to the sentry.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
