### PR TITLE
(Chore) #2450 Send/Receive by address - User should see a warning message

### DIFF
--- a/src/components/common/form/InputWithAdornment.js
+++ b/src/components/common/form/InputWithAdornment.js
@@ -18,6 +18,7 @@ const InputText = ({
   adornmentSize = 16,
   adornmentStyle,
   adornmentDisabled = false,
+  showError = true,
   error,
   styles,
   theme,
@@ -90,7 +91,7 @@ const InputText = ({
           </TouchableOpacity>
         )}
       </View>
-      <ErrorText error={error} />
+      {showError && <ErrorText error={error} />}
     </View>
   )
 }

--- a/src/components/dashboard/ReceiveToAddress.js
+++ b/src/components/dashboard/ReceiveToAddress.js
@@ -1,14 +1,14 @@
 // @flow
+
 import React from 'react'
-import { Image, View } from 'react-native'
+import { View } from 'react-native'
 import GoodWallet from '../../lib/wallet/GoodWallet'
 import InputText from '../common/form/InputText'
 import { Section, Text, Wrapper } from '../common'
 import TopBar from '../common/view/TopBar'
 import { withStyles } from '../../lib/styles'
-import { getDesignRelativeHeight } from '../../lib/utils/sizes'
+import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
 import normalize from '../../lib/utils/normalizeText'
