### PR TITLE
(Chore) #2369 Add google G logo to sign in button

### DIFF
--- a/src/components/auth/torus/AuthTorus.web.js
+++ b/src/components/auth/torus/AuthTorus.web.js
@@ -22,6 +22,7 @@ import { PrivacyPolicy, PrivacyPolicyAndTerms, SupportForUnsigned } from '../../
 import { createStackNavigator } from '../../appNavigation/stackNavigation'
 import { withStyles } from '../../../lib/styles'
 import illustration from '../../../assets/Auth/torusIllustration.svg'
+import googleBtnIcon from '../../../assets/Auth/btn_google.svg'
 import config from '../../../config/config'
 import { theme as mainTheme } from '../../theme/styles'
 import Section from '../../common/layout/Section'
@@ -396,16 +397,23 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
           </>
         )}
         <CustomButton
-          color={mainTheme.colors.googleRed}
-          style={styles.buttonLayout}
-          textStyle={[styles.buttonText, googleButtonTextStyle]}
+          compact={isSmallDevice}
+          mode="outlined"
+          style={styles.googleButtonLayout}
+          textStyle={{ width: '100%' }}
           onPress={googleButtonHandler}
           disabled={!sdkInitialized}
           testID="login_with_google"
         >
-          Agree & Continue with Google
+          <View style={styles.googleButtonContent}>
+            <Image source={googleBtnIcon} resizeMode="contain" style={styles.googleIcon} />
+            <Text textTransform="uppercase" style={styles.buttonText} fontWeight={500}>
+              Agree & Continue with Google
+            </Text>
+          </View>
         </CustomButton>
         <CustomButton
+          compact={isSmallDevice}
           color={mainTheme.colors.facebookBlue}
           style={styles.buttonLayout}
           textStyle={[styles.buttonText, facebookButtonTextStyle]}
@@ -422,7 +430,7 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
 }
 
 const getStylesFromProps = ({ theme }) => {
-  const buttonFontSize = normalizeText(isSmallDevice ? 15 : 16)
+  const buttonFontSize = normalizeText(isSmallDevice ? 13 : 16)
 
   return {
     mainWrapper: {
@@ -441,6 +449,22 @@ const getStylesFromProps = ({ theme }) => {
     buttonLayout: {
       marginTop: getDesignRelativeHeight(theme.sizes.default),
       marginBottom: getDesignRelativeHeight(theme.sizes.default),
+    },
+    googleButtonLayout: {
+      marginTop: getDesignRelativeHeight(theme.sizes.default),
+      marginBottom: getDesignRelativeHeight(theme.sizes.default),
+      borderWidth: 0,
+      boxShadow: '0 3px 15px -6px rgba(0,0,0,0.6)',
+    },
+    googleButtonContent: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    googleIcon: {
+      width: getDesignRelativeHeight(20),
+      height: getDesignRelativeHeight(20),
+      marginRight: getDesignRelativeWidth(10, false),
     },
     buttonText: {
       fontSize: buttonFontSize,

--- a/src/components/theme/styles.js
+++ b/src/components/theme/styles.js
@@ -16,6 +16,7 @@ export const theme = {
     gray50Percent: '#CBCBCB',
     gray80Percent: '#A3A3A3',
     placeholder: '#CBCBCB',
+    disabled: '#E3E3E2',
     green: '#00C3AE',
     lightGreen: '#00BBA5',
     lightGray: '#EEE',


### PR DESCRIPTION
# Description

Add google icon for the google login button on the AuthTorus screen.
make it responsive and good looking for small devices.

About #2369 

# How Has This Been Tested?

See google button on the login screen

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Browser | Simulators |
| --- | --- |
| <img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/91998478-ecd20500-ed43-11ea-8bc2-d3023f69b8f6.png"> | ![2](https://user-images.githubusercontent.com/49862004/91998488-f22f4f80-ed43-11ea-8882-6695ac6e1d66.png) |

