### PR TITLE
(Bug) Analytics fix 'toLowerCase is not a function' on empty errors

### DIFF
--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -2,7 +2,7 @@
 
 // libraries
 import amplitude from 'amplitude-js'
-import { assign, debounce, forIn, get, isError, isFunction, isString, remove, toLower } from 'lodash'
+import { assign, debounce, forIn, get, isEmpty, isError, isFunction, isString, remove, toLower } from 'lodash'
 import * as Sentry from '@sentry/browser'
 
 // utils
@@ -384,11 +384,15 @@ const patchLogger = () => {
       sessionUrlAtTime = FS.getCurrentSessionURL(true)
     }
 
-    if (
-      categoryToPassIntoLog === Unexpected &&
-      ['connection', 'websocket', 'network'].some(str => toLower(eMsg).includes(str))
-    ) {
-      categoryToPassIntoLog = Network
+    if (isString(eMsg) && !isEmpty(eMsg)) {
+      const lowerCased = toLower(eMsg)
+
+      if (
+        categoryToPassIntoLog === Unexpected &&
+        ['connection', 'websocket', 'network'].some(str => lowerCased.includes(str))
+      ) {
+        categoryToPassIntoLog = Network
+      }
     }
 
     if (isString(logMessage) && !logMessage.includes('axios')) {


### PR DESCRIPTION
# Description
analytics.js on patchLogger:
Fix error when 'error message' is empty or not a string ('.toLowerCase is not a function')

As suggested in comment in #2694 

('master' version of #2700 )

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
