### PR TITLE
(Chore) #2450 Send/Receive by address - User should see a warning message

### DIFF
--- a/src/components/dashboard/ReceiveToAddress.js
+++ b/src/components/dashboard/ReceiveToAddress.js
@@ -19,6 +19,28 @@ export type TypeProps = {
 
 const { account } = GoodWallet
 
+const warningBoxStyles = ({ theme }) => ({
+  warningTextWrapper: {
+    borderWidth: 2,
+    borderRadius: 5,
+    borderStyle: 'solid',
+    borderColor: theme.colors.red,
+    width: getDesignRelativeWidth(252, false),
+    marginHorizontal: 'auto',
+    marginBottom: getDesignRelativeHeight(20),
+    paddingVertical: getDesignRelativeHeight(14),
+    paddingHorizontal: getDesignRelativeWidth(14),
+  },
+})
+
+export const GDTokensWarningBox = withStyles(warningBoxStyles)(({ styles }) => (
+  <View style={styles.warningTextWrapper}>
+    <Text fontSize={13.5} fontFamily="Roboto Slab" letterSpacing={0.14} lineHeight={21} color="red">
+      Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
+    </Text>
+  </View>
+))
+
 const ReceiveToAddress = ({ screenProps, styles, address }: TypeProps) => (
   <Wrapper>
     <TopBar push={screenProps.push} hideProfile={false}>
@@ -36,11 +58,7 @@ const ReceiveToAddress = ({ screenProps, styles, address }: TypeProps) => (
       <Text style={styles.copyText} fontSize={24} fontWeight="medium" lineHeight={30}>
         {'Copy & share it\nwith others'}
       </Text>
-      <View style={styles.warningTextWrapper}>
-        <Text fontSize={13.5} fontFamily="Roboto Slab" letterSpacing={0.14} lineHeight={21} color="red">
-          Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
-        </Text>
-      </View>
+      <GDTokensWarningBox />
       <CopyButton style={styles.confirmButton} toCopy={address || account} onPressDone={screenProps.goToRoot} />
     </Section>
   </Wrapper>
@@ -72,16 +90,5 @@ export default withStyles(({ theme }) => ({
   copyText: {
     marginTop: getDesignRelativeHeight(14),
     marginBottom: getDesignRelativeHeight(20),
-  },
-  warningTextWrapper: {
-    borderWidth: 2,
-    borderRadius: 5,
-    borderStyle: 'solid',
-    borderColor: theme.colors.red,
-    width: getDesignRelativeWidth(252, false),
-    marginHorizontal: 'auto',
-    marginBottom: getDesignRelativeHeight(20),
-    paddingVertical: getDesignRelativeHeight(14),
-    paddingHorizontal: getDesignRelativeWidth(14),
   },
 }))(ReceiveToAddress)

--- a/src/components/dashboard/ReceiveToAddress.js
+++ b/src/components/dashboard/ReceiveToAddress.js
@@ -25,7 +25,7 @@ const warningBoxStyles = ({ theme }) => ({
     borderRadius: 5,
     borderStyle: 'solid',
     borderColor: theme.colors.red,
-    width: getDesignRelativeWidth(252, false),
+    width: 'auto',
     marginHorizontal: 'auto',
     marginBottom: getDesignRelativeHeight(20),
     paddingVertical: getDesignRelativeHeight(14),
@@ -33,10 +33,12 @@ const warningBoxStyles = ({ theme }) => ({
   },
 })
 
-export const GDTokensWarningBox = withStyles(warningBoxStyles)(({ styles }) => (
+export const GDTokensWarningBox = withStyles(warningBoxStyles)(({ styles, isSend = false }) => (
   <View style={styles.warningTextWrapper}>
     <Text fontSize={13.5} fontFamily="Roboto Slab" letterSpacing={0.14} lineHeight={21} color="red">
-      Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
+      {isSend
+        ? `Do not send tokens to Ethereum network addresses.\nYou are on Fuse Network.`
+        : `Do not send tokens to Ethereum network to this address.\nThis is a Fuse Network address for G$ tokens only.`}
     </Text>
   </View>
 ))

--- a/src/components/dashboard/SendToAddress.js
+++ b/src/components/dashboard/SendToAddress.js
@@ -21,6 +21,7 @@ import goodWallet from '../../lib/wallet/GoodWallet'
 import { withStyles } from '../../lib/styles'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import { Permissions } from '../permissions/types'
+import { GDTokensWarningBox } from './ReceiveToAddress'
 
 export type TypeProps = {
   screenProps: any,
@@ -89,7 +90,10 @@ const SendToAddress = (props: TypeProps) => {
             autoFocus
           />
         </Section.Stack>
-        <Section.Row grow alignItems="flex-end">
+        <Section grow justifyContent="center">
+          <GDTokensWarningBox />
+        </Section>
+        <Section.Row alignItems="flex-end">
           <Section.Row grow={1} justifyContent="flex-start">
             <BackButton mode="text" screenProps={screenProps}>
               Cancel

--- a/src/components/dashboard/SendToAddress.js
+++ b/src/components/dashboard/SendToAddress.js
@@ -91,7 +91,7 @@ const SendToAddress = (props: TypeProps) => {
           />
         </Section.Stack>
         <Section grow justifyContent="center">
-          <GDTokensWarningBox />
+          <GDTokensWarningBox isSend={true} />
         </Section>
         <Section.Row alignItems="flex-end">
           <Section.Row grow={1} justifyContent="flex-start">

--- a/src/components/dashboard/__tests__/__snapshots__/SendToAddress.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/SendToAddress.js.snap
@@ -504,23 +504,97 @@ exports[`SendToAddress matches snapshot 1`] = `
         className="css-view-1dbjc4n"
         style={
           Object {
+            "WebkitBoxFlex": 1,
+            "WebkitBoxPack": "center",
+            "WebkitFlexGrow": 1,
+            "WebkitJustifyContent": "center",
+            "backgroundColor": "rgba(255,255,255,1.00)",
+            "borderBottomLeftRadius": "5px",
+            "borderBottomRightRadius": "5px",
+            "borderTopLeftRadius": "5px",
+            "borderTopRightRadius": "5px",
+            "flexGrow": 1,
+            "justifyContent": "center",
+            "msFlexPack": "center",
+            "msFlexPositive": 1,
+            "paddingBottom": "16px",
+            "paddingLeft": "12px",
+            "paddingRight": "12px",
+            "paddingTop": "16px",
+          }
+        }
+      >
+        <div
+          className="css-view-1dbjc4n"
+          style={
+            Object {
+              "borderBottomColor": "rgba(250,108,119,1.00)",
+              "borderBottomLeftRadius": "5px",
+              "borderBottomRightRadius": "5px",
+              "borderBottomStyle": "solid",
+              "borderBottomWidth": "2px",
+              "borderLeftColor": "rgba(250,108,119,1.00)",
+              "borderLeftStyle": "solid",
+              "borderLeftWidth": "2px",
+              "borderRightColor": "rgba(250,108,119,1.00)",
+              "borderRightStyle": "solid",
+              "borderRightWidth": "2px",
+              "borderTopColor": "rgba(250,108,119,1.00)",
+              "borderTopLeftRadius": "5px",
+              "borderTopRightRadius": "5px",
+              "borderTopStyle": "solid",
+              "borderTopWidth": "2px",
+              "marginBottom": "20px",
+              "marginLeft": "auto",
+              "marginRight": "auto",
+              "paddingBottom": "14px",
+              "paddingLeft": "14px",
+              "paddingRight": "14px",
+              "paddingTop": "14px",
+              "width": "332.5px",
+            }
+          }
+        >
+          <div
+            className="css-text-901oao"
+            dir="auto"
+            letterSpacing={0.14}
+            style={
+              Object {
+                "color": "rgba(250,108,119,1.00)",
+                "direction": "ltr",
+                "fontFamily": "Roboto Slab",
+                "fontSize": "13.5px",
+                "fontWeight": "normal",
+                "letterSpacing": "0.14px",
+                "lineHeight": "21px",
+                "textAlign": "center",
+                "textDecoration": "none",
+                "textTransform": "none",
+              }
+            }
+          >
+            Do not send tokens from Ethereum network to this address. This is a Fuse Network address for G$ tokens only.
+          </div>
+        </div>
+      </div>
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
             "WebkitAlignItems": "flex-end",
             "WebkitBoxAlign": "end",
             "WebkitBoxDirection": "normal",
-            "WebkitBoxFlex": 1,
             "WebkitBoxOrient": "horizontal",
             "WebkitBoxPack": "justify",
             "WebkitFlexDirection": "row",
-            "WebkitFlexGrow": 1,
             "WebkitJustifyContent": "space-between",
             "alignItems": "flex-end",
             "flexDirection": "row",
-            "flexGrow": 1,
             "justifyContent": "space-between",
             "msFlexAlign": "end",
             "msFlexDirection": "row",
             "msFlexPack": "justify",
-            "msFlexPositive": 1,
           }
         }
       >


### PR DESCRIPTION
# Description

- add a warning box with a message to the sendToAddress screen.

About #2450 

# How Has This Been Tested?

Open SendToAddress screen - see a warning box

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes


| Browser | Simulator |
| --- | --- |
| <img width="475" alt="1" src="https://user-images.githubusercontent.com/49862004/93470385-7fed6c00-f8fa-11ea-991a-cc71fbe2b50d.png"> | ![2](https://user-images.githubusercontent.com/49862004/93470395-854ab680-f8fa-11ea-9fab-9fbe4b60cd0e.png) |

