### PR TITLE
(Bug) FV liveness failure should show the zoom native "retry" screen

### DIFF
--- a/src/components/dashboard/FaceVerification/sdk/EnrollmentProcessor.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/EnrollmentProcessor.web.js
@@ -133,7 +133,7 @@ export class EnrollmentProcessor {
       if (response) {
         // if error response was sent
         const { enrollmentResult, error } = response
-        const { isEnrolled, isLive, isDuplicate, code } = enrollmentResult || {}
+        const { isEnrolled, isLive, isDuplicate, code, subCode } = enrollmentResult || {}
 
         // setting lastMessage from server's response
         this.lastMessage = error
@@ -145,9 +145,14 @@ export class EnrollmentProcessor {
           return
         }
 
-        // if code is 200 then facetec server operations went ok but
-        // there could be issues with liveness check or image quality
-        if (200 === code) {
+        // checking if exception could be related to the liveness failure
+        // there's two possible cases:
+        //  a) if code is 200 then facetec server operations went ok but
+        //     there could be issues with liveness check or image quality
+        //  b) if server returns subCode = livenessCheckFailed it's
+        //     exactly a liveness check issue
+        if (200 === code || 'livenessCheckFailed' === subCode) {
+          // checking liveness / enrollment statuses flags
           // if liveness check failed or face wasn't enrolled by the other reasons
           // (e.g. wearing glasses or bad image quality)
           if (false === isLive || false === isEnrolled) {

--- a/src/components/dashboard/FaceVerification/sdk/UICustomization.css
+++ b/src/components/dashboard/FaceVerification/sdk/UICustomization.css
@@ -57,7 +57,7 @@
   letter-spacing: 0.08px;
 }
 
-@media screen and (max-width: 375px) {
+@media screen and (max-width: 425px) {
   #zoom-upload-progress-wrapper .loading::before {
     font-size: 15px;
   }


### PR DESCRIPTION
# Description

- fixed error processing in EnrollmentProcessor. It checked isLive/isEnrolled only for code = 200 but if liveness failed while face search code is 400. So, an additional check for subCode = livenessFailed (returning during face search failure) was added

About #2399 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
