### PR TITLE
(Bug) handle payment link of own wallet is stuck

### DIFF
--- a/src/components/dashboard/HandlePaymentLink.js
+++ b/src/components/dashboard/HandlePaymentLink.js
@@ -46,6 +46,7 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
       try {
         if (anyParams && anyParams.code) {
           const code = readCode(decodeURIComponent(anyParams.code))
+          
           log.debug('decoded payment request', { code })
 
           if (isTheSameUser(code)) {

--- a/src/components/dashboard/HandlePaymentLink.js
+++ b/src/components/dashboard/HandlePaymentLink.js
@@ -52,32 +52,38 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
             showErrorDialog('You cannot use your own payment link', undefined, {
               onDismiss: screenProps.goToRoot,
             })
-          } else {
-            showDialog({
-              onDismiss: noop,
-              title: 'Processing Payment Link...',
-              image: <LoadingIcon />,
-              message: 'please wait while processing...',
-              showCloseButtons: false,
-              showButtons: false,
-            })
-
-            try {
-              const { route, params } = await routeAndPathForCode('send', code)
-              hideDialog()
-              screenProps.push(route, params)
-            } catch (e) {
-              hideDialog()
-              log.warn('Payment link is incorrect', e.message, e, {
-                code,
-                category: ExceptionCategory.Human,
-                dialogShown: true,
-              })
-              showErrorDialog('Payment link is incorrect. Please double check your link.', undefined, {
-                onDismiss: screenProps.goToRoot,
-              })
-            }
+            
+            return
           }
+
+          showDialog({
+            onDismiss: noop,
+            title: 'Processing Payment Link...',
+            image: <LoadingIcon />,
+            message: 'please wait while processing...',
+            showCloseButtons: false,
+            showButtons: false,
+          })
+
+          try {
+            const { route, params } = await routeAndPathForCode('send', code)
+              
+            hideDialog()
+            screenProps.push(route, params)
+          } catch (e) {
+            hideDialog()
+              
+            log.warn('Payment link is incorrect', e.message, e, {
+              code,
+              category: ExceptionCategory.Human,
+              dialogShown: true,
+            })
+              
+            showErrorDialog('Payment link is incorrect. Please double check your link.', undefined, {
+              onDismiss: screenProps.goToRoot,
+            })
+          }
+          
         }
       } catch (e) {
         log.error('checkCode unexpected error:', e.message, e)

--- a/src/components/dashboard/HandlePaymentLink.js
+++ b/src/components/dashboard/HandlePaymentLink.js
@@ -45,16 +45,23 @@ const HandlePaymentLink = (props: HandlePaymentLinkProps) => {
     async anyParams => {
       try {
         if (anyParams && anyParams.code) {
-          showDialog({
-            onDismiss: noop,
-            title: 'Processing Payment Link...',
-            image: <LoadingIcon />,
-            message: 'please wait while processing...',
-            showCloseButtons: false,
-          })
           const code = readCode(decodeURIComponent(anyParams.code))
           log.debug('decoded payment request', { code })
-          if (isTheSameUser(code) === false) {
+
+          if (isTheSameUser(code)) {
+            showErrorDialog('You cannot use your own payment link', undefined, {
+              onDismiss: screenProps.goToRoot,
+            })
+          } else {
+            showDialog({
+              onDismiss: noop,
+              title: 'Processing Payment Link...',
+              image: <LoadingIcon />,
+              message: 'please wait while processing...',
+              showCloseButtons: false,
+              showButtons: false,
+            })
+
             try {
               const { route, params } = await routeAndPathForCode('send', code)
               hideDialog()


### PR DESCRIPTION
# Description

Error dialog is shown when user tries to use his own payment link. When using correct link a standard dailog is shown, without any buttons.

About #3281 

![payment](https://user-images.githubusercontent.com/67687265/123410538-beae0200-d5af-11eb-824b-cf7d822805cd.png)

![own_payment](https://user-images.githubusercontent.com/67687265/123410553-c2da1f80-d5af-11eb-9a18-460ea1215ab7.png)

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
