### PR TITLE
(Bug) export wallet copy buttons have empty background on click

### DIFF
--- a/src/components/common/view/BorderedBox.js
+++ b/src/components/common/view/BorderedBox.js
@@ -130,12 +130,21 @@ const BorderedBox = ({
         <View style={[styles.boxCopyIconWrapper, showCopyIcon ? null : styles.boxCopyButtonWrapper]}>
           {showCopyIcon ? (
             <>
-              <RoundIconButton
-                onPress={copyToClipboard}
-                iconSize={22}
-                iconName="copy"
-                style={styles.copyIconContainer}
-              />
+              {enableIndicateAction && performed ? (
+                <RoundIconButton
+                  onPress={copyToClipboard}
+                  iconSize={16}
+                  iconName="success"
+                  style={styles.copyIconContainer}
+                />
+              ) : (
+                <RoundIconButton
+                  onPress={copyToClipboard}
+                  iconSize={22}
+                  iconName="copy"
+                  style={styles.copyIconContainer}
+                />
+              )}
               <Section.Text fontSize={10} fontWeight="medium" color={theme.colors.primary}>
                 {copyButtonText}
               </Section.Text>

--- a/src/components/common/view/BorderedBox.js
+++ b/src/components/common/view/BorderedBox.js
@@ -15,7 +15,6 @@ import { useClipboardCopy } from '../../../lib/hooks/useClipboard'
 import { withStyles } from '../../../lib/styles'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../lib/utils/sizes'
 import { truncateMiddle } from '../../../lib/utils/string'
-import Icon from './Icon'
 
 const copiedActionTimeout = 3000 // time during which the copy success message is displayed
 
@@ -130,28 +129,19 @@ const BorderedBox = ({
         <View style={[styles.boxCopyIconWrapper, showCopyIcon ? null : styles.boxCopyButtonWrapper]}>
           {showCopyIcon ? (
             <>
-              {enableIndicateAction && performed ? (
-                <RoundIconButton
-                  onPress={copyToClipboard}
-                  iconSize={16}
-                  iconName="success"
-                  style={styles.copyIconContainer}
-                />
-              ) : (
-                <RoundIconButton
-                  onPress={copyToClipboard}
-                  iconSize={22}
-                  iconName="copy"
-                  style={styles.copyIconContainer}
-                />
-              )}
+              <RoundIconButton
+                onPress={copyToClipboard}
+                iconSize={22}
+                iconName="copy"
+                style={styles.copyIconContainer}
+              />
               <Section.Text fontSize={10} fontWeight="medium" color={theme.colors.primary}>
                 {copyButtonText}
               </Section.Text>
             </>
           ) : enableIndicateAction && performed ? (
             <CustomButton style={styles.copyButtonContainer} disabled>
-              <Icon size={16} name="success" color="white" />
+              Copied
             </CustomButton>
           ) : (
             <CustomButton onPress={copyToClipboard} style={styles.copyButtonContainer}>

--- a/src/components/common/view/BorderedBox.js
+++ b/src/components/common/view/BorderedBox.js
@@ -15,6 +15,7 @@ import { useClipboardCopy } from '../../../lib/hooks/useClipboard'
 import { withStyles } from '../../../lib/styles'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../lib/utils/sizes'
 import { truncateMiddle } from '../../../lib/utils/string'
+import Icon from './Icon'
 
 const copiedActionTimeout = 3000 // time during which the copy success message is displayed
 
@@ -140,12 +141,8 @@ const BorderedBox = ({
               </Section.Text>
             </>
           ) : enableIndicateAction && performed ? (
-            <CustomButton
-              style={[styles.copyButtonContainer, styles.performedButtonStyle]}
-              textStyle={styles.performedButtonText}
-              disabled
-            >
-              Copied
+            <CustomButton style={styles.copyButtonContainer} disabled>
+              <Icon size={16} name="success" color="white" />
             </CustomButton>
           ) : (
             <CustomButton onPress={copyToClipboard} style={styles.copyButtonContainer}>
@@ -212,14 +209,6 @@ const styles = ({ theme }) => {
       zIndex: 1,
       alignItems: 'center',
     },
-    performedButtonText: {
-      color: theme.colors.primary,
-    },
-    performedButtonStyle: {
-      backgroundColor: theme.colors.surface,
-      shadowOpacity: 0,
-      elevation: 0,
-    },
     boxCopyIconOuter: {
       width: '100%',
       height: height40,
@@ -273,6 +262,7 @@ const styles = ({ theme }) => {
       marginBottom: 0,
       marginRight: 'auto',
       marginLeft: 'auto',
+      backgroundColor: theme.colors.primary,
     },
   }
 }

--- a/src/components/profile/ProfilePrivacy.js
+++ b/src/components/profile/ProfilePrivacy.js
@@ -174,6 +174,7 @@ const ProfilePrivacy = props => {
               content={faceRecordId}
               truncateContent
               copyButtonText="Copy ID"
+              enableIndicateAction
             />
           </Section>
         </Section.Stack>


### PR DESCRIPTION
# Description

Copy buttons in export wallet section were updated so they show a check icon once pressed and maintain the same background color, similar to copy buttons in other screens.

About #3282 

![active](https://user-images.githubusercontent.com/67687265/123399262-b13f4a80-d5a4-11eb-8322-c98a6de7eadc.png)

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
