### PR TITLE
(Bug) Auth/eth fails for the old account created with GUN

### DIFF
--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -143,12 +143,29 @@ const AppSwitch = (props: LoadingProps) => {
     identifyWith(email, undefined)
   }
 
-  //TODO: should be removed once issue is resolved
+  // TODO: should be removed once issue is resolved
   const logoutTorusIssue = id => {
     if (id.toLowerCase() === '0xb5f2f134a543d55c24eaa9ef441c2a699d660b6b') {
-      throw new Error('bad torus account bug')
+      const exception = new Error('bad torus account bug')
+
+      exception.name = 'BadTorusAccountError'
+      throw exception
     }
   }
+
+  const restartWithMessage = useCallback(
+    async (message, withLogout = true) => {
+      if (false !== withLogout) {
+        await AsyncStorage.clear()
+      }
+
+      showErrorDialog(message, '', {
+        onDismiss: () => restart('/'),
+      })
+    },
+    [showErrorDialog],
+  )
+
   const init = async () => {
     log.debug('initializing')
 
@@ -157,30 +174,42 @@ const AppSwitch = (props: LoadingProps) => {
       //initialize the citizen status and wallet status
       //create jwt token and initialize the API service
       updateWalletStatus(gdstore)
-      const { isLoggedInCitizen, isLoggedIn } = await getLoginState()
+
+      const [isLoggedInCitizen, isLoggedIn] = await getLoginState()
+
       log.debug('initialize ready', { isLoggedIn, isLoggedInCitizen })
+
       const initReg = userStorage.initRegistered()
+
       gdstore.set('isLoggedIn')(isLoggedIn)
       gdstore.set('isLoggedInCitizen')(isLoggedInCitizen)
 
       //identify user asap for analytics
       const identifier = goodWallet.getAccountForType('login')
+
       logoutTorusIssue(identifier)
       identifyWith(undefined, identifier)
       showOutOfGasError(props)
+
       await initReg
       initialize()
       runUpdates() //this needs to wait after initreg where we initialize the database
 
       setReady(true)
     } catch (e) {
-      //TODO: remove once bug is resolvedß
-      if (e.message.includes('bad torus')) {
-        log.error('bad torus account bug', e.message, e, { seed: await localStorage.getItem('GD_masterSeed') })
-        await AsyncStorage.clear()
-        return showErrorDialog('We are sorry, please try to login again. We are working to resolve this issue.', '', {
-          onDismiss: () => restart('/'),
-        })
+      if (['OutdatedProfileSignatureError', 'UnsignedJWTError'].includes(e.name)) {
+        return restartWithMessage(
+          "You haven't used GoodDollar app on this device for a long time. " +
+            'You need to sign in again. Make sure to use the same account you previously signed in with.',
+        )
+      }
+
+      // TODO: remove once bug is resolved
+      if (e.name === 'BadTorusAccountError') {
+        const seed = await localStorage.getItem('GD_masterSeed')
+
+        log.error('bad torus account bug', e.message, e, { seed })
+        return restartWithMessage('We are sorry, please try to login again. We are working to resolve this issue.')
       }
 
       const dialogShown = unsuccessfulLaunchAttempts > 3
@@ -190,15 +219,15 @@ const AppSwitch = (props: LoadingProps) => {
       if (dialogShown) {
         //if error in realmdb logout the user, he needs to signin/signup again
         log.error('failed initializing app', e.message, e, { dialogShown })
+
         if (e.message.includes('realmdb')) {
-          await AsyncStorage.clear()
-          return showErrorDialog(
-            'We are sorry, but due to database upgrade, you need to perform the Signup process again. Make sure to use the same account you previously signed in with.',
-            '',
-            { onDismiss: () => restart('/') },
+          return restartWithMessage(
+            'We are sorry, but due to database upgrade, you need to perform the Signup process again. ' +
+              'Make sure to use the same account you previously signed in with.',
           )
         }
-        showErrorDialog('Wallet could not be loaded. Please refresh.', '', { onDismiss: () => restart('/') })
+
+        restartWithMessage('Wallet could not be loaded. Please refresh.', false)
       } else {
         await delay(1500)
         init()

--- a/src/components/appSwitch/AppSwitch.js
+++ b/src/components/appSwitch/AppSwitch.js
@@ -146,10 +146,7 @@ const AppSwitch = (props: LoadingProps) => {
   // TODO: should be removed once issue is resolved
   const logoutTorusIssue = id => {
     if (id.toLowerCase() === '0xb5f2f134a543d55c24eaa9ef441c2a699d660b6b') {
-      const exception = new Error('bad torus account bug')
-
-      exception.name = 'BadTorusAccountError'
-      throw exception
+      throw new Error('bad torus account bug')
     }
   }
 
@@ -197,7 +194,7 @@ const AppSwitch = (props: LoadingProps) => {
 
       setReady(true)
     } catch (e) {
-      if (['OutdatedProfileSignatureError', 'UnsignedJWTError'].includes(e.name)) {
+      if ('UnsignedJWTError' === e.name) {
         return restartWithMessage(
           "You haven't used GoodDollar app on this device for a long time. " +
             'You need to sign in again. Make sure to use the same account you previously signed in with.',
@@ -205,7 +202,7 @@ const AppSwitch = (props: LoadingProps) => {
       }
 
       // TODO: remove once bug is resolved
-      if (e.name === 'BadTorusAccountError') {
+      if (e.message.includes('bad torus')) {
         const seed = await localStorage.getItem('GD_masterSeed')
 
         log.error('bad torus account bug', e.message, e, { seed })

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -2,7 +2,7 @@
 
 import axios from 'axios'
 import type { $AxiosXHR, AxiosInstance, AxiosPromise } from 'axios'
-import { get, identity, isError, isObject, isString } from 'lodash'
+import { assign, get, identity, isError, isObject, isString } from 'lodash'
 
 import { throttleAdapter } from '../utils/axios'
 import AsyncStorage from '../utils/asyncStorage'
@@ -34,6 +34,16 @@ export type UserRecord = NameRecord &
 
 export const defaultErrorMessage = 'Unexpected error happened during api call'
 
+export const getErrorName = apiError => {
+  if (isObject(apiError)) {
+    const { name } = apiError
+
+    if (name && 'Error' !== name) {
+      return name
+    }
+  }
+}
+
 export const getErrorMessage = apiError => {
   let errorMessage
 
@@ -54,6 +64,24 @@ export const getErrorMessage = apiError => {
   }
 
   return errorMessage
+}
+
+export const makeAPIException = apiError => {
+  const message = getErrorMessage(apiError)
+  const name = getErrorName(apiError)
+  const exception = new Error(message)
+
+  if (name) {
+    assign(exception, { name })
+  }
+
+  return exception
+}
+
+export const throwAPIException = apiError => {
+  const exception = makeAPIException(apiError)
+
+  throw exception
 }
 
 /**

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -2,7 +2,7 @@
 
 import axios from 'axios'
 import type { $AxiosXHR, AxiosInstance, AxiosPromise } from 'axios'
-import { assign, get, identity, isError, isObject, isString } from 'lodash'
+import { get, identity, isError, isObject, isString } from 'lodash'
 
 import { throttleAdapter } from '../utils/axios'
 import AsyncStorage from '../utils/asyncStorage'
@@ -34,16 +34,6 @@ export type UserRecord = NameRecord &
 
 export const defaultErrorMessage = 'Unexpected error happened during api call'
 
-export const getErrorName = apiError => {
-  if (isObject(apiError)) {
-    const { name } = apiError
-
-    if (name && 'Error' !== name) {
-      return name
-    }
-  }
-}
-
 export const getErrorMessage = apiError => {
   let errorMessage
 
@@ -64,24 +54,6 @@ export const getErrorMessage = apiError => {
   }
 
   return errorMessage
-}
-
-export const makeAPIException = apiError => {
-  const message = getErrorMessage(apiError)
-  const name = getErrorName(apiError)
-  const exception = new Error(message)
-
-  if (name) {
-    assign(exception, { name })
-  }
-
-  return exception
-}
-
-export const throwAPIException = apiError => {
-  const exception = makeAPIException(apiError)
-
-  throw exception
 }
 
 /**

--- a/src/lib/login/LoginService.js
+++ b/src/lib/login/LoginService.js
@@ -1,7 +1,7 @@
 // @flow
 import * as jsonwebtoken from 'jsonwebtoken'
 import AsyncStorage from '../utils/asyncStorage'
-import API, { type Credentials, throwAPIException } from '../API/api'
+import API, { type Credentials, getErrorMessage } from '../API/api'
 import { CREDS, JWT } from '../constants/localStorage'
 import logger from '../logger/js-logger'
 
@@ -93,7 +93,7 @@ class LoginService {
       log.debug('jwt validation result:', { jwt })
 
       if (!jwt) {
-        const response = await API.auth(creds).catch(throwAPIException)
+        const response = await API.auth(creds)
         const { status, data, statusText } = response
 
         log.info('Got auth response', response)
@@ -107,9 +107,11 @@ class LoginService {
       }
 
       return { ...creds, jwt }
-    } catch (exception) {
-      log.error('Login service auth failed:', exception.message, exception)
+    } catch (e) {
+      const message = getErrorMessage(e)
+      const exception = new Error(message)
 
+      log.error('Login service auth failed:', message, exception)
       throw exception
     }
   }

--- a/src/lib/login/checkAuthStatus.js
+++ b/src/lib/login/checkAuthStatus.js
@@ -5,31 +5,45 @@ import goodWalletLogin from './GoodWalletLogin'
 
 const log = logger.child({ from: 'checkAuthStatus' })
 
+const signInAttempt = async (withRefresh = false) => {
+  const creds = await goodWalletLogin.auth(withRefresh)
+  const { decoded } = await goodWalletLogin.validateJWTExistenceAndExpiration()
+
+  log.info('jwtsignin: jwt data', { creds, decoded })
+
+  if (!decoded || decoded.aud === 'unsigned') {
+    const exception = new Error('jwt is of unsigned user')
+
+    exception.name = 'UnsignedJWTError'
+    throw exception
+  }
+
+  return creds
+}
+
 const jwtSignin = async () => {
-  const credsOrFailed = await goodWalletLogin.auth().catch(e => false)
-  let { decoded } = await goodWalletLogin.validateJWTExistenceAndExpiration()
-  log.info('jwtsignin: jwt data', { decoded })
-  if (credsOrFailed === false || decoded.aud === 'unsigned') {
-    log.warn('jwt login failed or missing aud in jwt, trying to refresh token', { credsOrFailed, decoded })
-    await goodWalletLogin.auth(true)
-    let { decoded: decoded2 } = await goodWalletLogin.validateJWTExistenceAndExpiration()
-    if (!decoded2 || decoded2.aud === 'unsigned') {
-      throw new Error('jwt is of unsigned user')
+  try {
+    const creds = await signInAttempt()
+
+    return creds
+  } catch (exception) {
+    if ('OutdatedProfileSignatureError' === exception.name) {
+      throw exception
     }
   }
-  return credsOrFailed
+
+  log.warn('jwt login failed or missing aud in jwt, trying to refresh token')
+  return signInAttempt(true)
 }
+
 export const checkAuthStatus = async () => {
   // when wallet is ready perform login to server (sign message with wallet and send to server)
-  const [credsOrError, isCitizen]: any = await Promise.all([jwtSignin(), goodWallet.isCitizen()])
-
-  const isAuthorized = credsOrError.jwt !== undefined
+  const [creds, isCitizen]: any = await Promise.all([jwtSignin(), goodWallet.isCitizen()])
+  const isAuthorized = creds.jwt !== undefined
   const isLoggedIn = isAuthorized
   const isLoggedInCitizen = isLoggedIn && isCitizen
-  log.debug('checkAuthStatus result:', { credsOrError, isCitizen })
-  return {
-    credsOrError,
-    isLoggedInCitizen,
-    isLoggedIn,
-  }
+
+  log.debug('checkAuthStatus result:', { creds, isCitizen })
+
+  return [isLoggedInCitizen, isLoggedIn]
 }


### PR DESCRIPTION

# Description

- login.auth() throws a custom error object with the name received from the server
- added check for the custom error in the checkAuthStatus()
- refactored restart dialog show
- added error processing helpers to API.js

About #3644 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
