### PR TITLE
(Bug) [RN] Native - goodmarket button is misaligned

### DIFF
--- a/src/components/dashboard/GoodMarket/components/GoodMarketButton.js
+++ b/src/components/dashboard/GoodMarket/components/GoodMarketButton.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react'
-import { Animated, Easing, TouchableOpacity } from 'react-native'
+import { Animated, Easing, TouchableOpacity, View } from 'react-native'
 import { noop } from 'lodash'
 
 import Icon from '../../../common/view/Icon'
@@ -11,6 +11,7 @@ import { useDialog } from '../../../../lib/undux/utils/dialog'
 import { fireEvent, GOTO_MARKET_POPUP } from '../../../../lib/analytics/analytics'
 import { withStyles } from '../../../../lib/styles'
 import { getDesignRelativeWidth } from '../../../../lib/utils/sizes'
+import { isIOSNative } from '../../../../lib/utils/platform'
 import GoodMarketDialog from './GoodMarketDialog'
 
 export const marketAnimationDuration = 1500
@@ -58,24 +59,30 @@ const GoodMarketButton = ({ styles, hidden = false }) => {
   }
 
   return (
-    <TouchableOpacity onPress={onButtonClicked} style={styles.marketButton}>
-      <Icon name="goodmarket" size={36} color="white" />
-    </TouchableOpacity>
+    <View style={styles.btnContainer}>
+      <TouchableOpacity onPress={onButtonClicked} style={styles.marketButton}>
+        <Icon name="goodmarket" size={36} color="white" />
+      </TouchableOpacity>
+    </View>
   )
 }
 
 const getStylesFromProps = ({ theme }) => ({
+  btnContainer: {
+    position: 'absolute',
+    right: '50%',
+    left: '50%',
+    bottom: 0,
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
   marketButton: {
     backgroundColor: theme.colors.primary,
     flexDirection: 'row',
     justifyContent: 'center',
-    paddingVertical: 8,
+    paddingTop: theme.sizes.default,
+    paddingBottom: isIOSNative ? theme.sizes.defaultDouble : theme.sizes.default,
     width: getDesignRelativeWidth(140),
-    position: 'absolute',
-    right: 0,
-    left: 0,
-    bottom: 0,
-    marginHorizontal: 'auto',
     borderTopRightRadius: 22,
     borderTopLeftRadius: 22,
   },


### PR DESCRIPTION
# Description
Alinged goodmarket button to the center using a container wrapping the button, because `position: absolute` + 'auto' horizontal margins didn't behave as expected on native.

**Also:** accomodated `paddingBottom` for ios' native home/gestures bar

About #2646 


# How Has This Been Tested?
Verified on all platforms (ios, android, web mobile & web desktop) by going to the dashboard screen

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

## Screensots:
**ios:**
![image](https://user-images.githubusercontent.com/28148619/97620588-8d6d3a00-1a00-11eb-836f-a6dc9a0843de.png)

**web mobile:**
![image](https://user-images.githubusercontent.com/28148619/97622091-89dab280-1a02-11eb-8145-e68a4fa43d1b.png)

**web desktop:**
![image](https://user-images.githubusercontent.com/28148619/97622207-b0005280-1a02-11eb-9191-12ca5899980a.png)
