### PR TITLE
(Bug) The correct sum of G$ displayed with delay after opening the invite page

### DIFF
--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -270,7 +270,7 @@ const Invite = () => {
   const [invitees, refresh, level, inviteState] = useInvited()
 
   const totalEarned = get(inviteState, 'totalEarned', 0)
-  const bounty = result(level, 'bounty.toNumber', 100) / 100
+  const bounty = result(level, 'bounty.toNumber')
 
   const toggleHowTo = () => {
     !showHowTo && fireEvent(INVITE_HOWTO)
@@ -294,8 +294,9 @@ const Invite = () => {
           fontSize={28}
           color={theme.colors.darkBlue}
           lineHeight={34}
+          style={styles.bounty}
         >
-          {`Get ${bounty}G$`}
+          {bounty && `Get ${bounty / 100}G$`}
         </Section.Text>
         <Section.Text
           letterSpacing={0.1}
@@ -354,6 +355,9 @@ const styles = {
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: getDesignRelativeHeight(theme.paddings.defaultMargin * 3, false),
+  },
+  bounty: {
+    height: 34,
   },
 }
 export default Invite

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Image, View } from 'react-native'
-import { get, result } from 'lodash'
+import { get, isNaN, isNil, result } from 'lodash'
 import { Avatar, CustomButton, Icon, Section, ShareButton, Text, Wrapper } from '../common'
 import { WavesBox } from '../common/view/WavesBox'
 import { theme } from '../theme/styles'
@@ -64,8 +64,11 @@ const ShareBox = ({ level }) => {
   const inviteCode = useInviteCode()
   const shareUrl = `${Config.invitesUrl}?inviteCode=${inviteCode}`
   const bounty = result(level, 'bounty.toNumber') / 100
-
   const share = useMemo(() => generateShareObject(shareTitle, shareMessage, shareUrl), [shareUrl])
+
+  if (isNil(bounty) || isNaN(bounty)) {
+    return null
+  }
 
   return (
     <WavesBox primarycolor={theme.colors.primary} style={styles.linkBoxStyle} title={'Share Your Invite Link'}>
@@ -270,7 +273,7 @@ const Invite = () => {
   const [invitees, refresh, level, inviteState] = useInvited()
 
   const totalEarned = get(inviteState, 'totalEarned', 0)
-  const bounty = result(level, 'bounty.toNumber')
+  const bounty = result(level, 'bounty.toNumber') / 100
 
   const toggleHowTo = () => {
     !showHowTo && fireEvent(INVITE_HOWTO)
@@ -284,53 +287,55 @@ const Invite = () => {
     }
   }, [inviteState])
 
+  if (isNil(bounty) || isNaN(bounty)) {
+    return
+  }
+
   return (
-    bounty !== undefined && (
-      <Wrapper style={styles.pageBackground} backgroundColor={theme.colors.lightGray}>
-        <Section.Stack style={styles.headLine}>
-          <Section.Text
-            letterSpacing={0.14}
-            fontWeight={'bold'}
-            fontFamily={theme.fonts.slab}
-            fontSize={28}
-            color={theme.colors.darkBlue}
-            lineHeight={34}
-            style={styles.bounty}
-          >
-            {`Get ${bounty / 100}G$`}
-          </Section.Text>
-          <Section.Text
-            letterSpacing={0.1}
-            fontWeight={'bold'}
-            fontFamily={theme.fonts.slab}
-            fontSize={20}
-            color={theme.colors.primary}
-            lineHeight={34}
-          >
-            For Each Friend You Invite!
-          </Section.Text>
-        </Section.Stack>
-        <Divider size={theme.sizes.defaultDouble} />
-        <Section.Text letterSpacing={-0.07} lineHeight={20} fontSize={15} color={theme.colors.darkBlue}>
-          {`Make sure they claim to get your reward`}
-        </Section.Text>
-        <Divider size={getDesignRelativeHeight(theme.paddings.defaultMargin * 3, false)} />
-        <CustomButton
+    <Wrapper style={styles.pageBackground} backgroundColor={theme.colors.lightGray}>
+      <Section.Stack style={styles.headLine}>
+        <Section.Text
+          letterSpacing={0.14}
+          fontWeight={'bold'}
+          fontFamily={theme.fonts.slab}
+          fontSize={28}
           color={theme.colors.darkBlue}
-          iconColor={theme.colors.darkBlue}
-          iconStyle={{ marginLeft: 10 }}
-          iconAlignment="right"
-          icon={showHowTo ? 'arrow-up' : 'arrow-down'}
-          mode="text"
-          textStyle={{ fontWeight: 'bold', letterSpacing: 0, textDecorationLine: 'underline' }}
-          onPress={toggleHowTo}
+          lineHeight={34}
+          style={styles.bounty}
         >
-          {`How Do I Invite People?`}
-        </CustomButton>
-        {showHowTo && <InvitesHowTO />}
-        <InvitesData {...{ invitees, refresh, level, totalEarned }} />
-      </Wrapper>
-    )
+          {`Get ${bounty / 100}G$`}
+        </Section.Text>
+        <Section.Text
+          letterSpacing={0.1}
+          fontWeight={'bold'}
+          fontFamily={theme.fonts.slab}
+          fontSize={20}
+          color={theme.colors.primary}
+          lineHeight={34}
+        >
+          For Each Friend You Invite!
+        </Section.Text>
+      </Section.Stack>
+      <Divider size={theme.sizes.defaultDouble} />
+      <Section.Text letterSpacing={-0.07} lineHeight={20} fontSize={15} color={theme.colors.darkBlue}>
+        {`Make sure they claim to get your reward`}
+      </Section.Text>
+      <Divider size={getDesignRelativeHeight(theme.paddings.defaultMargin * 3, false)} />
+      <CustomButton
+        color={theme.colors.darkBlue}
+        iconColor={theme.colors.darkBlue}
+        iconStyle={{ marginLeft: 10 }}
+        iconAlignment="right"
+        icon={showHowTo ? 'arrow-up' : 'arrow-down'}
+        mode="text"
+        textStyle={{ fontWeight: 'bold', letterSpacing: 0, textDecorationLine: 'underline' }}
+        onPress={toggleHowTo}
+      >
+        {`How Do I Invite People?`}
+      </CustomButton>
+      {showHowTo && <InvitesHowTO />}
+      <InvitesData {...{ invitees, refresh, level, totalEarned }} />
+    </Wrapper>
   )
 }
 

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -288,7 +288,7 @@ const Invite = () => {
   }, [inviteState])
 
   if (isNil(bounty) || isNaN(bounty)) {
-    return
+    return null
   }
 
   return (
@@ -303,7 +303,7 @@ const Invite = () => {
           lineHeight={34}
           style={styles.bounty}
         >
-          {`Get ${bounty / 100}G$`}
+          {`Get ${bounty}G$`}
         </Section.Text>
         <Section.Text
           letterSpacing={0.1}

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -63,7 +63,7 @@ const InvitedUser = ({ address, status }) => {
 const ShareBox = ({ level }) => {
   const inviteCode = useInviteCode()
   const shareUrl = `${Config.invitesUrl}?inviteCode=${inviteCode}`
-  const bounty = result(level, 'bounty.toNumber', 100) / 100
+  const bounty = result(level, 'bounty.toNumber', 0) / 100
 
   const share = useMemo(() => generateShareObject(shareTitle, shareMessage, shareUrl), [shareUrl])
 
@@ -270,7 +270,7 @@ const Invite = () => {
   const [invitees, refresh, level, inviteState] = useInvited()
 
   const totalEarned = get(inviteState, 'totalEarned', 0)
-  const bounty = result(level, 'bounty.toNumber')
+  const bounty = result(level, 'bounty.toNumber', 0) / 100
 
   const toggleHowTo = () => {
     !showHowTo && fireEvent(INVITE_HOWTO)
@@ -296,7 +296,7 @@ const Invite = () => {
           lineHeight={34}
           style={styles.bounty}
         >
-          {bounty && `Get ${bounty / 100}G$`}
+          {`Get ${bounty}G$`}
         </Section.Text>
         <Section.Text
           letterSpacing={0.1}

--- a/src/components/invite/Invite.js
+++ b/src/components/invite/Invite.js
@@ -63,7 +63,7 @@ const InvitedUser = ({ address, status }) => {
 const ShareBox = ({ level }) => {
   const inviteCode = useInviteCode()
   const shareUrl = `${Config.invitesUrl}?inviteCode=${inviteCode}`
-  const bounty = result(level, 'bounty.toNumber', 0) / 100
+  const bounty = result(level, 'bounty.toNumber') / 100
 
   const share = useMemo(() => generateShareObject(shareTitle, shareMessage, shareUrl), [shareUrl])
 
@@ -270,7 +270,7 @@ const Invite = () => {
   const [invitees, refresh, level, inviteState] = useInvited()
 
   const totalEarned = get(inviteState, 'totalEarned', 0)
-  const bounty = result(level, 'bounty.toNumber', 0) / 100
+  const bounty = result(level, 'bounty.toNumber')
 
   const toggleHowTo = () => {
     !showHowTo && fireEvent(INVITE_HOWTO)
@@ -285,50 +285,52 @@ const Invite = () => {
   }, [inviteState])
 
   return (
-    <Wrapper style={styles.pageBackground} backgroundColor={theme.colors.lightGray}>
-      <Section.Stack style={styles.headLine}>
-        <Section.Text
-          letterSpacing={0.14}
-          fontWeight={'bold'}
-          fontFamily={theme.fonts.slab}
-          fontSize={28}
+    bounty !== undefined && (
+      <Wrapper style={styles.pageBackground} backgroundColor={theme.colors.lightGray}>
+        <Section.Stack style={styles.headLine}>
+          <Section.Text
+            letterSpacing={0.14}
+            fontWeight={'bold'}
+            fontFamily={theme.fonts.slab}
+            fontSize={28}
+            color={theme.colors.darkBlue}
+            lineHeight={34}
+            style={styles.bounty}
+          >
+            {`Get ${bounty / 100}G$`}
+          </Section.Text>
+          <Section.Text
+            letterSpacing={0.1}
+            fontWeight={'bold'}
+            fontFamily={theme.fonts.slab}
+            fontSize={20}
+            color={theme.colors.primary}
+            lineHeight={34}
+          >
+            For Each Friend You Invite!
+          </Section.Text>
+        </Section.Stack>
+        <Divider size={theme.sizes.defaultDouble} />
+        <Section.Text letterSpacing={-0.07} lineHeight={20} fontSize={15} color={theme.colors.darkBlue}>
+          {`Make sure they claim to get your reward`}
+        </Section.Text>
+        <Divider size={getDesignRelativeHeight(theme.paddings.defaultMargin * 3, false)} />
+        <CustomButton
           color={theme.colors.darkBlue}
-          lineHeight={34}
-          style={styles.bounty}
+          iconColor={theme.colors.darkBlue}
+          iconStyle={{ marginLeft: 10 }}
+          iconAlignment="right"
+          icon={showHowTo ? 'arrow-up' : 'arrow-down'}
+          mode="text"
+          textStyle={{ fontWeight: 'bold', letterSpacing: 0, textDecorationLine: 'underline' }}
+          onPress={toggleHowTo}
         >
-          {`Get ${bounty}G$`}
-        </Section.Text>
-        <Section.Text
-          letterSpacing={0.1}
-          fontWeight={'bold'}
-          fontFamily={theme.fonts.slab}
-          fontSize={20}
-          color={theme.colors.primary}
-          lineHeight={34}
-        >
-          For Each Friend You Invite!
-        </Section.Text>
-      </Section.Stack>
-      <Divider size={theme.sizes.defaultDouble} />
-      <Section.Text letterSpacing={-0.07} lineHeight={20} fontSize={15} color={theme.colors.darkBlue}>
-        {`Make sure they claim to get your reward`}
-      </Section.Text>
-      <Divider size={getDesignRelativeHeight(theme.paddings.defaultMargin * 3, false)} />
-      <CustomButton
-        color={theme.colors.darkBlue}
-        iconColor={theme.colors.darkBlue}
-        iconStyle={{ marginLeft: 10 }}
-        iconAlignment="right"
-        icon={showHowTo ? 'arrow-up' : 'arrow-down'}
-        mode="text"
-        textStyle={{ fontWeight: 'bold', letterSpacing: 0, textDecorationLine: 'underline' }}
-        onPress={toggleHowTo}
-      >
-        {`How Do I Invite People?`}
-      </CustomButton>
-      {showHowTo && <InvitesHowTO />}
-      <InvitesData {...{ invitees, refresh, level, totalEarned }} />
-    </Wrapper>
+          {`How Do I Invite People?`}
+        </CustomButton>
+        {showHowTo && <InvitesHowTO />}
+        <InvitesData {...{ invitees, refresh, level, totalEarned }} />
+      </Wrapper>
+    )
   )
 }
 


### PR DESCRIPTION
# Description

Changed the logic so zeros are shown while values are fetching.

About #3328 

https://user-images.githubusercontent.com/67687265/125081744-a1585800-e0c6-11eb-8987-851a0313fe3d.mov

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [x] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
