### PR TITLE
(Bug) App crashes if change device orientation during FV initialize

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -828,6 +828,12 @@ export default createStackNavigator({
   FaceVerificationIntro,
   FaceVerificationError,
 
+  FaceVerificationIssue: {
+    screen: FaceVerificationError,
+    path: 'FaceVerificationError/:kindOfTheIssue',
+    params: { kindOfTheIssue: undefined },
+  },
+
   SendQRSummary,
 
   TransactionConfirmation: {

--- a/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/ErrorScreen.js
@@ -14,12 +14,13 @@ import useVerificationAttempts from '../hooks/useVerificationAttempts'
 
 import { getFirstWord } from '../../../../lib/utils/getFirstWord'
 
-const ErrorScreen = ({ styles, screenProps }) => {
+const ErrorScreen = ({ styles, screenProps, navigation }) => {
   const store = GDStore.useStore()
   const { isReachedMaxAttempts } = useVerificationAttempts()
 
   const exception = get(screenProps, 'screenState.error')
-  const kindOfTheIssue = get(exception, 'name')
+  const { kindOfTheIssue: fromParams } = get(navigation, 'state.params', {})
+  const kindOfTheIssue = get(exception, 'name', fromParams)
 
   const title = useMemo(() => {
     const { fullName } = store.get('profile')

--- a/src/components/dashboard/FaceVerification/sdk/EnrollmentProcessor.web.js
+++ b/src/components/dashboard/FaceVerification/sdk/EnrollmentProcessor.web.js
@@ -262,7 +262,14 @@ export class EnrollmentProcessor {
       // Only app reloading solves the issue and allows to retry FV attempt.
       // So, in that case we're redirecting app to the corresponding FV error scrren with full page reload
       _waitForSDKUIElementVisible('DOM_FT_cameraPermissionsScreen', () => {
-        restart('/AppNavigation/Dashboard/FaceVerificationError?kindOfTheIssue=DeviceOrientationError')
+        const uiContainer = document.getElementById('DOM_FT_mainInterfaceNonOverlayContainer')
+
+        if (uiContainer) {
+          // remove container only to keep blurred background while reloading
+          uiContainer.remove()
+        }
+
+        restart('/AppNavigation/Dashboard/FaceVerificationError/DeviceOrientationError')
       })
 
       // if we've got session ID - starting enrollment session


### PR DESCRIPTION
# Description

- used mutations observer to handle if the 'camera issue' dialog unexpectedly appears
- if the crash was detected - restart app on orientation error screen
- adjusted routing to have option to show specific error page by url (in our case - orientation error)
- fixed FV_Ready event - now it sends when user actually sees ready screen (before it was shown on FV UI just started loading)

About #3225 

# How Has This Been Tested?

- on instructions screen press 'ok verify'
- once FV starts loading, turn the device (need to do it **before** UI loads)
- FV error screen with 'wrong device orientation' should appears in a while

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
