### PR TITLE
(Bug) The amount of all invited before users are displayed on the counter after logging in to the inviter account on the next day 

### DIFF
--- a/src/components/appNavigation/TabsView.js
+++ b/src/components/appNavigation/TabsView.js
@@ -75,7 +75,7 @@ const RewardButton = React.memo(({ onPress, style }) => {
   const [updatesCount, setUpdatesCount] = useState(0)
 
   useEffect(() => {
-    const lastState = userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0 }
+    const lastState = userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0, totalEarned: 0 }
 
     const newPending = Math.max(inviteState.pending - lastState.pending, 0)
     const newApproved = Math.max(inviteState.approved - lastState.approved, 0)

--- a/src/components/appNavigation/TabsView.js
+++ b/src/components/appNavigation/TabsView.js
@@ -10,7 +10,6 @@ import { Icon, Text } from '../../components/common'
 import useOnPress from '../../lib/hooks/useOnPress'
 import useSideMenu from '../../lib/hooks/useSideMenu'
 import { isMobileNative } from '../../lib/utils/platform'
-import AsyncStorage from '../../lib/utils/asyncStorage'
 import userStorage from '../../lib/gundb/UserStorage'
 import { useInvited } from '../invite/useInvites'
 import { theme } from '../theme/styles'
@@ -76,16 +75,11 @@ const RewardButton = React.memo(({ onPress, style }) => {
   const [updatesCount, setUpdatesCount] = useState(0)
 
   useEffect(() => {
-    const updateIcon = async () => {
-      const lastState = (await AsyncStorage.getItem('GD_lastInviteState')) ||
-        userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0, total: 0 }
+    const lastState = userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0 }
 
-      const newPending = Math.max(inviteState.pending - lastState.pending, 0)
-      const newApproved = Math.max(inviteState.approved - lastState.approved, 0)
-      setUpdatesCount(newPending + newApproved)
-    }
-
-    updateIcon()
+    const newPending = Math.max(inviteState.pending - lastState.pending, 0)
+    const newApproved = Math.max(inviteState.approved - lastState.approved, 0)
+    setUpdatesCount(newPending + newApproved)
   }, [inviteState])
 
   return (

--- a/src/components/appNavigation/TabsView.js
+++ b/src/components/appNavigation/TabsView.js
@@ -77,9 +77,7 @@ const RewardButton = React.memo(({ onPress, style }) => {
   useEffect(() => {
     const lastState = userStorage.userProperties.get('lastInviteState') || { pending: 0, approved: 0, totalEarned: 0 }
 
-    const newPending = Math.max(inviteState.pending - lastState.pending, 0)
-    const newApproved = Math.max(inviteState.approved - lastState.approved, 0)
-    setUpdatesCount(newPending + newApproved)
+    setUpdatesCount(['pending', 'approved'].reduce((__, _) => __ + Math.max(inviteState[_] - lastState[_], 0), 0))
   }, [inviteState])
 
   return (

--- a/src/components/appNavigation/__tests__/TabsView.js
+++ b/src/components/appNavigation/__tests__/TabsView.js
@@ -4,8 +4,10 @@ import TabsView from '../TabsView'
 import Dashboard from '../../dashboard/Dashboard'
 import Profile from '../../profile/Profile'
 import SimpleStore from '../../../lib/undux/SimpleStore'
+import userStorage from '../../../lib/gundb/UserStorage'
 
 // Note: test renderer must be required after react-native.
+jest.setTimeout(20000)
 
 describe('TabsView', () => {
   const routes = {
@@ -16,6 +18,11 @@ describe('TabsView', () => {
       screen: Profile,
     },
   }
+
+  beforeAll(async () => {
+    await userStorage.wallet.ready
+    await userStorage.ready
+  })
 
   it('renders without errors', () => {
     const tree = renderer.create(

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -17,7 +17,6 @@ import { isMobile } from '../../lib/utils/platform'
 import { fireEvent, INVITE_HOWTO, INVITE_SHARE } from '../../lib/analytics/analytics'
 import Config from '../../config/config'
 import { generateShareObject, isSharingAvailable } from '../../lib/share'
-import AsyncStorage from '../../lib/utils/asyncStorage'
 import userStorage from '../../lib/gundb/UserStorage'
 import ModalLeftBorder from '../common/modal/ModalLeftBorder'
 import { useCollectBounty, useInviteCode, useInvited } from './useInvites'
@@ -349,7 +348,7 @@ const InvitesData = ({ invitees, refresh, level, totalEarned = 0 }) => (
 
 const Invite = () => {
   const [showHowTo, setShowHowTo] = useState(false)
-  const [invitees, refresh, level, inviteState] = useInvited()
+  const [invitees, refresh, level, inviteState, initialized] = useInvited()
 
   const totalEarned = get(inviteState, 'totalEarned', 0)
   const bounty = result(level, 'bounty.toNumber', 100) / 100
@@ -360,12 +359,11 @@ const Invite = () => {
   }
 
   useEffect(() => {
-    //reset state for rewards icon in navbar
-    if (inviteState.pending || inviteState.approved) {
-      userStorage.userProperties.set('lastInviteState', inviteState)
-      AsyncStorage.setItem('GD_lastInviteState', inviteState)
+    // reset state for rewards icon in navbar
+    if (initialized) {
+      userStorage.userProperties.set('lastInviteState', inviteState || { pending: 0, approved: 0 })
     }
-  }, [inviteState])
+  }, [initialized])
 
   return (
     <Wrapper style={styles.pageBackground} backgroundColor={theme.colors.lightGray}>

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -361,7 +361,7 @@ const Invite = () => {
   useEffect(() => {
     // reset state for rewards icon in navbar
     if (initialized) {
-      userStorage.userProperties.set('lastInviteState', inviteState || { pending: 0, approved: 0 })
+      userStorage.userProperties.set('lastInviteState', inviteState || { pending: 0, approved: 0, totalEarned: 0 })
     }
   }, [initialized])
 

--- a/src/components/invite/useInvites.js
+++ b/src/components/invite/useInvites.js
@@ -133,6 +133,7 @@ const useCollectBounty = () => {
 }
 
 const useInvited = () => {
+  const [initialized, setInitialized] = useState(false)
   const [invites, setInvites] = useState([])
   const [level, setLevel] = useState({})
   const [totalEarned, setTotalEarned] = useState(0)
@@ -181,12 +182,18 @@ const useInvited = () => {
   }
 
   useEffect(() => {
-    updateInvited()
+    updateInvited().then(() => setInitialized(true))
   }, [])
 
   const { pending = [], approved = [] } = groupBy(invites, 'status')
 
-  return [invites, updateInvited, level, { pending: pending.length, approved: approved.length, totalEarned }]
+  return [
+    invites,
+    updateInvited,
+    level,
+    { pending: pending.length, approved: approved.length, totalEarned },
+    initialized,
+  ]
 }
 
 export { useInviteCode, useInvited, useCollectBounty }

--- a/src/lib/gundb/UserPropertiesClass.js
+++ b/src/lib/gundb/UserPropertiesClass.js
@@ -1,5 +1,5 @@
 // @flow
-import { assign, isNil, isUndefined } from 'lodash'
+import { assign, isNil, isUndefined, pick } from 'lodash'
 import AsyncStorage from '../../lib/utils/asyncStorage'
 import { retry } from '../../lib/utils/async'
 import { REGISTRATION_METHOD_SELF_CUSTODY } from '../constants/login'
@@ -37,6 +37,8 @@ export default class UserProperties {
     inviteCode: null,
     lastInviteState: { pending: 0, approved: 0 },
   }
+
+  static keepFields = ['goodMarketClicked', 'lastInviteState']
 
   fields = [
     'isMadeBackup',
@@ -161,10 +163,12 @@ export default class UserProperties {
    * Reset properties to the default state
    */
   async reset() {
-    const { defaultProperties } = UserProperties
+    const { data } = this
+    const { defaultProperties, keepFields } = UserProperties
+    const dataBeenReset = assign({}, defaultProperties, pick(data || {}, keepFields))
 
-    this.data = assign({}, defaultProperties)
-    await this._storeProps(defaultProperties, 'reset()')
+    this.data = dataBeenReset
+    await this._storeProps(dataBeenReset, 'reset()')
 
     return true
   }


### PR DESCRIPTION
# Description

- keep invitees cache and last state in the user props
- remove extra usage of AsyncStorage (user props already cached inside it)
- wait for invitees and last state loaded and fully initialised before update lastState (for clear invited amount)
- do not clear  invitees / last state cache on userProps.reset(). This fixes the case when we removing then re-creating account.
- simplify invitees list and last state management by moving then both in a single hook




Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

About #2931



# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
