### PR TITLE
(Bug) [RN] Fix signup phone form: div & className usage

### DIFF
--- a/src/components/signup/PhoneForm.js
+++ b/src/components/signup/PhoneForm.js
@@ -122,18 +122,7 @@ class PhoneForm extends React.Component<Props, State> {
                 {`${getFirstWord(fullName)},\nenter your phone number\nso we could verify you`}
               </Section.Title>
             </Section.Row>
-            {/* react throws error on view with classname 
-            <Section.Stack className="signup_phone_input" justifyContent="center" style={styles.column}> */}
-            <div
-              className="signup_phone_input"
-              style={{
-                ...styles.column,
-                justifyContent: 'center',
-                flexDirection: 'column',
-                alignItems: 'stretch',
-                display: 'flex',
-              }}
-            >
+            <Section.Stack justifyContent="center" style={styles.column}>
               <FormNumberInput
                 id={key + '_input'}
                 value={this.state.mobile}
@@ -149,8 +138,7 @@ class PhoneForm extends React.Component<Props, State> {
                 textStyle={isMobileNative && errorMessage ? styles.inputError : undefined}
               />
               <ErrorText error={errorMessage} style={styles.customError} />
-            </div>
-            {/* </Section.Stack> */}
+            </Section.Stack>
           </Section.Stack>
           <Section.Row
             justifyContent="center"

--- a/src/components/signup/PhoneNumberInput/PhoneNumberInput.css
+++ b/src/components/signup/PhoneNumberInput/PhoneNumberInput.css
@@ -1,20 +1,18 @@
 @import url('~react-phone-number-input/style.css');
 
-.signup_phone_input .react-phone-number-input {
+.signup_phone_input.react-phone-number-input {
   width: 100% !important;
   border: none !important;
   border-radius: 0 !important;
 }
 
-.signup_phone_input
-  .react-phone-number-input
+.signup_phone_input.react-phone-number-input
   > .react-phone-number-input__row
   > .react-phone-number-input__input.react-phone-number-input__phone {
   border-bottom: 1px solid rgb(0, 0, 0);
 }
 
-.signup_phone_input
-  .react-phone-number-input
+.signup_phone_input.react-phone-number-input
   > .react-phone-number-input__row
   > .react-phone-number-input__input.react-phone-number-input__phone.react-phone-number-input__input--invalid {
   border-bottom: 1px solid #fa6c77;
@@ -22,11 +20,11 @@
   border-color: #fa6c77;
 }
 
-.signup_phone_input .react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error {
+.signup_phone_input.react-phone-number-input.react-phone-number-input--invalid .react-phone-number-input__error {
   display: none;
 }
 
-.signup_phone_input .react-phone-number-input__icon {
+.signup_phone_input.react-phone-number-input .react-phone-number-input__icon {
   border: 0;
   border-radius: 2px;
   width: 1.85em;

--- a/src/components/signup/PhoneNumberInput/PhoneNumberInput.web.js
+++ b/src/components/signup/PhoneNumberInput/PhoneNumberInput.web.js
@@ -4,4 +4,4 @@ import React from 'react'
 import PhoneNumberInput from '../../common/form/PhoneNumberInput/PhoneNumberInput'
 import './PhoneNumberInput.css'
 
-export default props => <PhoneNumberInput id="signup_phone" {...props} />
+export default props => <PhoneNumberInput className="signup_phone_input" id="signup_phone" {...props} />


### PR DESCRIPTION
# Description
Changed the way of customizing PhoneNumberInput's css styles on web:
* added `className` on the custom component
* adapted css to this change

Removed temporary `div`, back to `Section.Stack` but without `className`



# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
