### PR TITLE
(Bug) 3354 info feed cards are cropped

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -168,7 +168,7 @@ android {
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
-            abiFilters 'armeabi-v7a', 'x86'
+            abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a'
         }
         manifestPlaceholders = [
             'torusRedirectScheme': 'gooddollar',

--- a/src/components/dashboard/FeedItems/EventCounterParty.js
+++ b/src/components/dashboard/FeedItems/EventCounterParty.js
@@ -42,7 +42,7 @@ const EventCounterParty = ({ feedItem, styles, style, textStyle, subtitle, isSma
       <Text
         fontWeight="medium"
         textAlign={'left'}
-        lineHeight={hasSubtitle ? 19 : 38}
+        lineHeight={hasSubtitle ? 16 : 38}
         style={[styles.fullName, textStyle]}
       >
         {displayText}

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/EventCounterParty.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/EventCounterParty.js.snap
@@ -20,7 +20,7 @@ exports[`EventCounterParty receive matches snapshot 1`] = `
       From: 
     </span>
     <span
-      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
     >
       Misao Matimbo
     </span>
@@ -48,7 +48,7 @@ exports[`EventCounterParty send matches snapshot 1`] = `
       To: 
     </span>
     <span
-      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
     >
       Misao Matimbo
     </span>
@@ -76,7 +76,7 @@ exports[`EventCounterParty withdraw matches snapshot 1`] = `
       From: 
     </span>
     <span
-      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+      className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
     >
       Misao Matimbo
     </span>

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedListItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/FeedListItem.js.snap
@@ -156,7 +156,7 @@ exports[`FeedListItem - Send matches snapshot 1`] = `
                   To: 
                 </span>
                 <span
-                  className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                  className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
                 >
                   Misao Matimbo
                 </span>
@@ -340,7 +340,7 @@ exports[`FeedListItem - Withdraw matches snapshot 1`] = `
                   From: 
                 </span>
                 <span
-                  className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                  className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
                 >
                   Misao Matimbo
                 </span>

--- a/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
+++ b/src/components/dashboard/FeedItems/__tests__/__snapshots__/ListEventItem.js.snap
@@ -149,7 +149,7 @@ exports[`ListEventItem receive matches snapshot 1`] = `
                 From: 
               </span>
               <span
-                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
               >
                 Misao Matimbo
               </span>
@@ -325,7 +325,7 @@ exports[`ListEventItem send matches snapshot 1`] = `
                 To: 
               </span>
               <span
-                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
               >
                 Misao Matimbo
               </span>
@@ -501,7 +501,7 @@ exports[`ListEventItem withdraw matches snapshot 1`] = `
                 From: 
               </span>
               <span
-                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-qvk6io r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                className="css-text-901oao css-textHasAncestor-16my406 r-color-cddv6f r-fontFamily-vnw8o6 r-fontSize-ubezar r-fontWeight-majxgm r-lineHeight-1cwl3u0 r-textAlign-fdjqy7 r-textDecorationLine-13wfysu r-textTransform-3twk1y"
               >
                 Misao Matimbo
               </span>


### PR DESCRIPTION
# Description

Fixes text cropped vertically on some devices eg: A80.

Also allows testing on virtual devices with 'arm64-v8a' architecture

![image](https://user-images.githubusercontent.com/26396804/139257293-fcea7b35-ad87-4bfb-beae-b1caa82933e8.png)

![image (1)](https://user-images.githubusercontent.com/26396804/139257408-9efc45a1-41f1-4931-8176-755681de9a2a.png)

About # (link your issue here)
#3354 

# How Has This Been Tested?
Sent a possible APK fix to @vldkh he tasted it on his physical device.

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [X] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
