### PR TITLE
(Bug) Profile: save button not clickable / details not saved / the data goes out from the mobile/email fields 

### DIFF
--- a/src/components/common/animations/SaveButton/SaveButton.js
+++ b/src/components/common/animations/SaveButton/SaveButton.js
@@ -42,15 +42,21 @@ class SaveButton extends AnimationBase {
     }
   }
 
-  handlePress = () => {
-    const { onPress } = this.props
-    onPress && onPress()
-    if (isMobileReactNative) {
-      this.setState({ animStep: 1 })
-      this.anim.play(12, 101)
-    } else {
-      this.anim.goToAndPlay(12, true)
+  handlePress = event => {
+    const { anim, props } = this
+    const { onPress } = props
+
+    if (onPress) {
+      onPress(event)
     }
+
+    if (!isMobileReactNative) {
+      anim.goToAndPlay(12, true)
+      return
+    }
+
+    this.setState({ animStep: 1 })
+    anim.play(12, 101)
   }
 
   handleAnimationFinish = () => {

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -39,14 +39,6 @@ const EditProfile = ({ screenProps, styles, navigation }) => {
   const onProfileSaved = useCallback(() => push(`Dashboard`), [push])
   const handleEditAvatar = useOnPress(() => push(`ViewAvatar`), [push])
 
-  const updateProfile = useCallback(async () => {
-    // initialize profile value for first time from storedProfile in userStorage
-    const profileFromUserStorage = await userStorage.getProfile()
-
-    setPrivateProfile(profileFromUserStorage)
-    setProfile(profileFromUserStorage)
-  }, [setProfile.setPrivateProfile])
-
   const validate = useCallback(async () => {
     if (!profile || !profile.validate) {
       return false
@@ -139,7 +131,11 @@ const EditProfile = ({ screenProps, styles, navigation }) => {
       return
     }
 
-    updateProfile()
+    // initialize profile value for first time from storedProfile in userStorage
+    userStorage.getProfile().then(profileFromUserStorage => {
+      setPrivateProfile(profileFromUserStorage)
+      setProfile(profileFromUserStorage)
+    })
   }, [])
 
   // Validate after saving profile state in order to show errors

--- a/src/components/profile/EditProfile.js
+++ b/src/components/profile/EditProfile.js
@@ -1,10 +1,10 @@
 // @flow
 import React, { useCallback, useEffect, useState } from 'react'
 import { View } from 'react-native'
-import { debounce, isEqual, isEqualWith, merge, pickBy } from 'lodash'
+import { isEqual, isEqualWith, merge, pickBy } from 'lodash'
 import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
-import GDStore from '../../lib/undux/GDStore'
+import GDStore, { useCurriedSetters } from '../../lib/undux/GDStore'
 import { useErrorDialog } from '../../lib/undux/utils/dialog'
 import { withStyles } from '../../lib/styles'
 import { Section, UserAvatar, Wrapper } from '../common'
@@ -12,6 +12,8 @@ import SaveButton from '../common/animations/SaveButton/SaveButton'
 import SaveButtonDisabled from '../common/animations/SaveButton/SaveButtonDisabled'
 import { fireEvent, PROFILE_UPDATE } from '../../lib/analytics/analytics'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../lib/utils/sizes'
+import useOnPress from '../../lib/hooks/useOnPress'
+import { useDebounce } from '../../lib/hooks/useDebouce'
 import CameraButton from './CameraButton'
 import ProfileDataTable from './ProfileDataTable'
 
@@ -20,14 +22,10 @@ const log = logger.child({ from: TITLE })
 const avatarSize = getDesignRelativeWidth(136)
 const AVATAR_MARGIN = 6
 
-// To remove profile values that are already failing
-function filterObject(obj) {
-  return pickBy(obj, (v, k) => v !== undefined && v !== '')
-}
-
 const EditProfile = ({ screenProps, styles, navigation }) => {
   const store = GDStore.useStore()
   const storedProfile = store.get('privateProfile')
+  const [setPrivateProfile] = useCurriedSetters(['privateProfile'])
   const [profile, setProfile] = useState(storedProfile)
   const [saving, setSaving] = useState(false)
   const [isValid, setIsValid] = useState(true)
@@ -37,79 +35,70 @@ const EditProfile = ({ screenProps, styles, navigation }) => {
   const [showErrorDialog] = useErrorDialog()
   const { push } = screenProps
 
-  useEffect(() => {
-    if (isEqual(storedProfile, {})) {
-      updateProfile()
-    }
-  }, [])
-
-  // Validate after saving profile state in order to show errors
-  useEffect(() => {
-    //need to pass parameters into memoized debounced method otherwise setX hooks wont work
-    validate()
-  }, [profile])
+  const deboucedProfile = useDebounce(profile, 500)
+  const onProfileSaved = useCallback(() => push(`Dashboard`), [push])
+  const handleEditAvatar = useOnPress(() => push(`ViewAvatar`), [push])
 
   const updateProfile = useCallback(async () => {
     // initialize profile value for first time from storedProfile in userStorage
     const profileFromUserStorage = await userStorage.getProfile()
-    store.set('privateProfile')(profileFromUserStorage)
+
+    setPrivateProfile(profileFromUserStorage)
     setProfile(profileFromUserStorage)
-  }, [store, setProfile])
+  }, [setProfile.setPrivateProfile])
 
-  const validate = useCallback(
-    debounce(async () => {
-      if (profile && profile.validate) {
-        try {
-          const pristine = isEqualWith(storedProfile, profile, (x, y) => {
-            if (typeof x === 'function') {
-              return true
-            }
-            if (['string', 'number'].includes(typeof x)) {
-              return y && x.toString() === y.toString()
-            }
-            return undefined
-          })
-          const { isValid, errors } = profile.validate()
-
-          const { isValid: isValidIndex, errors: errorsIndex } = await userStorage.validateProfile(
-            filterObject(profile),
-          )
-          const valid = isValid && isValidIndex
-
-          setErrors(merge(errors, errorsIndex))
-          setIsValid(valid)
-          setIsPristine(pristine)
-
-          return valid
-        } catch (e) {
-          log.error('validate profile failed', e.message, e)
-
-          // showErrorDialog('Unexpected error while validating profile', e)
-          return false
-        }
-      }
+  const validate = useCallback(async () => {
+    if (!profile || !profile.validate) {
       return false
-    }, 500),
-    [profile, storedProfile, setIsPristine, setErrors, setIsValid],
-  )
+    }
+
+    try {
+      const pristine = isEqualWith(storedProfile, profile, (x, y) => {
+        if (typeof x === 'function') {
+          return true
+        }
+
+        if (['string', 'number'].includes(typeof x)) {
+          return y && x.toString() === y.toString()
+        }
+
+        return undefined
+      })
+
+      const { isValid, errors } = profile.validate()
+      const { isValid: isValidIndex, errors: errorsIndex } = await userStorage.validateProfile(pickBy(profile))
+      const valid = isValid && isValidIndex
+
+      setErrors(merge(errors, errorsIndex))
+      setIsValid(valid)
+      setIsPristine(pristine)
+
+      return valid
+    } catch (e) {
+      log.error('validate profile failed', e.message, e)
+      return false
+    }
+  }, [profile, storedProfile, setIsPristine, setErrors, setIsValid])
 
   const handleProfileChange = useCallback(
     newProfile => {
       if (saving) {
         return
       }
+
       setProfile(newProfile)
     },
     [setProfile, saving],
   )
 
-  const handleSaveButton = useCallback(async () => {
+  const handleSaveButton = useOnPress(async () => {
     setSaving(true)
-
     fireEvent(PROFILE_UPDATE)
 
+    const isValid = await validate()
+
     // with flush triggers immediate call for the validation
-    if (!(await validate.flush())) {
+    if (!isValid) {
       setSaving(false)
       return false
     }
@@ -119,60 +108,57 @@ const EditProfile = ({ screenProps, styles, navigation }) => {
       if (typeof v === 'function') {
         return true
       }
+
       if (storedProfile[k] === undefined) {
         return true
       }
+
       if (['string', 'number'].includes(typeof v)) {
         return v.toString() !== storedProfile[k].toString()
       }
+
       if (v !== storedProfile[k]) {
         return true
       }
+
       return false
     })
 
-    return userStorage
-      .setProfile(toupdate, true)
-      .catch(e => {
-        log.error('Error saving profile', e.message, e, { toupdate, dialogShown: true })
-        showErrorDialog('Could not save profile. Please try again.')
-        return false
-      })
-      .finally(_ => setSaving(false))
-  }, [setSaving, storedProfile, showErrorDialog])
+    try {
+      await userStorage.setProfile(toupdate, true)
+    } catch (e) {
+      log.error('Error saving profile', e.message, e, { toupdate, dialogShown: true })
+      showErrorDialog('Could not save profile. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }, [validate, profile, setSaving, storedProfile, showErrorDialog])
 
-  const onProfileSaved = useCallback(() => {
-    push(`Dashboard`)
-  }, [push])
+  useEffect(() => {
+    if (!isEqual(storedProfile, {})) {
+      return
+    }
 
-  const handleAvatarPress = useCallback(
-    event => {
-      event.preventDefault()
-      push(`ViewAvatar`)
-    },
-    [push],
-  )
+    updateProfile()
+  }, [])
 
-  const handleCameraPress = useCallback(
-    event => {
-      event.preventDefault()
-      push(`ViewAvatar`)
-    },
-    [push],
-  )
+  // Validate after saving profile state in order to show errors
+  useEffect(() => {
+    validate()
+  }, [deboucedProfile])
 
   return (
     <Wrapper>
       <Section.Row justifyContent="center" alignItems="flex-start" style={styles.userDataAndButtonsRow}>
         <UserAvatar
           profile={profile}
-          onPress={handleAvatarPress}
+          onPress={handleEditAvatar}
           size={avatarSize}
           imageSize={avatarSize - AVATAR_MARGIN}
           style={styles.userAvatar}
           containerStyle={styles.userAvatarWrapper}
         >
-          <CameraButton handleCameraPress={handleCameraPress} />
+          <CameraButton handleCameraPress={handleEditAvatar} />
         </UserAvatar>
         {lockSubmit || isPristine || !isValid ? (
           <SaveButtonDisabled style={styles.animatedSaveButton} />

--- a/src/lib/hooks/useDebouce.js
+++ b/src/lib/hooks/useDebouce.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+const defaultDelay = 500
+
+export const useDebounce = (value, delay = defaultDelay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
# Description

1. Missing dependencies and using debounce with useEffect could cause strange behavior of validation & profile update

- fixed hooks in EditProfile component
- removed debounce usage from validate() callback
- used custom useDebouce hook returning values changes debounced by specified interval
- according to useDebounce example we listening to the **debounced value** changes to keep the effect callback accessing actual data

2. Fixed some bugs in button handlers

About #2493 #2522 


# How Has This Been Tested?

1. execute
```
userStorage.setProfileField('email', ' ', 'private')
```

2. Reload app
3. Open profile, click edit
4. Enter new email
5. switch to another field
6. go over confirmation flow
7. you will come back to the profile page. click edit and you should see new email

then repeat the same steps for phone, use 'mobile' in setProfileField invocation

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
