### PR TITLE
(Bug) [RN] The version is overlapped by the "Gooddollar" text on the splashscreen

### DIFF
--- a/src/components/splash/Splash.js
+++ b/src/components/splash/Splash.js
@@ -12,7 +12,7 @@ import WavesBackground from '../common/view/WavesBackground'
 // utils
 import Config from '../../config/config'
 import { getDesignRelativeHeight } from '../../lib/utils/sizes'
-import { isMobile, isMobileNative } from '../../lib/utils/platform'
+import { isMobileNative } from '../../lib/utils/platform'
 import AsyncStorage from '../../lib/utils/asyncStorage'
 
 // assets
@@ -82,7 +82,7 @@ const Splash = ({ animation, isLoggedIn }) => {
             )}
             <AnimationsLogo
               animation={shouldAnimate && animation}
-              style={isMobile ? styles.mobileAnimation : styles.animation}
+              style={isMobileNative ? styles.mobileAnimation : styles.animation}
             />
             <Section.Text fontSize={16} color="darkBlue" fontWeight="medium">
               {isPhaseZero && 'Demo '}V{version}


### PR DESCRIPTION

# Description
Changes in Splash.js:
Using mobileAnimation styles **only** for native, styles.animation on web

About #2555 


# How Has This Been Tested?

Launched the app on web (mobile & desktop) & on native, checking & comparing splash text position.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screenshots:
**native:**
![image](https://user-images.githubusercontent.com/28148619/97189612-8e456800-1783-11eb-8503-c3efa051f0ec.png)

**web mobile:**
![image](https://user-images.githubusercontent.com/28148619/97189797-bcc34300-1783-11eb-9a82-fe41fdd0a8d3.png)

**web desktop:**
![image](https://user-images.githubusercontent.com/28148619/97189870-d5cbf400-1783-11eb-96a6-769f89306ac5.png)
