### PR TITLE
(Bug) 3239 user unable to set mobile in profile

### DIFF
--- a/src/components/profile/VerifyEdit.js
+++ b/src/components/profile/VerifyEdit.js
@@ -12,7 +12,6 @@ import normalize from '../../lib/utils/normalizeText'
 import CustomButton from '../common/buttons/CustomButton'
 import API from '../../lib/API/api'
 import { useErrorDialog } from '../../lib/undux/utils/dialog'
-import userStorage from '../../lib/gundb/UserStorage'
 
 const log = logger.child({ from: 'Verify edit profile field' })
 
@@ -52,11 +51,7 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
     try {
       setLoading(true)
 
-      const { data } = await API[sendCodeRequestFn]({ [fieldToSend]: content })
-      if (data.alreadyVerified) {
-        await userStorage.setProfileField(field, content)
-        screenProps.pop()
-      }
+      await API[sendCodeRequestFn]({ [fieldToSend]: content })
       screenProps.push('VerifyEditCode', { field, content })
     } catch (e) {
       log.error('Failed to send code', e.message, e, { dialogShown: true })

--- a/src/components/profile/VerifyEdit.js
+++ b/src/components/profile/VerifyEdit.js
@@ -56,9 +56,8 @@ const EditProfile = ({ screenProps, theme, styles, navigation }) => {
       if (data.alreadyVerified) {
         await userStorage.setProfileField(field, content)
         screenProps.pop()
-      } else {
-        screenProps.push('VerifyEditCode', { field, content })
       }
+      screenProps.push('VerifyEditCode', { field, content })
     } catch (e) {
       log.error('Failed to send code', e.message, e, { dialogShown: true })
 


### PR DESCRIPTION
# Description

after the user press the "verify" button an SMS is sent and the user is shown the form to fill the OTP code

About # ([3239](https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/3239))


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
