### PR TITLE
(Bug) app crashed when pressing back

### DIFF
--- a/src/lib/utils/handleBackButton.js
+++ b/src/lib/utils/handleBackButton.js
@@ -30,6 +30,7 @@ class BackButtonHandler {
     const now = Date.now()
 
     if (now - this.lastPress <= 300) {
+      this.unregister()
       return BackHandler.exitApp()
     }
 

--- a/src/lib/utils/handleBackButton.js
+++ b/src/lib/utils/handleBackButton.js
@@ -27,6 +27,13 @@ class BackButtonHandler {
   }
 
   handler = action => {
+    const now = Date.now()
+
+    if (now - this.lastPress <= 300) {
+      return BackHandler.exitApp()
+    }
+
+    this.lastPress = Date.now()
     this.defaultAction()
 
     return true


### PR DESCRIPTION
# Description

This PR Activates the back-button functionality, when on the dashboard if back button is double tapped it should close the app. 

I tested this with my device and on some emulators and It seems that the app is no longer crashing, maby due to the removal of gun subscriptions.

This needs to be tested further in QA.

About # (link your issue here)
#3302

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added reference to a related issue in the repository
- [X] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [X] @mentions of the person or team responsible for reviewing proposed changes
