### PR TITLE
(BUG) #2398 The "agree&continue with google" text is cut off on the button

### DIFF
--- a/src/components/auth/torus/AuthTorus.web.js
+++ b/src/components/auth/torus/AuthTorus.web.js
@@ -30,7 +30,7 @@ import SimpleStore from '../../../lib/undux/SimpleStore'
 import { useDialog } from '../../../lib/undux/utils/dialog'
 import retryImport from '../../../lib/utils/retryImport'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../lib/utils/sizes'
-import { isSmallDevice } from '../../../lib/utils/mobileSizeDetect'
+import { isSmallDevice, isMediumDevice } from '../../../lib/utils/mobileSizeDetect'
 import normalizeText from '../../../lib/utils/normalizeText'
 import { isBrowser } from '../../../lib/utils/platform'
 import { userExists } from '../../../lib/login/userExists'
@@ -289,7 +289,7 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
               onPress={signupAuth0Mobile}
               disabled={!sdkInitialized}
               testID="login_via_mobile"
-              compact={isSmallDevice}
+              compact={isSmallDevice || isMediumDevice}
             >
               Via Phone Code
             </CustomButton>
@@ -300,7 +300,7 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
               onPress={signupAuth0Email}
               disabled={!sdkInitialized}
               testID="login_via_email"
-              compact={isSmallDevice}
+              compact={isSmallDevice || isMediumDevice}
             >
               Via Email Code
             </CustomButton>
@@ -397,7 +397,7 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
           </>
         )}
         <CustomButton
-          compact={isSmallDevice}
+          compact={isSmallDevice || isMediumDevice}
           mode="outlined"
           style={styles.googleButtonLayout}
           textStyle={{ width: '100%' }}
@@ -413,7 +413,7 @@ const AuthTorus = ({ screenProps, navigation, styles, store }) => {
           </View>
         </CustomButton>
         <CustomButton
-          compact={isSmallDevice}
+          compact={isSmallDevice || isMediumDevice}
           color={mainTheme.colors.facebookBlue}
           style={styles.buttonLayout}
           textStyle={[styles.buttonText, facebookButtonTextStyle]}


### PR DESCRIPTION
# Description

- Use the compact button in case it is a medium size mobile device.
- set letter spacing to zero for google button

About #2398 

# How Has This Been Tested?

Google button should look fine on mobile devices.
The letter spacing of the google button should be the same as other buttons has.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshot:
<img width="474" alt="1" src="https://user-images.githubusercontent.com/49862004/92495595-c60e4580-f1ff-11ea-82cb-8d70e7715c7f.png">
