### PR TITLE
(Bug) The image goes out of the container on the "Unfortunately, we found your twin" screen

### DIFF
--- a/src/components/common/animations/FaceVerificationErrorSmiley/index.js
+++ b/src/components/common/animations/FaceVerificationErrorSmiley/index.js
@@ -5,8 +5,12 @@ import AnimationBase from '../Base'
 import animationData from './data.json'
 
 const styles = {
-  android: {},
-  ios: {},
+  android: {
+    height: '100%',
+  },
+  ios: {
+    height: '100%',
+  },
   web: {
     height: '100%',
   },

--- a/src/components/common/animations/FaceVerificationErrorSmiley/index.js
+++ b/src/components/common/animations/FaceVerificationErrorSmiley/index.js
@@ -1,20 +1,7 @@
 import React from 'react'
-import { Platform } from 'react-native'
 import Lottie from 'lottie-react-native'
 import AnimationBase from '../Base'
 import animationData from './data.json'
-
-const styles = {
-  android: {
-    height: '100%',
-  },
-  ios: {
-    height: '100%',
-  },
-  web: {
-    height: '100%',
-  },
-}
 
 class FaceVerificationSmiley extends AnimationBase {
   render() {
@@ -24,7 +11,7 @@ class FaceVerificationSmiley extends AnimationBase {
         autoPlay
         loop
         autoSize
-        style={Platform.select(styles)}
+        style={{ height: '100%' }}
         source={this.improveAnimationData(animationData)}
       />
     )

--- a/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
+++ b/src/components/dashboard/FaceVerification/components/DuplicateFoundError.js
@@ -87,6 +87,7 @@ const getStylesFromProps = ({ theme }) => {
       maxHeight: isMobileOnly ? getDesignRelativeHeight(97) : 'auto',
       display: 'flex',
       justifyContent: 'center',
+      alignItems: 'center',
       marginRight: 0,
       marginLeft: 0,
     },

--- a/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
+++ b/src/components/dashboard/FaceVerification/components/__tests__/__snapshots__/DuplicateFoundError.js.snap
@@ -31,7 +31,7 @@ We found your twin...
           className="css-view-1dbjc4n r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1d7fvdj"
         >
           <div
-            className="css-view-1dbjc4n r-display-6koalj r-justifyContent-1777fci r-marginBottom-p1pxzi r-marginLeft-11wrixw r-marginRight-61z16t r-marginTop-1mnahxq r-maxHeight-wwnmln r-width-snplw3"
+            className="css-view-1dbjc4n r-alignItems-1awozwy r-display-6koalj r-justifyContent-1777fci r-marginBottom-p1pxzi r-marginLeft-11wrixw r-marginRight-61z16t r-marginTop-1mnahxq r-maxHeight-wwnmln r-width-snplw3"
           >
             <div
               className="css-view-1dbjc4n"
@@ -43,7 +43,7 @@ We found your twin...
             />
           </div>
           <div
-            className="css-view-1dbjc4n r-display-6koalj r-justifyContent-1777fci r-marginBottom-p1pxzi r-marginLeft-11wrixw r-marginRight-61z16t r-marginTop-1mnahxq r-maxHeight-wwnmln r-width-snplw3"
+            className="css-view-1dbjc4n r-alignItems-1awozwy r-display-6koalj r-justifyContent-1777fci r-marginBottom-p1pxzi r-marginLeft-11wrixw r-marginRight-61z16t r-marginTop-1mnahxq r-maxHeight-wwnmln r-width-snplw3"
           >
             <div
               className="css-view-1dbjc4n"


### PR DESCRIPTION
# Description

The image of the twins was aligned at the center of the screen

About #3001 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
