### PR TITLE
(Bug) The amount of all invited before users are displayed on the counter after logging in to the inviter account on the next day

### DIFF
--- a/src/components/appNavigation/TabsView.js
+++ b/src/components/appNavigation/TabsView.js
@@ -10,8 +10,6 @@ import { Icon, Text } from '../../components/common'
 import useOnPress from '../../lib/hooks/useOnPress'
 import useSideMenu from '../../lib/hooks/useSideMenu'
 import { isMobileNative } from '../../lib/utils/platform'
-import AsyncStorage from '../../lib/utils/asyncStorage'
-import userStorage from '../../lib/gundb/UserStorage'
 import { useInvited } from '../invite/useInvites'
 import { theme } from '../theme/styles'
 const { isEToro, enableInvites, showRewards } = config
@@ -72,21 +70,15 @@ const defaultRightButtonStyles = [iconStyle, styles.iconViewRight]
 const inviteButtonStyles = showRewardsFlag ? defaultLeftButtonStyles.slice(1) : defaultLeftButtonStyles
 
 const RewardButton = React.memo(({ onPress, style }) => {
-  const [, , , inviteState] = useInvited()
+  const { inviteState, lastState } = useInvited()
   const [updatesCount, setUpdatesCount] = useState(0)
 
   useEffect(() => {
-    const updateIcon = async () => {
-      const lastState = (await AsyncStorage.getItem('GD_lastInviteState')) ||
-        userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0, total: 0 }
+    const newPending = Math.max(inviteState.pending - lastState.pending, 0)
+    const newApproved = Math.max(inviteState.approved - lastState.approved, 0)
 
-      const newPending = Math.max(inviteState.pending - lastState.pending, 0)
-      const newApproved = Math.max(inviteState.approved - lastState.approved, 0)
-      setUpdatesCount(newPending + newApproved)
-    }
-
-    updateIcon()
-  }, [inviteState])
+    setUpdatesCount(newPending + newApproved)
+  }, [inviteState, lastState])
 
   return (
     <>

--- a/src/components/appNavigation/TabsView.js
+++ b/src/components/appNavigation/TabsView.js
@@ -10,7 +10,7 @@ import { Icon, Text } from '../../components/common'
 import useOnPress from '../../lib/hooks/useOnPress'
 import useSideMenu from '../../lib/hooks/useSideMenu'
 import { isMobileNative } from '../../lib/utils/platform'
-import { useInvited } from '../invite/useInvites'
+import { useInvited, useLastInviteState } from '../invite/useInvites'
 import { theme } from '../theme/styles'
 const { isEToro, enableInvites, showRewards } = config
 
@@ -70,7 +70,8 @@ const defaultRightButtonStyles = [iconStyle, styles.iconViewRight]
 const inviteButtonStyles = showRewardsFlag ? defaultLeftButtonStyles.slice(1) : defaultLeftButtonStyles
 
 const RewardButton = React.memo(({ onPress, style }) => {
-  const { inviteState, lastState } = useInvited()
+  const [, , , inviteState] = useInvited()
+  const [lastState] = useLastInviteState(inviteState)
   const [updatesCount, setUpdatesCount] = useState(0)
 
   useEffect(() => {

--- a/src/components/appNavigation/__tests__/TabsView.js
+++ b/src/components/appNavigation/__tests__/TabsView.js
@@ -4,8 +4,11 @@ import TabsView from '../TabsView'
 import Dashboard from '../../dashboard/Dashboard'
 import Profile from '../../profile/Profile'
 import SimpleStore from '../../../lib/undux/SimpleStore'
+import userStorage from '../../../lib/gundb/UserStorage'
 
 // Note: test renderer must be required after react-native.
+
+jest.setTimeout(20000)
 
 describe('TabsView', () => {
   const routes = {
@@ -16,6 +19,11 @@ describe('TabsView', () => {
       screen: Profile,
     },
   }
+
+  beforeAll(async () => {
+    await userStorage.wallet.ready
+    await userStorage.ready
+  })
 
   it('renders without errors', () => {
     const tree = renderer.create(

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -18,7 +18,7 @@ import { fireEvent, INVITE_HOWTO, INVITE_SHARE } from '../../lib/analytics/analy
 import Config from '../../config/config'
 import { generateShareObject, isSharingAvailable } from '../../lib/share'
 import ModalLeftBorder from '../common/modal/ModalLeftBorder'
-import { useCollectBounty, useInviteCode, useInvited } from './useInvites'
+import { useCollectBounty, useInviteCode, useInvited, useLastInviteState } from './useInvites'
 import FriendsSVG from './friends.svg'
 import EtoroPNG from './etoro.png'
 
@@ -347,7 +347,8 @@ const InvitesData = ({ invitees, refresh, level, totalEarned = 0 }) => (
 
 const Invite = () => {
   const [showHowTo, setShowHowTo] = useState(false)
-  const { invitees, refresh, level, inviteState, clearLastState, initialized } = useInvited()
+  const [invitees, refresh, level, inviteState, initialized] = useInvited()
+  const [, clearLastState] = useLastInviteState(inviteState)
   const totalEarned = get(inviteState, 'totalEarned', 0)
   const bounty = result(level, 'bounty.toNumber', 100) / 100
 

--- a/src/components/invite/useInvites.js
+++ b/src/components/invite/useInvites.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { defaults, find, groupBy, keyBy, uniqBy } from 'lodash'
 import goodWallet from '../../lib/wallet/GoodWallet'
+import UserProperties from '../../lib/gundb/UserPropertiesClass'
 import userStorage from '../../lib/gundb/UserStorage'
 import logger from '../../lib/logger/pino-logger'
 import { useDialog } from '../../lib/undux/utils/dialog'
@@ -9,7 +10,7 @@ import { decorate, ExceptionCode } from '../../lib/logger/exceptions'
 import Config from '../../config/config'
 
 const log = logger.child({ from: 'useInvites' })
-const defaultLastInviteState = { pending: 0, approved: 0 }
+const { lastInviteState: defaultLastInviteState } = UserProperties.defaultProperties
 
 const registerForInvites = async () => {
   const inviterInviteCode = userStorage.userProperties.get('inviterInviteCode')

--- a/src/components/invite/useInvites.js
+++ b/src/components/invite/useInvites.js
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react'
 import { defaults, find, groupBy, keyBy, uniqBy } from 'lodash'
 import goodWallet from '../../lib/wallet/GoodWallet'
 import userStorage from '../../lib/gundb/UserStorage'
-import UserPropertiesClass from '../../lib/gundb/UserPropertiesClass'
 import logger from '../../lib/logger/pino-logger'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import { fireEvent, INVITE_BOUNTY, INVITE_JOIN } from '../../lib/analytics/analytics'
@@ -10,8 +9,7 @@ import { decorate, ExceptionCode } from '../../lib/logger/exceptions'
 import Config from '../../config/config'
 
 const log = logger.child({ from: 'useInvites' })
-
-const { lastInviteState: defaultLastInviteState } = UserPropertiesClass.defaultProperties
+const defaultLastInviteState = { pending: 0, approved: 0 }
 
 const registerForInvites = async () => {
   const inviterInviteCode = userStorage.userProperties.get('inviterInviteCode')

--- a/src/components/invite/useInvites.js
+++ b/src/components/invite/useInvites.js
@@ -40,6 +40,9 @@ const getInviteCode = async () => {
   return code
 }
 
+const getInitialLastInviteState = () =>
+  defaults(userStorage.userProperties.get('lastInviteState') || {}, defaultLastInviteState)
+
 export const useInviteCode = () => {
   const [inviteCode, setInviteCode] = useState(userStorage.userProperties.get('inviteCode'))
 
@@ -134,16 +137,12 @@ export const useCollectBounty = () => {
 }
 
 export const useLastInviteState = inviteState => {
-  const [lastState, setLastState] = useState(defaultLastInviteState)
+  const [lastState, setLastState] = useState(getInitialLastInviteState())
 
   const clearLastState = useCallback(() => {
     setLastState(inviteState)
     userStorage.userProperties.set('lastInviteState', inviteState)
   }, [inviteState, setLastState])
-
-  useEffect(() => {
-    setLastState(defaults(userStorage.userProperties.get('lastInviteState') || {}, defaultLastInviteState))
-  }, [])
 
   return [lastState, clearLastState]
 }

--- a/src/lib/gundb/UserPropertiesClass.js
+++ b/src/lib/gundb/UserPropertiesClass.js
@@ -47,7 +47,6 @@ export default class UserProperties {
   // eslint-disable-next-line
   static keepFields = [
     'goodMarketClicked',
-    'cachedInvites',
     'lastInviteState',
   ]
 


### PR DESCRIPTION
# Description

- keep invitees cache and last state in the user props
- remove extra usage of AsyncStorage (user props already cached inside it)
- wait for invitees and last state loaded and fully initialised before update lastState (for clear invited amount)
- do not clear  invitees / last state cache on userProps.reset(). This fixes the case when we removing then re-creating account.
- simplify invitees list and last state management by moving then both in a single hook




Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

About #2931



# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
