### PR TITLE
(BUG) [RN] The pop-ups shadow is too dark

### DIFF
--- a/src/components/common/modal/ModalInnerContents.js
+++ b/src/components/common/modal/ModalInnerContents.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { withStyles } from '../../../lib/styles'
 import { lowZIndex } from './styles'
 
@@ -13,11 +13,25 @@ const getStylesFromProps = ({ theme }) => ({
     backgroundColor: theme.modals.backgroundColor,
     borderBottomRightRadius: theme.modals.borderRadius,
     borderTopRightRadius: theme.modals.borderRadius,
-    boxShadow: '0 20px 24px rgba(0, 0, 0, 0.5)',
     flexGrow: 1,
     padding: theme.modals.contentPadding,
     position: 'relative',
     zIndex: lowZIndex,
+    ...Platform.select({
+      web: {
+        boxShadow: '0 20px 24px rgba(0, 0, 0, 0.5)',
+      },
+      default: {
+        shadowColor: '#000',
+        shadowOffset: {
+          width: 0,
+          height: theme.modals.jaggedEdgeSize,
+        },
+        shadowOpacity: 0.5,
+        shadowRadius: 20,
+        elevation: 24,
+      },
+    }),
   },
 })
 

--- a/src/components/common/modal/ModalWrapper.js
+++ b/src/components/common/modal/ModalWrapper.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { ScrollView, View } from 'react-native'
-import { isMobileNative, isMobileOnly } from '../../../lib/utils/platform'
+import { isMobileOnly } from '../../../lib/utils/platform'
 import { withStyles } from '../../../lib/styles'
 import ModalCloseButton from './ModalCloseButton'
 import ModalJaggedEdge from './ModalJaggedEdge'
@@ -47,7 +47,6 @@ const ModalWrapper = (props: any) => {
             <ModalInnerContents
               style={[
                 showJaggedEdge ? styles.modalContainerStraightenBottomRightEdge : '',
-                isMobileNative && styles.nativeBlur,
                 showTooltipArrow && styles.noneShadow,
               ]}
             >
@@ -84,16 +83,6 @@ const getStylesFromProps = ({ theme }) => ({
   },
   shadow: {
     boxShadow: '0px 2px 4px #00000029',
-  },
-  nativeBlur: {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: theme.modals.jaggedEdgeSize,
-    },
-    shadowOpacity: 0.75,
-    shadowRadius: 16,
-    elevation: 24,
   },
   triangle: {
     position: 'absolute',

--- a/src/components/common/modal/ModalWrapper.js
+++ b/src/components/common/modal/ModalWrapper.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { ScrollView, View } from 'react-native'
-import { isMobileOnly } from '../../../lib/utils/platform'
+import { isMobileNative, isMobileOnly } from '../../../lib/utils/platform'
 import { withStyles } from '../../../lib/styles'
 import ModalCloseButton from './ModalCloseButton'
 import ModalJaggedEdge from './ModalJaggedEdge'
@@ -47,7 +47,7 @@ const ModalWrapper = (props: any) => {
             <ModalInnerContents
               style={[
                 showJaggedEdge ? styles.modalContainerStraightenBottomRightEdge : '',
-                isMobileOnly && styles.nativeBlur,
+                isMobileNative && styles.nativeBlur,
                 showTooltipArrow && styles.noneShadow,
               ]}
             >


### PR DESCRIPTION
# Description
Fix pop-up shadow on web mobile:
Moved native shadow styles from ModalWrapper to ModalInnerContents, where we are selecting between these and `boxShadow` via `Platform.select()`

About #2657 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes


## Screenshot:
![image](https://user-images.githubusercontent.com/28148619/98380340-33372f00-2027-11eb-9eeb-d9c77af620d1.png)
