### PR TITLE
3482 commas in balance are cropped when scrolling

### DIFF
--- a/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
+++ b/src/components/appNavigation/__tests__/__snapshots__/AppNavigation.js.snap
@@ -222,7 +222,7 @@ exports[`AppNavigation matches snapshot 1`] = `
                     data-testid="amount_value"
                   >
                     <div
-                      className="css-text-901oao css-textMultiLine-cens5h r-alignSelf-1pz39u2 r-color-181bzza r-fontFamily-6jnb14 r-fontSize-111xbm8 r-fontWeight-b88u0q r-lineHeight-1gvhk8w r-marginRight-a5pmau r-textAlign-q4m81j r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                      className="css-text-901oao css-textMultiLine-cens5h r-alignSelf-1pz39u2 r-color-181bzza r-fontFamily-6jnb14 r-fontSize-111xbm8 r-fontWeight-b88u0q r-height-ur6pnr r-lineHeight-1gvhk8w r-marginRight-a5pmau r-textAlign-q4m81j r-textDecorationLine-13wfysu r-textTransform-3twk1y"
                       dir="auto"
                       style={
                         Object {

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -791,6 +791,7 @@ const getStylesFromProps = ({ theme }) => ({
     fontSize: 42,
     fontWeight: '700',
     lineHeight: 42,
+    height: 42,
     textAlign: 'center',
 
     alignSelf: 'stretch',

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -427,7 +427,7 @@ const Dashboard = props => {
           useNativeDriver: false,
         }),
         Animated.timing(headerHeightAnimValue, {
-          toValue: 40,
+          toValue: Platform.select({ web: 40, default: 50 }),
           duration: timing,
           easing: easingIn,
           useNativeDriver: false,

--- a/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
+++ b/src/components/dashboard/__tests__/__snapshots__/Dashboard.js.snap
@@ -222,7 +222,7 @@ exports[`Dashboard matches snapshot 1`] = `
                     data-testid="amount_value"
                   >
                     <div
-                      className="css-text-901oao css-textMultiLine-cens5h r-alignSelf-1pz39u2 r-color-181bzza r-fontFamily-6jnb14 r-fontSize-111xbm8 r-fontWeight-b88u0q r-lineHeight-1gvhk8w r-marginRight-a5pmau r-textAlign-q4m81j r-textDecorationLine-13wfysu r-textTransform-3twk1y"
+                      className="css-text-901oao css-textMultiLine-cens5h r-alignSelf-1pz39u2 r-color-181bzza r-fontFamily-6jnb14 r-fontSize-111xbm8 r-fontWeight-b88u0q r-height-ur6pnr r-lineHeight-1gvhk8w r-marginRight-a5pmau r-textAlign-q4m81j r-textDecorationLine-13wfysu r-textTransform-3twk1y"
                       dir="auto"
                       style={
                         Object {


### PR DESCRIPTION
# Description

I changed the header height of the 'Amount height' on mobile. This will ensure the commas show.  

About # (link your issue here)
#3482 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
