### PR TITLE
(Bug) [RN] The Claim button jumps after the user coming back to the dashboard

### DIFF
--- a/src/components/common/buttons/ClaimButton.js
+++ b/src/components/common/buttons/ClaimButton.js
@@ -24,12 +24,10 @@ const getStylesFromProps = ({ theme }) => ({
     }),
     borderWidth: 3,
     height: '100%',
-    left: '50%',
     marginHorizontal: 0,
     elevation: 0,
     padding: 3,
     position: 'absolute',
-    top: '50%',
     width: '100%',
     zIndex: 99,
   },
@@ -110,10 +108,7 @@ const AnimatedClaimButton = ({ screenProps, styles, animated, animatedScale }) =
     }
 
     return {
-      transform: [
-        { translateY: pushButtonTranslate.translateY || 0 },
-        { translateX: pushButtonTranslate.translateX || 0 },
-      ],
+      transform: [{ translateY: 0 }, { translateX: 0 }],
     }
   }, [pushButtonTranslate])
 


### PR DESCRIPTION
# Description

The problem wasn't related to dynamic calc of position and measure as initially thought.
After applying this translates the parent after a timeout then applies new positioning that centers the button back in.

About #2625 

# How Has This Been Tested?

| navigating | navigating + scroll anim |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/14169682/97660803-612dd980-1a51-11eb-974b-1768ff5ccb5b.gif" /> | <img src="https://user-images.githubusercontent.com/14169682/97661409-0a290400-1a53-11eb-959c-14ff0b96b479.gif" /> |

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

