### PR TITLE
(Bug) #2274 profile image should not be clickable in send screens

### DIFF
--- a/src/components/dashboard/ReceiveToAddress.js
+++ b/src/components/dashboard/ReceiveToAddress.js
@@ -45,7 +45,7 @@ export const GDTokensWarningBox = withStyles(warningBoxStyles)(({ styles, isSend
 
 const ReceiveToAddress = ({ screenProps, styles, address }: TypeProps) => (
   <Wrapper>
-    <TopBar push={screenProps.push} hideProfile={false}>
+    <TopBar push={screenProps.push} hideProfile={false} profileAsLink={false}>
       <View />
     </TopBar>
     <Section grow justifyContent="space-between">

--- a/src/components/dashboard/SendToAddress.js
+++ b/src/components/dashboard/SendToAddress.js
@@ -71,7 +71,7 @@ const SendToAddress = (props: TypeProps) => {
 
   return (
     <Wrapper>
-      <TopBar push={push} hideProfile={false} />
+      <TopBar push={push} hideProfile={false} profileAsLink={false} />
       <Section grow>
         <Section.Stack justifyContent="flex-start" style={styles.container}>
           <Section.Title fontWeight="medium">Send To?</Section.Title>


### PR DESCRIPTION
# Description

Make the profile links not clickable for send/receive screens.

About #2274 

# How Has This Been Tested?

Got to send/receive via address screens and try to click on the profile image at the top. It shouldn't be clickable.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
