### PR TITLE
add: vendor callback

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -55,7 +55,6 @@ import TransactionConfirmation from './TransactionConfirmation'
 import SendToAddress from './SendToAddress'
 import SendByQR from './SendByQR'
 import SendLinkSummary from './SendLinkSummary'
-import SendQRSummary from './SendQRSummary'
 import { ACTION_SEND } from './utils/sendReceiveFlow'
 
 import FaceVerification from './FaceVerification/screens/VerificationScreen'
@@ -833,8 +832,6 @@ export default createStackNavigator({
     path: 'FaceVerificationError/:kindOfTheIssue',
     params: { kindOfTheIssue: undefined },
   },
-
-  SendQRSummary,
 
   TransactionConfirmation: {
     screen: TransactionConfirmation,

--- a/src/components/dashboard/HandlePaymentLink.js
+++ b/src/components/dashboard/HandlePaymentLink.js
@@ -53,7 +53,7 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
             showCloseButtons: false,
           })
           const code = readCode(decodeURIComponent(anyParams.code))
-
+          log.debug('decoded payment request', { code })
           if (isTheSameUser(code) === false) {
             try {
               const { route, params } = await routeAndPathForCode('send', code)

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -12,6 +12,9 @@ import logger from '../../lib/logger/pino-logger'
 import { ExceptionCategory } from '../../lib/logger/exceptions'
 import { useDialog } from '../../lib/undux/utils/dialog'
 import goodWallet from '../../lib/wallet/GoodWallet'
+import { retry } from '../../lib/utils/async'
+import API from '../../lib/API/api'
+
 import { useScreenState } from '../appNavigation/stackNavigation'
 import { generateSendShareObject, generateSendShareText } from '../../lib/share'
 import { ACTION_SEND, ACTION_SEND_TO_ADDRESS, SEND_TITLE } from './utils/sendReceiveFlow'
@@ -40,7 +43,16 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
 
   const { goToRoot, navigateTo } = screenProps
   const { fullName } = gdstore.get('profile')
-  const { amount, reason = null, category = null, counterPartyDisplayName, contact, address, action } = screenState
+  const {
+    amount,
+    reason = null,
+    category = null,
+    counterPartyDisplayName,
+    contact,
+    address,
+    action,
+    vendorInfo,
+  } = screenState
 
   // Going to root after shared
   useEffect(() => {
@@ -144,6 +156,14 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
           onTransactionHash: hash => {
             log.debug('Send G$ to address', { hash })
             txhash = hash
+
+            //integrate with vendors callback, notifying payment has been made
+            const vendorCallback = get(vendorInfo, 'callbackUrl')
+            if (vendorCallback) {
+              retry(() => API.post(vendorCallback, { transactionId: txhash, invoiceId: vendorInfo.invoiceId })).catch(
+                e => log.error('failed notifying vendor callback', { vendorInfo }),
+              )
+            }
 
             // Save transaction
             const transactionEvent: TransactionEvent = {

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -157,8 +157,9 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
             log.debug('Send G$ to address', { hash })
             txhash = hash
 
-            //integrate with vendors callback, notifying payment has been made
+            // integrate with vendors callback, notifying payment has been made
             const vendorCallback = get(vendorInfo, 'callbackUrl')
+            
             if (vendorCallback) {
               retry(() => API.post(vendorCallback, { transactionId: txhash, invoiceId: vendorInfo.invoiceId })).catch(
                 e => log.error('failed notifying vendor callback', { vendorInfo }),

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -158,8 +158,10 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
             txhash = hash
 
             // integrate with vendors callback, notifying payment has been made
-            retry(() => API.notifyVendor(txhash, vendorInfo).catch(
-              e => log.error('failed notifying vendor callback', { vendorInfo }),
+            retry(() =>
+              API.notifyVendor(txhash, vendorInfo).catch(e =>
+                log.error('failed notifying vendor callback', { vendorInfo }),
+              ),
             )
 
             // Save transaction

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -158,13 +158,9 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
             txhash = hash
 
             // integrate with vendors callback, notifying payment has been made
-            const vendorCallback = get(vendorInfo, 'callbackUrl')
-            
-            if (vendorCallback) {
-              retry(() => API.post(vendorCallback, { transactionId: txhash, invoiceId: vendorInfo.invoiceId })).catch(
-                e => log.error('failed notifying vendor callback', { vendorInfo }),
-              )
-            }
+            retry(() => API.notifyVendor(txhash, vendorInfo).catch(
+              e => log.error('failed notifying vendor callback', { vendorInfo }),
+            )
 
             // Save transaction
             const transactionEvent: TransactionEvent = {

--- a/src/components/dashboard/utils/routeAndPathForCode.js
+++ b/src/components/dashboard/utils/routeAndPathForCode.js
@@ -26,7 +26,7 @@ export const routeAndPathForCode = async (
     throw new Error('Invalid QR Code.')
   }
 
-  const { networkId, address, amount, reason, category } = code
+  const { networkId, address, amount, reason, category, vendorInfo } = code
 
   await goodWallet.ready
   const currentNetworkId = goodWallet.networkId
@@ -51,6 +51,7 @@ export const routeAndPathForCode = async (
         category,
         amount,
         profile,
+        vendorInfo,
         counterPartyDisplayName: profile.name,
         action: ACTION_SEND_TO_ADDRESS,
         type: screen === 'sendByQR' ? 'QR' : 'receive',

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -399,6 +399,11 @@ export class APIService {
 
     return data.phase
   }
+
+  // eslint-disable-next-line require-await
+  async post(url, params) {
+    return this.client.post(url, params)
+  }
 }
 
 const api = new APIService()

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -399,10 +399,15 @@ export class APIService {
 
     return data.phase
   }
-
   // eslint-disable-next-line require-await
-  async post(url, params) {
-    return this.client.post(url, params)
+  async notifyVendor(transactionId, vendorInfo) {
+    const { callbackUrl, invoiceId } = vendorInfo || {}
+    
+    if (!callbackUrl) {
+      return  // or throw error
+    }
+    
+    return this.client.post(callbackUrl, { invoiceId, transactionId })
   }
 }
 

--- a/src/lib/share/__tests__/generateCode.js
+++ b/src/lib/share/__tests__/generateCode.js
@@ -63,7 +63,7 @@ describe('generateCode', () => {
       counterPartyDisplayName,
       vendorInfo: {
         callbackUrl: 'http://shop.example.com/api/callback',
-        invoiceData: 'INV#33333',
+        invoiceId: 'INV#33333',
         website: 'http://shop.example.com',
         vendorName: 'Example Shop',
       },

--- a/src/lib/share/index.js
+++ b/src/lib/share/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { Platform, Share } from 'react-native'
-import { fromPairs, isEmpty } from 'lodash'
+import { fromPairs, isEmpty, pickBy } from 'lodash'
 import { decode, encode, isMNID } from 'mnid'
 import isURL from 'validator/lib/isURL'
 import isEmail from '../validators/isEmail'
@@ -25,7 +25,7 @@ export const isSharingAvailable = Platform.select({
 export class VendorMetadata {
   callbackUrl: URL
 
-  invoiceData: string
+  invoiceId: string
 
   website: URL
 
@@ -39,9 +39,9 @@ export class VendorMetadata {
 
   static VENDOR_SHORT = 'ven'
 
-  constructor(callbackUrl: URL, invoiceData: string, website: URL, vendorName: string) {
+  constructor(callbackUrl: URL, invoiceId: string, website: URL, vendorName: string) {
     this.callbackUrl = callbackUrl
-    this.invoiceData = invoiceData
+    this.invoiceId = invoiceId
     this.website = website
     this.vendorName = vendorName
   }
@@ -54,7 +54,7 @@ export class VendorMetadata {
   toConcise(): Object {
     let response = {}
     response[VendorMetadata.CALLBACK_URL_SHORT] = this.callbackUrl
-    response[VendorMetadata.INVOICE_DATA_SHORT] = this.invoiceData
+    response[VendorMetadata.INVOICE_DATA_SHORT] = this.invoiceId
     response[VendorMetadata.WEBSITE_SHORT] = this.website
     response[VendorMetadata.VENDOR_SHORT] = this.vendorName
 
@@ -70,7 +70,7 @@ export class VendorMetadata {
   static fromConcise(concise: Object): VendorMetadata {
     return {
       callbackUrl: concise[VendorMetadata.CALLBACK_URL_SHORT],
-      invoiceData: concise[VendorMetadata.INVOICE_DATA_SHORT],
+      invoiceId: concise[VendorMetadata.INVOICE_DATA_SHORT],
       website: concise[VendorMetadata.WEBSITE_SHORT],
       vendorName: concise[VendorMetadata.VENDOR_SHORT],
     }
@@ -109,8 +109,7 @@ export function generateCode(
   if (counterPartyDisplayName) {
     codeObj.c = counterPartyDisplayName
   }
-
-  return codeObj
+  return pickBy(codeObj, _ => !isEmpty(_))
 }
 
 /**


### PR DESCRIPTION
# Description
Implements vendor callback as part of the wallet payment API #3162 
If payment request contains a vendor callback (as in example blow), once user makes the payment it will also POST to the callback url the txhash + invoiceid
(tested with pipedream)
```
{"m":"3d8XyMvBLDpNVZgFNtARFLCEfdxdChvgvSq", "ven":{"cbu":"https://f35acb37aa319b77c33c30b8ed9632bf.m.pipedream.net", "invoiceId":"64566"}}
```

About #3162 