### PR TITLE
fix for bridge confirm that could be triggered multiple times

### DIFF
--- a/src/components/dashboard/SendReceive/SummaryGeneric.js
+++ b/src/components/dashboard/SendReceive/SummaryGeneric.js
@@ -100,7 +100,11 @@ const SummaryGeneric = ({
     try {
       await onConfirm(vendorFields)
     } finally {
-      setLoading(false)
+      // the bridge transaction is handled by a separate useEffect so incorrectly finalizes here
+      // while it should still be loading
+      if (!isBridge) {
+        setLoading(false)
+      }
     }
   }, [name, email, vendorInfo, onConfirm])
 
@@ -266,7 +270,7 @@ const SummaryGeneric = ({
             </BackButton>
           </Section.Row>
           <Section.Stack grow={3} style={styles.nextButtonContainer}>
-            <CustomButton disabled={formHasErrors()} onPress={_onPress} loading={loading}>
+            <CustomButton disabled={formHasErrors() || loading} onPress={_onPress} loading={loading}>
               {address || isBridge ? 'Confirm' : 'Confirm & Share Link'}
             </CustomButton>
           </Section.Stack>


### PR DESCRIPTION
# Description
The last part of sendViaBridge is handled by a separate useEffect so the loading on confirm button is incorrectly reset

About # (link your issue here)
#3966 
