### PR TITLE
(Bug) [RN] 2621 support dialog layout broken

### DIFF
--- a/src/components/common/animations/Error/index.js
+++ b/src/components/common/animations/Error/index.js
@@ -4,11 +4,14 @@ import Lottie from 'lottie-react-native'
 import AnimationBase from '../Base'
 import { getAnimationData } from '../../../../lib/utils/lottie'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
+import { isMobileNative } from '../../../../lib/utils/platform'
+import { withStyles } from '../../../../lib/styles'
 
 const { animationData, imageAssetsFolder } = getAnimationData('Error', require('./data'))
 
 class Error extends AnimationBase {
   render() {
+    const { styles } = this.props
     return (
       <Lottie
         imageAssetsFolder={imageAssetsFolder}
@@ -16,17 +19,24 @@ class Error extends AnimationBase {
         autoPlay={true}
         source={this.improveAnimationData(animationData)}
         autoSize={false}
-        style={{
-          top: -getDesignRelativeHeight(97, false) * 0.33,
-          width: getDesignRelativeWidth(97, false),
-          marginHorizontal: 'auto',
-          marginVertical: 'auto',
-          alignSelf: 'center',
-        }}
+        style={styles.animation}
         loop={false}
       />
     )
   }
 }
 
-export default Error
+const styles = ({ theme }) => {
+  const topValue = isMobileNative ? 15 : 40
+  return {
+    animation: {
+      top: -getDesignRelativeHeight(topValue, true),
+      width: getDesignRelativeWidth(97, false),
+      marginHorizontal: 'auto',
+      marginVertical: 'auto',
+      alignSelf: 'center',
+    },
+  }
+}
+
+export default withStyles(styles)(Error)

--- a/src/components/common/animations/Error/index.js
+++ b/src/components/common/animations/Error/index.js
@@ -3,7 +3,7 @@ import Lottie from 'lottie-react-native'
 
 import AnimationBase from '../Base'
 import { getAnimationData } from '../../../../lib/utils/lottie'
-import { getDesignRelativeWidth } from '../../../../lib/utils/sizes'
+import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../../lib/utils/sizes'
 
 const { animationData, imageAssetsFolder } = getAnimationData('Error', require('./data'))
 
@@ -17,9 +17,11 @@ class Error extends AnimationBase {
         source={this.improveAnimationData(animationData)}
         autoSize={false}
         style={{
+          top: -getDesignRelativeHeight(97, false) * 0.33,
           width: getDesignRelativeWidth(97, false),
           marginHorizontal: 'auto',
           marginVertical: 'auto',
+          alignSelf: 'center',
         }}
         loop={false}
       />

--- a/src/components/common/dialogs/showSupportDialog.js
+++ b/src/components/common/dialogs/showSupportDialog.js
@@ -1,6 +1,7 @@
 //@flow
 
 import React from 'react'
+import { View } from 'react-native'
 import Text from '../view/Text'
 
 export const showSupportDialog = (
@@ -11,7 +12,7 @@ export const showSupportDialog = (
 ) => {
   showErrorDialog(message, undefined, {
     boldMessage: (
-      <>
+      <View style={{ justifyContent: 'center', flexDirection: 'row', alignItems: 'center', flex: 1 }}>
         <Text fontWeight="inherit" color="inherit">
           {'Or contact '}
         </Text>
@@ -26,7 +27,7 @@ export const showSupportDialog = (
         >
           support
         </Text>
-      </>
+      </View>
     ),
   })
 }

--- a/src/components/common/dialogs/showSupportDialog.js
+++ b/src/components/common/dialogs/showSupportDialog.js
@@ -10,9 +10,16 @@ export const showSupportDialog = (
   push,
   message = 'Something went wrong on our side. Please try again',
 ) => {
+  const wrapperStyles = {
+    justifyContent: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  }
+
   showErrorDialog(message, undefined, {
     boldMessage: (
-      <View style={{ justifyContent: 'center', flexDirection: 'row', alignItems: 'center', flex: 1 }}>
+      <View style={wrapperStyles}>
         <Text fontWeight="inherit" color="inherit">
           {'Or contact '}
         </Text>


### PR DESCRIPTION
# Description

In native we aren't using the 'ooops' text as part of the animation, hence we need to manipulate the margins manually. This PR fixes that and the wrong text positions.

About #2621 


# How Has This Been Tested?

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/14169682/97351356-654ed100-1870-11eb-9957-4b9b63e8a1eb.png) | ![image](https://user-images.githubusercontent.com/14169682/97351546-ac3cc680-1870-11eb-949a-72b5b4299c2b.png) |

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## More examples

**Web mobile**
<img src="https://user-images.githubusercontent.com/14169682/97503956-c4861180-1954-11eb-89c0-e90a2095a824.png" width="450" />
**Web desktop**
<img src="https://user-images.githubusercontent.com/14169682/97503990-d49df100-1954-11eb-8058-4cd50ef9d848.png" width="450" />
**Native**
<img src="https://user-images.githubusercontent.com/14169682/97503904-ab7d6080-1954-11eb-8281-b93dcbb029c2.png" width="450" />

