### PR TITLE
(Bug) [RN] feed empty after opening account with self custody

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -382,7 +382,11 @@ const Dashboard = props => {
       return
     }
 
-    const { width } = await measure(balanceView)
+    const measurements = await measure(balanceView)
+
+    // Android never gets values from measure causing animation to crash because of NaN
+    const width = measurements.width || 0
+
     const balanceCenteredPosition = headerContentWidth / 2 - width / 2
 
     setBalanceBlockWidth(width)

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -221,9 +221,6 @@ const Dashboard = props => {
           //so we use a global variable
           if (!didRender) {
             log.debug('waiting for feed animation')
-
-            // a time to perform feed load animation till the end
-            await delay(2000)
             didRender = true
           }
           res = (await feedPromise) || []


### PR DESCRIPTION
# Description

This fixes the initial load of feeds in web after a successful signup.
This PR also includes a crash in android that it was trying to set the animation of G$ with a NaN value, caused because measure never returns measurements

About #2569 


# How Has This Been Tested?

1. Signed up using web, iOS and android
2. Refreshed using the same platforms
3. Navigating and coming back to dashboard using same platforms

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
