### PR TITLE
(Feature) #2474 user should be able to receive otp code by voice call

### DIFF
--- a/src/components/signup/SmsForm.js
+++ b/src/components/signup/SmsForm.js
@@ -90,14 +90,19 @@ class SmsForm extends React.Component<Props, State> {
     return API.verifyMobile({ otp })
   }
 
-  handleRetry = async () => {
+  handleRetryWithCall = async () => {
+    await this.handleRetry({ otpChannel: 'call' })
+  }
+
+  handleRetry = async (options: any) => {
+    const { otpChannel } = options
     this.setState({ sendingCode: true, otp: Array(NumInputs).fill(null), errorMessage: '' })
     let { retryFunctionName } = this.props.screenProps
 
     retryFunctionName = retryFunctionName || 'sendOTP'
 
     try {
-      await API[retryFunctionName]({ ...this.props.screenProps.data })
+      await API[retryFunctionName]({ ...this.props.screenProps.data, otpChannel })
       this.setState({ sendingCode: false, resentCode: true })
     } catch (e) {
       const errorMessage = getErrorMessage(e)
@@ -144,10 +149,12 @@ class SmsForm extends React.Component<Props, State> {
             </Section.Stack>
             <Section.Row alignItems="center" justifyContent="center" style={styles.row}>
               <SMSAction
+                styles={styles}
                 sendingCode={sendingCode}
                 resentCode={resentCode}
                 renderButton={renderButton}
                 handleRetry={this.handleRetry}
+                handleRetryWithCall={this.handleRetryWithCall}
                 onFinish={() => {
                   //reset smsaction state
                   this.setState({ resentCode: false })
@@ -161,14 +168,14 @@ class SmsForm extends React.Component<Props, State> {
   }
 }
 
-const SMSAction = ({ handleRetry, resentCode, sendingCode, onFinish }) => {
+const SMSAction = ({ handleRetry, handleRetryWithCall, resentCode, sendingCode, onFinish, styles }) => {
   const [showWait, setWait] = useState(true)
 
   useEffect(() => {
     if (showWait) {
       setTimeout(() => {
         setWait(false)
-      }, 10000)
+      })
     }
   }, [showWait])
 
@@ -189,8 +196,18 @@ const SMSAction = ({ handleRetry, resentCode, sendingCode, onFinish }) => {
           fontSize={14}
           color="primary"
           onPress={handleRetry}
+          style={styles.sendCodeAgainButton}
         >
-          Send me the code again
+          Send the code again
+        </Section.Text>
+        <Section.Text
+          textDecorationLine="underline"
+          fontWeight="medium"
+          fontSize={14}
+          color="primary"
+          onPress={handleRetryWithCall}
+        >
+          Send via voice call
         </Section.Text>
       </SpinnerCheckMark>
     )
@@ -236,6 +253,9 @@ const getStylesFromProps = ({ theme }) => ({
   bottomContent: {
     marginTop: 'auto',
     marginBottom: theme.sizes.defaultDouble,
+  },
+  sendCodeAgainButton: {
+    marginRight: 'auto',
   },
 })
 

--- a/src/components/signup/SmsForm.js
+++ b/src/components/signup/SmsForm.js
@@ -175,7 +175,7 @@ const SMSAction = ({ handleRetry, handleRetryWithCall, resentCode, sendingCode, 
     if (showWait) {
       setTimeout(() => {
         setWait(false)
-      })
+      }, 10000)
     }
   }, [showWait])
 


### PR DESCRIPTION
# Description

- add the voice call button on SMS from.
- add functionality to contact with the receiver via voice call

About #2474 

The link to the GoodServer PR - https://github.com/GoodDollar/GoodServer/pull/264

# How Has This Been Tested?

Try to register a user with self custody. After you entered the phone number wait 10 seconds and retry options will be shown. There should be a new option called 'Send via voice call'.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:

| Browser | Simulators |
| --- | --- |
| <img width="472" alt="1" src="https://user-images.githubusercontent.com/49862004/93860511-e0e4bd80-fcc7-11ea-8fb6-d72bbc551815.png"> | ![2](https://user-images.githubusercontent.com/49862004/93860523-e4784480-fcc7-11ea-99d3-c34a81adc4ad.png) |