-import illustration from '../../assets/Signup/maginLinkIllustration.svg'
 import CopyButton from '../common/buttons/CopyButton'
 
 export type TypeProps = {
@@ -31,11 +31,16 @@ const ReceiveToAddress = ({ screenProps, styles, address }: TypeProps) => (
         style={styles.input}
         value={address || account}
         editable={false}
+        showError={false}
       />
-      <Text fontSize={24} fontWeight="medium" lineHeight={30}>
-        {'You can copy and share it\nwith others'}
+      <Text style={styles.copyText} fontSize={24} fontWeight="medium" lineHeight={30}>
+        {'Copy & share it\nwith others'}
       </Text>
-      <Image source={illustration} style={styles.illustration} resizeMode="contain" />
+      <View style={styles.warningTextWrapper}>
+        <Text fontSize={13.5} fontFamily="Roboto Slab" letterSpacing={0.14} lineHeight={21} color="red">
+          Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
+        </Text>
+      </View>
       <CopyButton style={styles.confirmButton} toCopy={address || account} onPressDone={screenProps.goToRoot} />
     </Section>
   </Wrapper>
@@ -48,8 +53,8 @@ ReceiveToAddress.navigationOptions = {
 export default withStyles(({ theme }) => ({
   containerInput: {
     flex: 0,
-    marginTop: getDesignRelativeHeight(25),
-    marginBottom: getDesignRelativeHeight(33),
+    marginTop: getDesignRelativeHeight(15),
+    marginBottom: 0,
     marginHorizontal: getDesignRelativeHeight(10),
   },
   input: {
@@ -63,5 +68,20 @@ export default withStyles(({ theme }) => ({
     minHeight: getDesignRelativeHeight(140),
     marginTop: getDesignRelativeHeight(15),
     marginBottom: getDesignRelativeHeight(15),
+  },
+  copyText: {
+    marginTop: getDesignRelativeHeight(14),
+    marginBottom: getDesignRelativeHeight(20),
+  },
+  warningTextWrapper: {
+    borderWidth: 2,
+    borderRadius: 5,
+    borderStyle: 'solid',
+    borderColor: theme.colors.red,
+    width: getDesignRelativeWidth(252, false),
+    marginHorizontal: 'auto',
+    marginBottom: getDesignRelativeHeight(20),
+    paddingVertical: getDesignRelativeHeight(14),
+    paddingHorizontal: getDesignRelativeWidth(14),
   },
 }))(ReceiveToAddress)

--- a/src/components/dashboard/__tests__/__snapshots__/ReceiveToAddress.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/ReceiveToAddress.js.snap
@@ -250,10 +250,10 @@ exports[`ReceiveToAddress matches snapshot 1`] = `
             "flexBasis": "0%",
             "flexGrow": 0,
             "flexShrink": 0,
-            "marginBottom": "33px",
+            "marginBottom": "0px",
             "marginLeft": "10px",
             "marginRight": "10px",
-            "marginTop": "25px",
+            "marginTop": "15px",
             "msFlexNegative": 0,
             "msFlexPositive": 0,
             "msFlexPreferredSize": "0%",
@@ -314,27 +314,6 @@ exports[`ReceiveToAddress matches snapshot 1`] = `
             value="face-account-wallet-address"
           />
         </div>
-        <div
-          className="css-text-901oao"
-          dir="auto"
-          style={
-            Object {
-              "WebkitTransform": "translateY(0px)",
-              "color": "rgba(250,108,119,1.00)",
-              "direction": "ltr",
-              "fontFamily": "Roboto, \\"Helvetica Neue\\", Helvetica, Arial, sans-serif",
-              "fontSize": "12px",
-              "height": "18px",
-              "opacity": 0,
-              "paddingBottom": "0px",
-              "paddingLeft": "0px",
-              "paddingRight": "12px",
-              "paddingTop": "0px",
-              "textAlign": "center",
-              "transform": "translateY(0px)",
-            }
-          }
-        />
       </div>
       <div
         className="css-text-901oao"
@@ -347,65 +326,69 @@ exports[`ReceiveToAddress matches snapshot 1`] = `
             "fontSize": "24px",
             "fontWeight": "500",
             "lineHeight": "30px",
+            "marginBottom": "20px",
+            "marginTop": "14px",
             "textAlign": "center",
             "textDecoration": "none",
             "textTransform": "none",
           }
         }
       >
-        You can copy and share it
+        Copy & share it
 with others
       </div>
       <div
         className="css-view-1dbjc4n"
         style={
           Object {
-            "WebkitBoxFlex": 1,
-            "WebkitFlexBasis": "auto",
-            "WebkitFlexGrow": 1,
-            "WebkitFlexShrink": 0,
-            "flexBasis": "auto",
-            "flexGrow": 1,
-            "flexShrink": 0,
-            "marginBottom": "15px",
-            "marginTop": "15px",
-            "maxHeight": "230px",
-            "minHeight": "140px",
-            "msFlexNegative": 0,
-            "msFlexPositive": 1,
-            "msFlexPreferredSize": "auto",
-            "overflowX": "hidden",
-            "overflowY": "hidden",
-            "zIndex": 0,
+            "borderBottomColor": "rgba(250,108,119,1.00)",
+            "borderBottomLeftRadius": "5px",
+            "borderBottomRightRadius": "5px",
+            "borderBottomStyle": "solid",
+            "borderBottomWidth": "2px",
+            "borderLeftColor": "rgba(250,108,119,1.00)",
+            "borderLeftStyle": "solid",
+            "borderLeftWidth": "2px",
+            "borderRightColor": "rgba(250,108,119,1.00)",
+            "borderRightStyle": "solid",
+            "borderRightWidth": "2px",
+            "borderTopColor": "rgba(250,108,119,1.00)",
+            "borderTopLeftRadius": "5px",
+            "borderTopRightRadius": "5px",
+            "borderTopStyle": "solid",
+            "borderTopWidth": "2px",
+            "marginBottom": "20px",
+            "marginLeft": "auto",
+            "marginRight": "auto",
+            "paddingBottom": "14px",
+            "paddingLeft": "14px",
+            "paddingRight": "14px",
+            "paddingTop": "14px",
+            "width": "332.5px",
           }
         }
       >
         <div
-          className="css-view-1dbjc4n"
+          className="css-text-901oao"
+          dir="auto"
+          letterSpacing={0.14}
           style={
             Object {
-              "backgroundColor": "rgba(0,0,0,0.00)",
-              "backgroundImage": "url(\\"maginLinkIllustration.svg\\")",
-              "backgroundPosition": "center",
-              "backgroundRepeat": "no-repeat",
-              "backgroundSize": "contain",
-              "bottom": "0px",
-              "height": "100%",
-              "left": "0px",
-              "position": "absolute",
-              "right": "0px",
-              "top": "0px",
-              "width": "100%",
-              "zIndex": -1,
+              "color": "rgba(250,108,119,1.00)",
+              "direction": "ltr",
+              "fontFamily": "Roboto Slab",
+              "fontSize": "13.5px",
+              "fontWeight": "normal",
+              "letterSpacing": "0.14px",
+              "lineHeight": "21px",
+              "textAlign": "center",
+              "textDecoration": "none",
+              "textTransform": "none",
             }
           }
-        />
-        <img
-          alt=""
-          className="css-accessibilityImage-9pa8cd"
-          draggable={false}
-          src="maginLinkIllustration.svg"
-        />
+        >
+          Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
+        </div>
       </div>
       <div
         className="css-view-1dbjc4n"


### PR DESCRIPTION
# Description

Add warning text box on the ReceiveToAddress screen. Fix styles according to design.

About #2450 

# How Has This Been Tested?

Open ReceiveToAddress screen - see changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Browser | Simulators |
| --- | --- |
| <img width="475" alt="1" src="https://user-images.githubusercontent.com/49862004/93222670-dda57b00-f777-11ea-95f2-17a677c22619.png"> | ![2](https://user-images.githubusercontent.com/49862004/93222687-e26a2f00-f777-11ea-8898-1f331503d853.png) |

