### PR TITLE
(Bug):  The 'My Wallet Address' popup is stuck after pressing the 'I understand' button

### DIFF
--- a/src/components/backupWallet/ExportWalletData.js
+++ b/src/components/backupWallet/ExportWalletData.js
@@ -90,6 +90,7 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
           title="My Private Key"
           content={fullPrivateKey}
           imageSize={checkmarkIconSize}
+          onBeforeCopy={onPrivateKeyCopy}
           image={Checkmark}
           copyButtonText="Copy Key"
           showCopyIcon={false}
@@ -110,7 +111,6 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
           truncateContent
           enableIndicateAction
           enableSideMode
-          onBeforeCopy={onPrivateKeyCopy}
         />
         <Divider />
         <BorderedBox

--- a/src/components/backupWallet/ExportWalletData.js
+++ b/src/components/backupWallet/ExportWalletData.js
@@ -19,6 +19,8 @@ import config from '../../config/config'
 
 // assets
 import Checkmark from '../../assets/checkmark.svg'
+import { useDialog } from '../../lib/dialog/useDialog'
+import ExportWarningPopup from './ExportWarningPopup'
 
 // localization
 
@@ -36,6 +38,7 @@ const Divider = ({ size = 50 }) => <Section.Separator color="transparent" width=
 const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
   const { navigate } = navigation
   const goodWallet = useWallet()
+  const { showDialog, hideDialog } = useDialog()
 
   const handleGoHome = useCallback(() => navigate('Home'), [navigate])
 
@@ -49,6 +52,24 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
       networkId,
     ]
   }, [goodWallet])
+
+  const onPrivateKeyCopy = useCallback(
+    resultCallback => {
+      const onCancel = () => resultCallback(false)
+
+      const onConfirm = () => {
+        hideDialog()
+        resultCallback(true)
+      }
+
+      showDialog({
+        showButtons: false,
+        onDismiss: onCancel,
+        content: <ExportWarningPopup onDismiss={onConfirm} />,
+      })
+    },
+    [showDialog, hideDialog],
+  )
 
   return (
     <Wrapper style={styles.wrapper}>
@@ -89,7 +110,7 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
           truncateContent
           enableIndicateAction
           enableSideMode
-          isDangerous
+          onBeforeCopy={onPrivateKeyCopy}
         />
         <Divider />
         <BorderedBox

--- a/src/components/backupWallet/ExportWalletData.js
+++ b/src/components/backupWallet/ExportWalletData.js
@@ -3,7 +3,7 @@
 // libraries
 import React, { useCallback, useMemo } from 'react'
 import { ScrollView } from 'react-native'
-import { get, noop } from 'lodash'
+import { get } from 'lodash'
 
 // components
 import { t } from '@lingui/macro'
@@ -12,9 +12,6 @@ import { Section } from '../common'
 import BorderedBox from '../common/view/BorderedBox'
 import NavBar from '../appNavigation/NavBar'
 
-// hooks
-import { useDialog } from '../../lib/dialog/useDialog'
-
 // utils
 import { withStyles } from '../../lib/styles'
 import { useWallet } from '../../lib/wallet/GoodWalletProvider'
@@ -22,7 +19,6 @@ import config from '../../config/config'
 
 // assets
 import Checkmark from '../../assets/checkmark.svg'
-import ExportWarningPopup from './ExportWarningPopup'
 
 // localization
 
@@ -39,7 +35,6 @@ const Divider = ({ size = 50 }) => <Section.Separator color="transparent" width=
 //TODO: handle 3rd party wallet
 const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
   const { navigate } = navigation
-  const { showDialog } = useDialog()
   const goodWallet = useWallet()
 
   const handleGoHome = useCallback(() => navigate('Home'), [navigate])
@@ -54,16 +49,6 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
       networkId,
     ]
   }, [goodWallet])
-
-  const onPublicKeyCopied = useCallback(
-    () =>
-      showDialog({
-        showButtons: false,
-        onDismiss: noop,
-        content: <ExportWarningPopup />,
-      }),
-    [showDialog],
-  )
 
   return (
     <Wrapper style={styles.wrapper}>
@@ -101,10 +86,10 @@ const ExportWalletData = ({ navigation, styles, theme }: ExportWalletProps) => {
           image={Checkmark}
           copyButtonText="Copy address"
           showCopyIcon={false}
-          onCopied={onPublicKeyCopied}
           truncateContent
           enableIndicateAction
           enableSideMode
+          isDangerous
         />
         <Divider />
         <BorderedBox

--- a/src/components/common/view/BorderedBox.js
+++ b/src/components/common/view/BorderedBox.js
@@ -15,8 +15,6 @@ import { useClipboardCopy } from '../../../lib/hooks/useClipboard'
 import { withStyles } from '../../../lib/styles'
 import { getDesignRelativeHeight, getDesignRelativeWidth } from '../../../lib/utils/sizes'
 import { truncateMiddle } from '../../../lib/utils/string'
-import ExportWarningPopup from '../../backupWallet/ExportWarningPopup'
-import { useDialog } from '../../../lib/dialog/useDialog'
 
 const copiedActionTimeout = 3000 // time during which the copy success message is displayed
 
@@ -41,7 +39,6 @@ const BorderedBox = ({
 }) => {
   // show the copy success message or no
   const [performed, setPerformed] = useState(false)
-  const { showDialog, hideDialog } = useDialog()
 
   const _onCopied = useCallback(() => {
     enableIndicateAction && setPerformed(true)
@@ -52,29 +49,11 @@ const BorderedBox = ({
   const copyToClipboard = useClipboardCopy(content, _onCopied)
   const displayContent = truncateContent ? truncateMiddle(content, 29) : content // 29 = 13 chars left side + 3 chars of '...' + 13 chars right side
 
-  // TODO: move to upper componentm pass as onBeforeCopy
-  const onDangerousCopy = useCallback(resultCallback => {
-      const onCancel = () => resultCallback(false)
-
-      const onConfirm = () => {
-        hideDialog()
-        resultCallback(true)
-      }
-
-      showDialog({
-        showButtons: false,
-        onDismiss: onCancel,
-        content: <ExportWarningPopup onDismiss={onConfirm} />,
-      }),
-    },
-    [showDialog, hideDialog],
-  )
-
   const handleCopy = useCallback(() => {
     if (!onBeforeCopy) {
       copyToClipboard()
     }
-    
+
     onBeforeCopy(allow => {
       if (allow) {
         copyToClipboard()


### PR DESCRIPTION
# Description

- extended BorderedBox component, adding the ability to copy secure data with confirming through a pop-up window
- fixed closing of pop-up on copy public key

About #3713

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
