### PR TITLE
(Bug) The grey frame is displayed on the feed cards while the cards are appearing on the Home screen

### DIFF
--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { TouchableHighlight, View } from 'react-native'
 import * as Animatable from 'react-native-animatable'
 
@@ -42,7 +42,6 @@ const FeedListItem = (props: FeedListItemProps) => {
   const itemStyle = getEventSettingsByType(theme, itemType)
   const disableAnimForTests = Config.env === 'test'
   const easing = 'ease-in'
-  const duration = 1000 // default duration for Animatable
 
   const imageStyle = {
     backgroundColor: itemStyle.color,
@@ -61,12 +60,14 @@ const FeedListItem = (props: FeedListItemProps) => {
     }
   }, [fireEvent, type, onItemPress, id])
 
-  // show shadow for native android only after opacity animation was finished
-  useEffect(() => {
-    if (isAndroidNative) {
-      setTimeout(() => setShowAndroidShadow(true), duration)
-    }
-  }, [])
+  const onAnimationFinished = useCallback(
+    ({ finished }) => {
+      if (finished && isAndroidNative) {
+        setShowAndroidShadow(true)
+      }
+    },
+    [setShowAndroidShadow],
+  )
 
   if (isItemEmpty) {
     const feedLoadAnimShown = simpleStore.get('feedLoadAnimShown')
@@ -135,7 +136,7 @@ const FeedListItem = (props: FeedListItemProps) => {
 
   return (
     <Animatable.View
-      duration={duration}
+      onAnimationEnd={onAnimationFinished}
       animation={disableAnimForTests ? '' : 'fadeIn'}
       easing={easing}
       useNativeDriver

--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -31,7 +31,7 @@ type FeedListItemProps = {
  * @returns {React.Node}
  */
 const FeedListItem = (props: FeedListItemProps) => {
-  const [animationFinished, setAnimationFinished] = useState<boolean>(false)
+  const [animationFinished, setAnimationFinished] = useState<boolean>(disableAnimForTests)
   const simpleStore = SimpleStore.useStore()
   const { theme, item, handleFeedSelection, styles } = props
   const { id, type, displayType, action } = item

--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -31,7 +31,7 @@ type FeedListItemProps = {
  * @returns {React.Node}
  */
 const FeedListItem = (props: FeedListItemProps) => {
-  const [endAnimation, setEndAnimation] = useState<boolean>(false)
+  const [animationFinished, setAnimationFinished] = useState<boolean>(false)
   const simpleStore = SimpleStore.useStore()
   const { theme, item, handleFeedSelection, styles } = props
   const { id, type, displayType, action } = item
@@ -59,7 +59,7 @@ const FeedListItem = (props: FeedListItemProps) => {
     }
   }, [fireEvent, type, onItemPress, id])
 
-  const onAnimationFinished = useCallback(({ finished }) => finished && setEndAnimation(true), [setEndAnimation])
+  const onAnimationFinished = useCallback(({ finished }) => finished && setAnimationFinished(true), [setAnimationFinished])
 
   if (isItemEmpty) {
     const feedLoadAnimShown = simpleStore.get('feedLoadAnimShown')
@@ -136,7 +136,7 @@ const FeedListItem = (props: FeedListItemProps) => {
       <TouchableHighlight
         activeOpacity={0.5}
         onPress={onPress}
-        style={[styles.row, endAnimation && styles.endAnimationRow]}
+        style={[styles.row, animationFinished && styles.rowHasBeenAnimated]}
         tvParallaxProperties={{ pressMagnification: 1.1 }}
         underlayColor={theme.colors.lightGray}
       >
@@ -163,7 +163,7 @@ const getStylesFromProps = ({ theme }) => ({
     shadowOpacity: 0.16,
     shadowRadius: 4,
   },
-  endAnimationRow: Platform.select({
+  rowHasBeenAnimated: Platform.select({
     android: { elevation: 1 },
     default: {},
   }),

--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -31,6 +31,7 @@ type FeedListItemProps = {
  * @returns {React.Node}
  */
 const FeedListItem = (props: FeedListItemProps) => {
+  const disableAnimForTests = Config.env === 'test'
   const [animationFinished, setAnimationFinished] = useState<boolean>(disableAnimForTests)
   const simpleStore = SimpleStore.useStore()
   const { theme, item, handleFeedSelection, styles } = props
@@ -39,7 +40,6 @@ const FeedListItem = (props: FeedListItemProps) => {
   const itemType = displayType || type
   const isItemEmpty = itemType === 'empty'
   const itemStyle = getEventSettingsByType(theme, itemType)
-  const disableAnimForTests = Config.env === 'test'
   const easing = 'ease-in'
 
   const imageStyle = {


### PR DESCRIPTION
# Description
Reason: On Android if View have shadow (elevation) and we animated opacity that View, we getting grey frame.
Solution: Show shadow for android only after animation was finished

About #3007 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
