### PR TITLE
(Bug) Fixed camera wont open when modifying profile

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature android:name="android.hardware.camera.front" android:required="false" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <permission
       android:name="${applicationId}.permission.C2D_MESSAGE"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "react-native-fs": "^2.18.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.7.0",
-    "react-native-image-crop-picker": "^0.32.0",
+    "react-native-image-crop-picker": "^0.36.4",
     "react-native-image-resizer": "^1.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.4",
     "react-native-level-fs": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19083,10 +19083,10 @@ react-native-get-random-values@^1.7.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
-react-native-image-crop-picker@^0.32.0:
-  version "0.32.3"
-  resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.32.3.tgz#53aa18249485e002e3a57a8cf70447482112b86e"
-  integrity sha512-+2em4wBcjpAkDat9gfNjGMIDvtjd67ekVaUQ6jC0dP2KOylX5zQbUlUQxx/gMbxQRZZDmBy8YGCDG1Y8D2d+oA==
+react-native-image-crop-picker@^0.36.4:
+  version "0.36.4"
+  resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.36.4.tgz#13a659fc296bea695a88a36de9eacd1e4aebc9b8"
+  integrity sha512-FOWkYbCEh78V5/aK9HqMSvRnQJtelGwj0UOu1zhE49gO6e4YoKKNBvA15jweAMM/kPA+omDXBIgJaruonoEXGA==
 
 react-native-image-resizer@^1.4.5:
   version "1.4.5"


### PR DESCRIPTION
# Description

react-native-image-crop-picker version was incompatible with the new version of react-native, I just uploaded it. 
Also added `<uses-feature android:name="android.hardware.camera.front" android:required="false" />` to AndroidManifest.xml so the front camera can be used.

About # (link your issue here)
#3467

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
