### PR TITLE
(BUG) #2318 The blank screen is displayed after canceling sing in and trying to sign in with another mail

### DIFF
--- a/src/components/auth/torus/AuthTorus.js
+++ b/src/components/auth/torus/AuthTorus.js
@@ -103,13 +103,14 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
   const signupFacebook = () => handleSignUp('facebook')
   const signupAuth0 = loginType => handleSignUp(loginType === 'email' ? 'auth0-pwdless-email' : 'auth0-pwdless-sms')
 
-  const showLoadingDialog = success => {
+  const showLoadingDialog = () => {
     showDialog({
-      image: success ? undefined : <LoadingIcon />,
+      image: <LoadingIcon />,
       loading: true,
       message: 'Please wait\nThis might take a few seconds...',
       showButtons: false,
       title: `PREPARING\nYOUR WALLET`,
+      showCloseButtons: false,
     })
   }
 
@@ -150,7 +151,8 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
           torusUser = await AsyncStorage.getItem('TorusTestUser').then(JSON.parse)
         }
 
-        showLoadingDialog(false)
+        showLoadingDialog()
+
         if (torusUser == null) {
           torusUser = await torusSDK.triggerLogin(provider)
         }


### PR DESCRIPTION
# Description

Remove close button from loading popup while torus login is processing to prevent user close the dialog.

About #2318 

# How Has This Been Tested?

User cant close loading popup after he already select login method and user.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
