### PR TITLE
(chore) build script to use react rewired again

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,10 +1,12 @@
 const assign = require('lodash/assign')
 
-let configType = process.env === 'production' ? 'prod' : 'dev'
-const webpackConfig = require(`./config/webpack.config.${configType}`)
-
 module.exports = {
-  webpack: config => assign(config, webpackConfig),
+  webpack: (config, env) => {
+    const configType = env === 'production' ? 'prod' : 'dev'
+    const webpackConfig = require(`./config/webpack.config.${configType}`)
+
+    return assign(config, webpackConfig)
+  },
 
   jest: config => {
     config.transformIgnorePatterns = [

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -215,6 +215,7 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
       'lottie-react-native': 'react-native-web-lottie',
+      'react-native-linear-gradient': 'react-native-web-linear-gradient',
       //hack to remove duplicate usage in dependencies
       'bn.js': paths.appNodeModules + '/bn.js',
     },
@@ -400,6 +401,42 @@ module.exports = {
               },
               'sass-loader'
             ),
+          },
+          // SVGR is a tool that converts SVG files into React components that you can use directly in JXS.
+          {
+            test: /\.svg$/,
+            exclude: /src\/assets\/fonts/,
+            use: [{
+              loader: '@svgr/webpack',
+              options: {
+                template: function defaultTemplate({ template }, opts, { imports, interfaces, componentName, props, jsx, exports }) {
+                  const plugins = ['jsx']
+                  let exportLoadedFileAsUrl = ''
+
+                  if (opts.state.caller.previousExport) {
+                    exportLoadedFileAsUrl = opts.state.caller.previousExport.replace('default', 'const url =')
+                  }
+
+                  if (opts.typescript) {
+                    plugins.push('typescript')
+                  }
+
+                  const typeScriptTpl = template.smart({ plugins })
+
+                  return typeScriptTpl.ast`
+                    ${imports}
+                    ${interfaces}
+                    function ${componentName}(${props}) {
+                      return ${jsx};
+                    }
+                    ${exportLoadedFileAsUrl}
+                    export default ${componentName}
+                  `
+                }
+              }
+            }, {
+              loader: 'file-loader'
+            }],
           },
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start-clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm start:native -- --reset-cache",
     "link": "npm link @gooddollar/goodcontracts",
     "web:local": "npm run link && npm run web",
-    "build": "node scripts/build.js --stats",
+    "build": "react-app-rewired build --analyze",
     "animation:assets": "node ./animationAssets.js",
     "test": "npm run link && npm run test:web && npm run test:native",
     "test:setup": "./scripts/blockchainTestSetup.sh",


### PR DESCRIPTION
# Description

This reverts the previous changes for goodnative builds on netlify and adds react-app-rewired for the build script

About #2504 


# How Has This Been Tested?

Ran npm run build and successfully creates static files
<img src="https://user-images.githubusercontent.com/14169682/95404588-db07f280-08eb-11eb-961e-eb706972fb77.png" width="450">

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
