### PR TITLE
(Bug) [RN] Opening dashboard feed items always shows the popup for the first item on the list

### DIFF
--- a/src/components/dashboard/FeedModalList.js
+++ b/src/components/dashboard/FeedModalList.js
@@ -48,8 +48,10 @@ const FeedModalList = ({
   const [loading, setLoading] = useState(true)
   const [offset, setOffset] = useState()
 
-  const selectedFeedIndex = useMemo(() => (selectedFeed ? data.findIndex(item => item.id === selectedFeed.id) : -1), [
-    data,
+  const feeds = useFeeds(data)
+
+  const selectedFeedIndex = useMemo(() => (selectedFeed ? feeds.findIndex(item => item.id === selectedFeed.id) : -1), [
+    feeds,
     selectedFeed,
   ])
 
@@ -116,8 +118,6 @@ const FeedModalList = ({
     [offset, setLoading],
   )
 
-  const feeds = useFeeds(data)
-
   return (
     <Portal>
       <View style={[styles.horizontalContainer, { opacity: loading ? 0 : 1 }]}>
@@ -161,14 +161,14 @@ const getStylesFromProps = ({ theme }) => ({
     }),
     width: '100%',
   },
-  horizontalList: {
-    width: '100%',
-    maxWidth: Platform.select({
-      web: '100vw',
-      default: getScreenWidth(),
-    }),
-    flex: 1,
-  },
+  horizontalList: Platform.select({
+    web: {
+      width: '100%',
+      maxWidth: '100vw',
+      flex: 1,
+    },
+    default: {},
+  }),
   horizontalListItem: {
     width: maxScreenWidth,
   },

--- a/src/components/dashboard/FeedModalList.js
+++ b/src/components/dashboard/FeedModalList.js
@@ -48,7 +48,7 @@ const FeedModalList = ({
   const [loading, setLoading] = useState(true)
   const [offset, setOffset] = useState()
 
-  const feeds = useFeeds(data)
+  const feeds = useFeeds(data, false) // get feeds without invites
 
   const selectedFeedIndex = useMemo(() => (selectedFeed ? feeds.findIndex(item => item.id === selectedFeed.id) : -1), [
     feeds,
@@ -84,23 +84,18 @@ const FeedModalList = ({
   }, [offset, flatListRef, setLoading])
 
   const renderItemComponent = useCallback(
-    ({ item, separators }: ItemComponentProps) => {
-      if (item.type === 'invite') {
-        return
-      }
-      return (
-        <View style={styles.horizontalListItem}>
-          <FeedModalItem
-            navigation={navigation}
-            item={item}
-            separators={separators}
-            fixedHeight
-            onPress={() => handleFeedSelection(item, false)}
-          />
-        </View>
-      )
-    },
-    [handleFeedSelection, navigation],
+    ({ item, separators }: ItemComponentProps) => (
+      <View style={styles.horizontalListItem}>
+        <FeedModalItem
+          navigation={navigation}
+          item={item}
+          separators={separators}
+          fixedHeight
+          onPress={() => handleFeedSelection(item, false)}
+        />
+      </View>
+    ),
+    [(handleFeedSelection, navigation)],
   )
 
   const initialNumToRender = useMemo(() => Math.abs(selectedFeedIndex), [selectedFeedIndex])

--- a/src/components/dashboard/FeedModalList.js
+++ b/src/components/dashboard/FeedModalList.js
@@ -95,7 +95,7 @@ const FeedModalList = ({
         />
       </View>
     ),
-    [(handleFeedSelection, navigation)],
+    [handleFeedSelection, navigation],
   )
 
   const initialNumToRender = useMemo(() => Math.abs(selectedFeedIndex), [selectedFeedIndex])

--- a/src/components/dashboard/utils/feed.js
+++ b/src/components/dashboard/utils/feed.js
@@ -33,15 +33,15 @@ export const keyExtractor = item => {
   return itemKeyMap.get(item)
 }
 
-export const useFeeds = data =>
+export const useFeeds = (data, includeInvites = true) =>
   useMemo(() => {
     if (!isArray(data) || isEmpty(data)) {
       return [emptyFeed]
     }
 
-    if (Config.enableInvites) {
+    if (includeInvites && Config.enableInvites) {
       return data
     }
 
     return data.filter(item => get(item, 'type') !== 'invite')
-  }, [data])
+  }, [data, includeInvites])


### PR DESCRIPTION
# Description
Fixed FeedModalList scrolling not working on native: 
removed (for native) `flex: 1` & width styles passed to FlatList in `contentContainerStyle` that were causing problems with scrolling on native

Also fixed issues with index mismatch of data/feeds and rendered items which would sometimes open the wrong modal:
this happened because invite items were not rendered but could still be present in the feeds array (when config.enableInvites == true)
To fix this, added an option on `useFeeds()` to filter them regardless of the config & doing so FeedModalList.js
Then, removed the no longer necessary filtering of invite items in `renderItemComponent()`

About #2839 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
