### PR TITLE
(Bug) #2418 empty error message from FV

### DIFF
--- a/src/components/dashboard/FaceVerification/api/FaceVerificationApi.js
+++ b/src/components/dashboard/FaceVerification/api/FaceVerificationApi.js
@@ -159,7 +159,7 @@ class FaceVerificationApi {
 
     if (false === success) {
       // non - success - throwing an exception with failed response
-      const exception = new Error(error)
+      const exception = new Error(error || 'An unexpected issue during the face verification API call')
 
       exception.response = response
       throw exception

--- a/src/components/dashboard/FaceVerification/api/FaceVerificationApi.js
+++ b/src/components/dashboard/FaceVerification/api/FaceVerificationApi.js
@@ -152,7 +152,7 @@ class FaceVerificationApi {
       // don't forget to set success = false flag
       // it's supposed that GoodServer will return false in the case of non-200 code
       // but let's add this additional safety check
-      response = { ...errorObject, success: false }
+      response = { ...failedResponse, success: false }
     }
 
     const { success, error } = response || {}

--- a/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
+++ b/src/components/dashboard/FaceVerification/components/UnrecoverableError.js
@@ -24,7 +24,7 @@ if (Platform.OS === 'web') {
   Image.prefetch(illustration)
 }
 
-const UnrecoverableError = ({ styles, exception, attemptsHistory, screenProps }) => {
+const UnrecoverableError = ({ styles, exception, screenProps }) => {
   const [, hideDialog, showErrorDialog] = useDialog()
   const { navigateTo, goToRoot, push } = screenProps
 

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { map } from 'lodash'
 
 import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
 import { fireEvent, FV_TRYAGAINLATER } from '../../../../lib/analytics/analytics'
@@ -32,7 +31,7 @@ export default () => {
 
       // prepare updated count & history
       const updatedCount = attemptsCount + 1
-      const updatedHistory = [...attemptsHistory, exception]
+      const updatedHistory = [...attemptsHistory, message]
 
       // if we still not reached MAX_ATTEMPTS_ALLOWED - just add to the historu
       if (updatedCount < MAX_ATTEMPTS_ALLOWED) {
@@ -43,29 +42,26 @@ export default () => {
 
       // otherwise
 
-      // 1. convert history to the array of messages
-      const attemptsErrorMessages = map(updatedHistory, 'message')
-
-      // 2. reset history in the store
+      // 1. reset history in the store
       resetAttempts()
 
-      // 3. log for debug purposes
+      // 2. log for debug purposes
       log.error(
         `FaceVerification still failing after ${MAX_ATTEMPTS_ALLOWED} attempts - FV_TRY_AGAIN_LATER fired:`,
         message,
         exception,
-        { attemptsErrorMessages },
+        { attemptsErrorMessages: updatedHistory },
       )
 
-      // 4. fire event and send error messages to the Amplitude
-      fireEvent(FV_TRYAGAINLATER, { attemptsErrorMessages })
+      // 3. fire event and send error messages to the Amplitude
+      fireEvent(FV_TRYAGAINLATER, { attemptsErrorMessages: updatedHistory })
 
-      // 5. set "reached max attempts" flag in the store
+      // 4. set "reached max attempts" flag in the store
       setReachedMaxAttempts(true)
     },
 
     // resetAttempts already depends from setAttemptsCount, setAttemptsHistory & setReachedMaxAttempts
-    [attemptsCount, attemptsHistory, resetAttempts],
+    [attemptsCount, attemptsHistory, resetAttempts, setAttemptsCount, setAttemptsHistory, setReachedMaxAttempts],
   )
 
   // returns isReachedMaxAttempts flag, resets it once got

--- a/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
+++ b/src/components/dashboard/FaceVerification/hooks/useVerificationAttempts.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { map } from 'lodash'
 import GDStore, { useCurriedSetters } from '../../../../lib/undux/GDStore'
 import { fireEvent, FV_TRYAGAINLATER } from '../../../../lib/analytics/analytics'
 import logger from '../../../../lib/logger/pino-logger'
@@ -42,26 +43,29 @@ export default () => {
 
       // otherwise
 
-      // 1. reset history in the store
+      // 1. get history to the error messages
+      const attemptsErrorMessages = map(updatedHistory)
+
+      // 2. reset history in the store
       resetAttempts()
 
-      // 2. log for debug purposes
+      // 3. log for debug purposes
       log.error(
         `FaceVerification still failing after ${MAX_ATTEMPTS_ALLOWED} attempts - FV_TRY_AGAIN_LATER fired:`,
         message,
         exception,
-        { attemptsErrorMessages: updatedHistory },
+        { attemptsErrorMessages },
       )
 
       // 3. fire event and send error messages to the Amplitude
-      fireEvent(FV_TRYAGAINLATER, { attemptsErrorMessages: updatedHistory })
+      fireEvent(FV_TRYAGAINLATER, { attemptsErrorMessages })
 
       // 4. set "reached max attempts" flag in the store
       setReachedMaxAttempts(true)
     },
 
     // resetAttempts already depends from setAttemptsCount, setAttemptsHistory & setReachedMaxAttempts
-    [attemptsCount, attemptsHistory, resetAttempts, setAttemptsCount, setAttemptsHistory, setReachedMaxAttempts],
+    [attemptsCount, attemptsHistory, resetAttempts],
   )
 
   // returns isReachedMaxAttempts flag, resets it once got


### PR DESCRIPTION
# Description

Fix returning the correct error object (failedResponse) from the wrapApiCall method in case the HTTP call failed.
After research, I don't see any other reason for this issue.

About #2418 

# How Has This Been Tested?

There shouldn't be empty message in amplitude error logs for:
useVerificationAttempts
FaceRecognitionAPI

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
