### PR TITLE
3896: possible fix for not showing dialog

### DIFF
--- a/src/components/common/connectionDialog/internetConnection.js
+++ b/src/components/common/connectionDialog/internetConnection.js
@@ -13,8 +13,9 @@ const log = logger.child({ from: 'InternetConnection' })
 
 const InternetConnection = props => {
   const { hideDialog, showDialog } = useDialog()
+  const { isLoggedIn } = props
   const isConnection = useConnection()
-  const isAPIConnection = useAPIConnection(!props.isLoggedIn) // only ping server and block usage for new users if server is down.
+  const isAPIConnection = useAPIConnection(!isLoggedIn) // only ping server and block usage for new users if server is down.
   const [showDisconnect, setShowDisconnect] = useState(false)
   const [firstLoadError, setFirstLoadError] = useState(true)
 
@@ -22,15 +23,17 @@ const InternetConnection = props => {
     message => {
       setShowDisconnect(true)
 
-      showDialog({
-        title: t`Waiting for network`,
-        image: <LoadingIcon />,
-        message,
-        showButtons: false,
-        showCloseButtons: false,
-      })
+      if (!isLoggedIn) {
+        showDialog({
+          title: t`Waiting for network`,
+          image: <LoadingIcon />,
+          message,
+          showButtons: false,
+          showCloseButtons: false,
+        })
+      }
     },
-    [setShowDisconnect, showDialog],
+    [setShowDisconnect, showDialog, isLoggedIn],
   )
 
   const showDialogWindow = useDebouncedCallback(showWaiting, Config.delayMessageNetworkDisconnection)


### PR DESCRIPTION
# Description

The initial fix did not fully work as the isLoggedIn prop is not immediately set.
Because of the useDebounce delay, after user logs in in the modal for the waiting network still pops-up
because of the first run where props.isLoggedIn is not defined

This is the simplest way to skip the dialog window.

About # (link your issue here)
#3896 

# How Has This Been Tested?
Local web