### PR TITLE
2897 (Bug) trimLeft fullName string

### DIFF
--- a/src/components/signup/NameForm.js
+++ b/src/components/signup/NameForm.js
@@ -41,6 +41,7 @@ class NameForm extends React.Component<Props, State> {
   input = undefined
 
   handleChange = (fullName: string) => {
+    fullName = fullName.trimLeft()
     this.checkErrorsSlow()
     this.setState({ fullName })
   }

--- a/src/lib/validators/validateFullName.js
+++ b/src/lib/validators/validateFullName.js
@@ -4,7 +4,7 @@ export const validateFullName = (fullName: string) => {
     return ERROR_MESSAGE.EMPTY
   } else if (/\d+/.test(fullName)) {
     return ERROR_MESSAGE.ONLY_LETTERS
-  } else if (fullName.match(/\w{2,} \w{2,}/) == null) {
+  } else if (fullName.match(/^\w{2,} \w{2,}/) == null) {
     return ERROR_MESSAGE.FULL_NAME
   }
 


### PR DESCRIPTION
improve regex to validate full name

# Description

User is able to enter more than 1 space in a row on the name input stage of the Sign-up via passwordless

About #2897


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
