### PR TITLE
(Bug) Fixed captcha not opening on native

### DIFF
--- a/src/components/auth/login/Recaptcha/Recaptcha.native.js
+++ b/src/components/auth/login/Recaptcha/Recaptcha.native.js
@@ -1,7 +1,7 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
 import ReCAPTCHA from 'react-native-recaptcha-that-works'
 
-const Recaptcha = forwardRef(({ siteKey, baseUrl, onLoad, onError, onVerify, children, ...props }, ref) => {
+const Recaptcha = forwardRef(({ siteKey, baseUrl, onError, onVerify, children, ...props }, ref) => {
   const captchaRef = useRef()
   const onExpired = useCallback(() => captchaRef.current.close(), [])
 
@@ -17,7 +17,6 @@ const Recaptcha = forwardRef(({ siteKey, baseUrl, onLoad, onError, onVerify, chi
         siteKey={siteKey}
         baseUrl={baseUrl}
         size="normal"
-        onLoad={onLoad}
         onExpire={onExpired}
         onError={onError}
         onVerify={onVerify}

--- a/src/components/auth/login/Recaptcha/Recaptcha.web.js
+++ b/src/components/auth/login/Recaptcha/Recaptcha.web.js
@@ -1,16 +1,13 @@
-import { noop } from 'lodash'
 import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
 import Reaptcha from 'reaptcha'
 
 import usePromise from '../../../../lib/hooks/usePromise'
 
-const Recaptcha = forwardRef(({ siteKey, onLoad = noop, onVerify, onError, children, ...props }, ref) => {
+const Recaptcha = forwardRef(({ siteKey, onVerify, onError, children, ...props }, ref) => {
   const captchaRef = useRef()
   const setCaptchaRef = useCallback(ref => (captchaRef.current = ref), [])
   const onExpired = useCallback(() => captchaRef.current.reset(), [])
   const [whenLoaded, setLoaded] = usePromise()
-
-  const handleLoaded = () => setLoaded() && onLoad()
 
   useImperativeHandle(
     ref,
@@ -30,7 +27,7 @@ const Recaptcha = forwardRef(({ siteKey, onLoad = noop, onVerify, onError, child
         ref={setCaptchaRef}
         sitekey={siteKey}
         size="invisible"
-        onLoad={handleLoaded}
+        onLoad={setLoaded}
         onVerify={onVerify}
         onError={onError}
         onExpire={onExpired}

--- a/src/components/auth/login/Recaptcha/index.js
+++ b/src/components/auth/login/Recaptcha/index.js
@@ -3,17 +3,15 @@ import React, { useCallback, useImperativeHandle, useRef, useState } from 'react
 import Config from '../../../../config/config'
 import logger from '../../../../lib/logger/js-logger'
 import API from '../../../../lib/API/api'
-import usePromise from '../../../../lib/hooks/usePromise'
 import Captcha from './Recaptcha'
 
 const log = logger.child({ from: 'init' })
 
 const { recaptchaSiteKey, publicUrl } = Config
 
-const Recaptcha = React.forwardRef(({ onSuccess = noop, onFailure = noop, children }, ref) => {
+const Recaptcha = React.forwardRef(({ onSuccess = noop, onLoad = noop, onFailure = noop, children }, ref) => {
   const captchaRef = useRef()
   const [isPassed, setIsPassed] = useState(false)
-  const [whenLoaded, setLoaded] = usePromise()
 
   const onVerify = useCallback(
     async payload => {
@@ -43,24 +41,23 @@ const Recaptcha = React.forwardRef(({ onSuccess = noop, onFailure = noop, childr
     ref,
     () => ({
       hasPassedCheck: () => isPassed,
-      launchCheck: async () => {
+      launchCheck: () => {
         if (isPassed) {
           return
         }
 
-        await whenLoaded
         captchaRef.current.launch()
       },
     }),
-    [isPassed, whenLoaded],
+    [isPassed],
   )
 
   return (
     <Captcha
       ref={captchaRef}
+      onLoad={onLoad}
       siteKey={recaptchaSiteKey}
       baseUrl={publicUrl}
-      onLoad={setLoaded}
       onError={onFailure}
       onVerify={onVerify}
     >

--- a/src/components/auth/login/Recaptcha/index.js
+++ b/src/components/auth/login/Recaptcha/index.js
@@ -9,7 +9,7 @@ const log = logger.child({ from: 'init' })
 
 const { recaptchaSiteKey, publicUrl } = Config
 
-const Recaptcha = React.forwardRef(({ onSuccess = noop, onLoad = noop, onFailure = noop, children }, ref) => {
+const Recaptcha = React.forwardRef(({ onSuccess = noop, onFailure = noop, children }, ref) => {
   const captchaRef = useRef()
   const [isPassed, setIsPassed] = useState(false)
 
@@ -53,14 +53,7 @@ const Recaptcha = React.forwardRef(({ onSuccess = noop, onLoad = noop, onFailure
   )
 
   return (
-    <Captcha
-      ref={captchaRef}
-      onLoad={onLoad}
-      siteKey={recaptchaSiteKey}
-      baseUrl={publicUrl}
-      onError={onFailure}
-      onVerify={onVerify}
-    >
+    <Captcha ref={captchaRef} siteKey={recaptchaSiteKey} baseUrl={publicUrl} onError={onFailure} onVerify={onVerify}>
       {children}
     </Captcha>
   )


### PR DESCRIPTION
# Description

The captcha was not triggering because the onLoad behavior differs for the npm packages we're using for the captchas.
In `reaptcha` we have to wait for the onLoad to trigger before we can call `captchaRef.current.execute()` but in `react-native-recaptcha-that-works` actually have to call the `captchaRef.current.open()` for the onLoad to trigger, and we don't need to wait for anything to load.
I moved the logic for waiting for the `captcha` to load to the `web component` as it is not needed in the native one.

About # (link your issue here)
#3543

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
