### PR TITLE
(Feature) #2463 show info for argentina mobiles

### DIFF
--- a/src/components/signup/PhoneForm.web.js
+++ b/src/components/signup/PhoneForm.web.js
@@ -1,9 +1,11 @@
 // @flow
-import { isMobile } from 'mobile-device-detect'
+
 import React from 'react'
 import PhoneInput from 'react-phone-number-input'
+import { isMobile } from 'mobile-device-detect'
 import { debounce } from 'lodash'
 import './PhoneForm.css'
+import { enhanceArgentinaCountryCode } from '../../lib/utils/phoneNumber'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
 import { userModelValidations } from '../../lib/gundb/UserModel'
 import { getScreenHeight } from '../../lib/utils/orientation'
@@ -72,7 +74,9 @@ class PhoneForm extends React.Component<Props, State> {
   handleChange = (mobile: string) => {
     this.checkErrorsSlow()
 
-    this.setState({ mobile })
+    this.setState({
+      mobile: enhanceArgentinaCountryCode(mobile),
+    })
   }
 
   handleSubmit = async () => {

--- a/src/lib/utils/__tests__/phoneNumber.js
+++ b/src/lib/utils/__tests__/phoneNumber.js
@@ -1,0 +1,18 @@
+import { enhanceArgentinaCountryCode } from '../phoneNumber'
+
+describe('phoneNumber', () => {
+  it('should return the same phone number', () => {
+    const nonARMobile = '+380500100500'
+    const result = enhanceArgentinaCountryCode(nonARMobile)
+
+    expect(result).toBe(nonARMobile)
+  })
+
+  it('should return enhanced phone number', () => {
+    const arMobile = '+543624733805'
+    const enhancedARMobile = '+5493624733805'
+    const result = enhanceArgentinaCountryCode(arMobile)
+
+    expect(result).toBe(enhancedARMobile)
+  })
+})

--- a/src/lib/utils/phoneNumber.js
+++ b/src/lib/utils/phoneNumber.js
@@ -1,0 +1,16 @@
+// @flow
+
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+
+const ARGENTINA_COUNTRY_CODE = 'AR'
+
+export const enhanceArgentinaCountryCode = (mobile: string = '') => {
+  const parsedPhone = parsePhoneNumberFromString(mobile) || {}
+  const { country, countryCallingCode, nationalNumber } = parsedPhone
+
+  if (country === ARGENTINA_COUNTRY_CODE && nationalNumber[0] !== '9') {
+    return `+${countryCallingCode}9${nationalNumber}`
+  }
+
+  return mobile
+}


### PR DESCRIPTION
# Description

- add method which will check if mobile number is from Argentina and paste '9' after the country code.
- add tests for a new method

About #2463 

# How Has This Been Tested?

When selecting the Argentina mobile number on the Phone step during registration then if the country code format is not matching +549 it will be modified automatically.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
