### PR TITLE
(Bug) country flag wont show on phone inputs

### DIFF
--- a/src/components/common/form/PhoneNumberInput/PhoneNumberInput.web.js
+++ b/src/components/common/form/PhoneNumberInput/PhoneNumberInput.web.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/no-named-as-default
-import PhoneInput from 'react-phone-number-input'
+import React from 'react'
+import PhoneInputComponent from 'react-phone-number-input'
+import flags from 'react-phone-number-input/flags'
 
-export default PhoneInput
+export default props => <PhoneInputComponent flags={flags} {...props} />

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -91,7 +91,7 @@ const Config = {
   delayMessageNetworkDisconnection: env.REACT_APP_DELAY_MSG_NETWORK_DISCONNECTION || 5000,
   showSplashDesktop: env.REACT_APP_SPLASH_DESKTOP === 'true',
   showAddToHomeDesktop: env.REACT_APP_ADDTOHOME_DESKTOP === 'true',
-  flagsUrl: env.REACT_APP_FLAGS_URL || 'https://lipis.github.io/flag-icon-css/flags/4x3/',
+  flagsUrl: env.REACT_APP_FLAGS_URL || 'https://flagicons.lipis.dev/flags/4x3/',
   claimQueue: env.REACT_APP_CLAIM_QUEUE_ENABLED === 'true',
   mauticUrl: env.REACT_APP_MAUTIC_URL || 'https://go.gooddollar.org',
   mauticAddContractFormID: env.REACT_APP_MAUTIC_ADDCONTRACT_FORMID || '15',


### PR DESCRIPTION
# Description

Flags are not working because the component we are using for the phoneInput https://www.npmjs.com/package/react-phone-number-input/v/2.3.18 uses a public URL (`https://lipis.github.io/flag-icon-css/flags/4x3/`) to load the fonts, recently this endpoint changed locations to (`https://flagicons.lipis.dev/flags/4x3/`) I changed the URL in the config file and changed the implementation of the phoneInput to use local assets instead of loading from the public endpoint, that way we avoid this from happening in the future.

About # (link your issue here)
#3471 

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
