### PR TITLE
(BUG) The "HandlePaymentLink" blank page is displayed after closing the "You can't withdraw your own payment link" pop-up

### DIFF
--- a/src/components/dashboard/HandlePaymentLink.js
+++ b/src/components/dashboard/HandlePaymentLink.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { useCallback, useEffect } from 'react'
+import { noop } from 'lodash'
 import { Wrapper } from '../common'
 import logger from '../../lib/logger/pino-logger'
 import { parsePaymentLinkParams, readCode } from '../../lib/share'
@@ -44,13 +45,22 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
     async anyParams => {
       try {
         if (anyParams && anyParams.code) {
+          showDialog({
+            onDismiss: noop,
+            title: 'Processing Payment Link...',
+            image: <LoadingIcon />,
+            message: 'please wait while processing...',
+            showCloseButtons: false,
+          })
           const code = readCode(decodeURIComponent(anyParams.code))
 
           if (isTheSameUser(code) === false) {
             try {
               const { route, params } = await routeAndPathForCode('send', code)
+              hideDialog()
               screenProps.push(route, params)
             } catch (e) {
+              hideDialog()
               log.error('Payment link is incorrect', e.message, e, {
                 code,
                 category: ExceptionCategory.Human,
@@ -194,6 +204,7 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
 
 HandlePaymentLink.navigationOptions = {
   title: ' ',
+  navigationBar: () => null,
 }
 
 const getStylesFromProps = ({ theme }) => ({
@@ -201,7 +212,5 @@ const getStylesFromProps = ({ theme }) => ({
     backgroundColor: theme.colors.gray50Percent,
   },
 })
-
-HandlePaymentLink.navigationOptions = {}
 
 export default withStyles(getStylesFromProps)(HandlePaymentLink)


### PR DESCRIPTION
# Description

Removed TabBar on empty screen and added modal loader while processing

About #3163 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
