### PR TITLE
(BUG) smartbanner GET button overlaps the title

### DIFF
--- a/src/components/smartBanner/SmartBanner.js
+++ b/src/components/smartBanner/SmartBanner.js
@@ -5,6 +5,7 @@ import Config from '../../config/config'
 
 import 'smartbanner.js/dist/smartbanner.min.js'
 import 'smartbanner.js/dist/smartbanner.min.css'
+import './smartbanner-custom-style.css'
 
 const SmartBanner = () => (
   <MetaTags>

--- a/src/components/smartBanner/smartbanner-custom-style.css
+++ b/src/components/smartBanner/smartbanner-custom-style.css
@@ -1,0 +1,4 @@
+/* smartbanner smartbanner--gooddollar js_smartbanner */
+.smartbanner__info {
+  padding-right: 35px;
+}

--- a/src/components/smartBanner/smartbanner-custom-style.css
+++ b/src/components/smartBanner/smartbanner-custom-style.css
@@ -1,4 +1,3 @@
-/* smartbanner smartbanner--gooddollar js_smartbanner */
 .smartbanner__info {
   padding-right: 35px;
 }


### PR DESCRIPTION
# Description

I overwrote the CSS for the __info component to prevent the title to overlap the GET button.
I did not use the `custom-design-modifier` because It will prevent the default styles to be applied on all components, overwriting seems to be a better solution in this case.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
