### PR TITLE
(BUG) [RN] 2672 code withdraw failed Private key must be 32 bytes long

### DIFF
--- a/src/RouterSelector.web.js
+++ b/src/RouterSelector.web.js
@@ -19,7 +19,6 @@ import SimpleStore from './lib/undux/SimpleStore'
 import { DESTINATION_PATH } from './lib/constants/localStorage'
 import { delay } from './lib/utils/async'
 import retryImport from './lib/utils/retryImport'
-import { extractQueryParams } from './lib/share/index'
 import DeepLinking from './lib/utils/deepLinking'
 import InternetConnection from './components/common/connectionDialog/internetConnection'
 import isWebApp from './lib/utils/isWebApp'
@@ -37,8 +36,7 @@ const DisconnectedSplash = () => <Splash animation={false} />
  * @returns {Promise<boolean>}
  */
 const handleLinks = async () => {
-  const decodedHref = decodeURI(window.location.href)
-  const params = extractQueryParams(decodedHref)
+  const params = DeepLinking.params
 
   try {
     const { magiclink } = params
@@ -115,8 +113,10 @@ const NestedRouter = memo(({ isLoggedIn }) => {
   useEffect(() => {
     let source, platform
     if (Platform.OS === 'web') {
+      const params = DeepLinking.params
+
       source = document.referrer.match(/^https:\/\/(www\.)?gooddollar\.org/) == null ? source : 'web3'
-      source = Object.keys(pick(DeepLinking.params, ['inviteCode', 'paymentCode', 'code'])).pop() || source
+      source = Object.keys(pick(params, ['inviteCode', 'paymentCode', 'code'])).pop() || source
       platform = isWebApp ? 'webapp' : 'web'
     } else {
       platform = 'native'

--- a/src/lib/gundb/UserStorageClass.js
+++ b/src/lib/gundb/UserStorageClass.js
@@ -717,7 +717,7 @@ export class UserStorage {
     let magicLink = `${username}+${password}`
     magicLink = Buffer.from(magicLink)
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     return magicLink
   }

--- a/src/lib/share/__tests__/generateShareLink.js
+++ b/src/lib/share/__tests__/generateShareLink.js
@@ -44,7 +44,7 @@ describe('generateShareLink', () => {
     }
     let paramsBase64 = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const link = generateShareLink(action, params)
@@ -61,7 +61,7 @@ describe('generateShareLink', () => {
     }
     let paramsBase64 = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const link = generateShareLink(action, params)
@@ -81,7 +81,7 @@ describe('generateShareLink', () => {
     }
     let paramsBase64 = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const link = generateShareLink(action, params)
@@ -101,7 +101,7 @@ describe('generateShareLink', () => {
     }
     let paramsBase64 = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const link = generateShareLink(action, params)
@@ -116,7 +116,7 @@ describe('generateShareLink', () => {
     const params = { key: 'value with spaces' }
     let paramsBase64 = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const link = generateShareLink(action, params)

--- a/src/lib/share/__tests__/readCode.js
+++ b/src/lib/share/__tests__/readCode.js
@@ -27,7 +27,7 @@ describe('readCode', () => {
     // Given
     const code = Buffer.from(JSON.stringify({ mnid: '3cvdwVrcFXaMDBpkeJdrFKnfCyxQ1PDx6TG' }))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     // When
     const decoded = readCode(code)

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -241,7 +241,7 @@ export function generateShareLink(action: ActionType = 'receive', params: {} = {
   let paramsBase64 = encodeURIComponent(
     Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, ''),
+      .replace(/=+$/, ''),
   )
   let queryParams = ''
 

--- a/src/lib/undux/utils/__tests__/withdraw.js
+++ b/src/lib/undux/utils/__tests__/withdraw.js
@@ -67,7 +67,7 @@ describe('Decode base64', () => {
     }
     const code = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
     const decoded = parsePaymentLinkParams({ paymentCode: code })
 
     // Then
@@ -87,7 +87,7 @@ describe('Decode base64', () => {
 
     const code = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
     const decoded = parsePaymentLinkParams({ paymentCode: code, ...otherParams })
 
     expect(decoded).toEqual(params)
@@ -105,7 +105,7 @@ describe('Decode base64', () => {
     }
     const code = Buffer.from(JSON.stringify(params))
       .toString('base64')
-      .replace(/==$/, '')
+      .replace(/=+$/, '')
 
     const decoded = parsePaymentLinkParams({ paymentCode: code, ...otherParams })
 

--- a/src/lib/utils/deepLinking.native.js
+++ b/src/lib/utils/deepLinking.native.js
@@ -82,8 +82,12 @@ class DeepLinkingNative {
     this._isFirstRun = false
     this._lastClick = clickTimestamp
     const branchLink = referingLink
+    let queryParams = params
 
-    const queryParams = nonBranchLink ? extractQueryParams(nonBranchLink) : params
+    if (nonBranchLink) {
+      const decodedLink = decodeURI(nonBranchLink)
+      queryParams = extractQueryParams(decodedLink)
+    }
 
     this.pathname = extractPathname(nonBranchLink || branchLink)
 

--- a/src/lib/utils/deepLinking.web.js
+++ b/src/lib/utils/deepLinking.web.js
@@ -4,7 +4,8 @@ class DeepLinkingWeb {
   pathname = window.location.pathname
 
   get params() {
-    return extractQueryParams(window.location.href)
+    const decodedHref = decodeURI(window.location.href)
+    return extractQueryParams(decodedHref)
   }
 }
 


### PR DESCRIPTION
# Description

This PR adds decoding of url for deeplinks for both web and android. It also fixes the regex used in all base64 conversions to remove all padding automatically added and prevent having links with '=' at the end

About #2672 


# How Has This Been Tested?

Generated various links by sending money between different accounts.
1. generate links by adding reason to the transaction 
2. generate links by leaving empty the reason of the transaction 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
