### PR TITLE
(Feature) Upgrade Facetec 9.4 - Breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@gooddollar/gun": "^0.2020.902",
     "@gooddollar/gun-asyncstorage": "^1.0.3",
     "@gooddollar/gun-pk-auth": "^1.1.0",
-    "@gooddollar/react-native-facetec": "^1.0.22",
+    "@gooddollar/react-native-facetec": "^1.0.23",
     "@gooddollar/react-native-side-menu": "^2.0.2",
     "@indexeddbshim/indexeddbshim": "^6.5.0",
     "@lingui/react": "^3.13.0",

--- a/src/components/dashboard/FaceVerification/hooks/useFaceTecSDK.js
+++ b/src/components/dashboard/FaceVerification/hooks/useFaceTecSDK.js
@@ -7,7 +7,7 @@ import { ExceptionType, kindOfSDKIssue } from '../utils/kindOfTheIssue'
 import { hideRedBoxIfNonCritical } from '../utils/redBox'
 
 import logger from '../../../../lib/logger/js-logger'
-import { isE2ERunning, isEmulator } from '../../../../lib/utils/platform'
+import { isEmulator } from '../../../../lib/utils/platform'
 
 import FaceTecGlobalState from '../sdk/FaceTecGlobalState'
 import useCriticalErrorHandler from './useCriticalErrorHandler'
@@ -64,7 +64,7 @@ export default (eventHandlers = {}) => {
         const isDeviceEmulated = await isEmulator
 
         // if cypress is running - do nothing and immediately call success callback
-        if (!isE2ERunning && !isDeviceEmulated) {
+        if (!isDeviceEmulated) {
           await FaceTecGlobalState.initialize()
         }
 

--- a/src/components/dashboard/FaceVerification/hooks/useFaceTecVerification.js
+++ b/src/components/dashboard/FaceVerification/hooks/useFaceTecVerification.js
@@ -3,7 +3,7 @@ import { assign, noop } from 'lodash'
 
 // logger & utils
 import logger from '../../../../lib/logger/js-logger'
-import { isE2ERunning, isEmulator } from '../../../../lib/utils/platform'
+import { isEmulator } from '../../../../lib/utils/platform'
 
 // Zoom SDK reference & helpers
 import api from '../api/FaceVerificationApi'
@@ -57,8 +57,8 @@ export default (options = null) => {
 
     // if cypress is running
     // isMobileNative is temporary check, will be removed once we'll deal with Zoom on native
-    if (isE2ERunning || isDeviceEmulated) {
-      log.debug('skipping fv ui for non real devices or IOS', { isE2ERunning, isDeviceEmulated })
+    if (isDeviceEmulated) {
+      log.debug('skipping fv ui for non real devices or IOS', { isDeviceEmulated })
 
       try {
         // don't start session, just call enroll with fake data to whitelist user on server

--- a/src/components/dashboard/FaceVerification/screens/IntroScreen.js
+++ b/src/components/dashboard/FaceVerification/screens/IntroScreen.js
@@ -29,7 +29,7 @@ import {
   isSmallDevice,
 } from '../../../../lib/utils/sizes'
 import { withStyles } from '../../../../lib/styles'
-import { isBrowser, isE2ERunning, isEmulator, isIOSWeb, isMobileSafari } from '../../../../lib/utils/platform'
+import { isBrowser, isEmulator, isIOSWeb, isMobileSafari } from '../../../../lib/utils/platform'
 import { openLink } from '../../../../lib/utils/linking'
 import Config from '../../../../config/config'
 import { Permissions } from '../../../permissions/types'
@@ -195,7 +195,7 @@ const IntroScreen = ({ styles, screenProps }) => {
 
     // if cypress is running - just redirect to FR as we're skipping
     // zoom componet (which requires camera access) in this case
-    if (isE2ERunning || isDeviceEmulated) {
+    if (isDeviceEmulated) {
       openFaceVerification()
       return
     }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -9,9 +9,6 @@ import mustache from '../lib/utils/mustache'
 
 import env from './env'
 
-// E2E checker utility import
-//import { isE2ERunning } from '../lib/utils/platform'
-
 const { search: qs = '' } = isWeb ? window.location : {}
 const webStorage = isWeb ? window.localStorage : { getItem: noop }
 
@@ -192,11 +189,7 @@ export const serverSettings = once(() => {
     .then(settings => Object.assign(Config, settings))
 })
 
-// TODO: wrap all stubs / "backdoors" made for automated testing
-// if (isE2ERunning) {
 global.config = Config
-
-//}
 
 // Forcing value as number, if not MNID encoder/decoder may fail
 // Config.networkId = Config.ethereum[Config.networkId].network_id

--- a/src/lib/utils/platform.js
+++ b/src/lib/utils/platform.js
@@ -20,8 +20,6 @@ import { getSystemName, getSystemVersion, isEmulator as isEmulatedDevice } from 
 
 import isWebApp from './isWebApp'
 
-import { appEnv } from './env'
-
 export const isSafari = isMobileSafari || isSafariWeb
 
 export const isWeb = Platform.OS === 'web'
@@ -54,8 +52,6 @@ export const isEmulator = isMobileNative ? isEmulatedDevice() : Promise.resolve(
 
 export const isCypress =
   !isMobileReactNative && 'undefined' !== typeof window && get(window, 'navigator.userAgent', '').includes('Cypress')
-
-export const isE2ERunning = isCypress && 'development' === appEnv
 
 export const osVersionInfo = (() => {
   const [osName, version] = Platform.select({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,10 +2918,10 @@
     emailjs "^2.2.0"
     text-encoding "^0.7.0"
 
-"@gooddollar/react-native-facetec@^1.0.22":
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/@gooddollar/react-native-facetec/-/react-native-facetec-1.0.22.tgz#14a81d2e73c1ee6fd801a7c11d6771daa99fcb29"
-  integrity sha512-MgTSZyvfbewlfMX6lixRzUfvlErCd9xe7+5MEUJALYexb9gVzPCbHiWqUvK80Nc3ISIvu5itlck1e6MShBqrig==
+"@gooddollar/react-native-facetec@^1.0.23":
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/@gooddollar/react-native-facetec/-/react-native-facetec-1.0.23.tgz#b44dc233d14404c411717725474916119b27f50e"
+  integrity sha512-ApquLbxFrfCyW+Tc0mN0WW1UtUUWLTWvp9wLiwljd3NErXXvNDhvJ5e/Sd1wK6jtKIQyIdEsfdusUD5xlHzxWg==
 
 "@gooddollar/react-native-side-menu@^2.0.2":
   version "2.0.2"


### PR DESCRIPTION
# Description

- using `resultBlob` json response fields instead of recalling `.retry()` / `.succeed()` has been deprecated

About #3429 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
