### PR TITLE
(Fix) deleteAccount crashes in RN android

### DIFF
--- a/src/components/common/dialogs/DeleteAccountDialog.js
+++ b/src/components/common/dialogs/DeleteAccountDialog.js
@@ -12,7 +12,7 @@ const TrashIcon = () => <IconWrapper iconName="trash" color={theme.colors.error}
 
 const MessageTextComponent = () => (
   <Text style={{ color: theme.colors.error, fontSize: normalizeText(18) }}>
-    If you delete your account <br /> <Text style={{ fontWeight: 'bold' }}> you might lose access to your G$!</Text>
+    If you delete your account {'\n'} <Text style={{ fontWeight: 'bold' }}> you might lose access to your G$!</Text>
   </Text>
 )
 


### PR DESCRIPTION
# Description

Android version was crashing because there was a <br/> instead of {'\n'} in the delete dialog

About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
