### PR TITLE
(Bug) [Native/Android] The app is crashed on the authentication screen after closing the "Complete action using" pop up

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -11,3 +11,4 @@
 
 -dontwarn io.branch.**
 -keep class org.gooddollar.BuildConfig { *; }
+-keep public class com.horcrux.svg.** { *; }


### PR DESCRIPTION
# Description
Fixed svg crash (on release apk) when showing error popup:
* keeping classes used by rn-svg in proguard rules, as suggested [here](https://github.com/react-native-svg/react-native-svg/issues/1061#issuecomment-517031073)

About #2818 

# How Has This Been Tested?

Tested by generating release apks locally and doing the steps detailed in the issue
* tested this without this fix, reproducing the error
* tested this with the fix, app no longer crashes

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
