### PR TITLE
(Bug) Add Locale Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ account.data.txt
 .DS_Store
 
 # Localization build files
-# src/language/locales/*/*.js
+src/language/locales/*/*.js
 
 # Bundle artifact
 *.jsbundle


### PR DESCRIPTION
# Description

Cross-platform locale detection has been added @johnsmith-gooddollar 

Also:
- The render in case async loading was not yet completed was an important fix to prevent Jest tests from making empty renders, so I added it back in.
- Since the `catalog.js` files are now generated again every time the project is build I have added them back to `.gitignore`.