### PR TITLE
(Fix) Wallet event subscriber ID being `NaN`

### DIFF
--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -791,7 +791,7 @@ export class GoodWallet {
     }
 
     const subscribers = this.subscribers[eventName]
-    const id = Math.max(...Object.keys(subscribers).map(parseInt), 0) + 1 // Give next id in a raw to current subscriber
+    const id = Math.max(...Object.keys(subscribers).map(val => parseInt(val)), 0) + 1 // Give next id in a raw to current subscriber
     this.subscribers[eventName][id] = cb
     return { id, eventName }
   }

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -791,7 +791,7 @@ export class GoodWallet {
     }
 
     const subscribers = this.subscribers[eventName]
-    const id = Math.max(...Object.keys(subscribers).map(val => parseInt(val)), 0) + 1 // Give next id in a raw to current subscriber
+    const id = Math.max(...Object.keys(subscribers).map(Number), 0) + 1 // Give next id in a raw to current subscriber
     this.subscribers[eventName][id] = cb
     return { id, eventName }
   }


### PR DESCRIPTION
# Description

I noticed you use `.map(parseInt)` to determine the next ID for a event subscriber, this will cause issues.
`parseInt` takes two parameters, a string, and a radix. `Array#map`'s callback function has three parameters, the element, the index and the array itself. With `.map(parseInt)` you are passing the element's index as the `radix` and this can sometimes result in `NaN` (in fact the second element - index of 1 - will result in `NaN`).

This pull request replaces that code with `.map(val => parseInt(val))` which prevents the index being passed to `parseInt`.

## Example Screenshots

### With current code

Notice the `.map(parseInt)`

![Screenshot 2023-05-22 165655](https://github.com/GoodDollar/GoodDAPP/assets/40654585/dd65a926-8061-4d80-a3a7-8c991ce4a13e)

### With new code

Notice the `.map(val => parseInt(val))`

![Screenshot 2023-05-22 165736](https://github.com/GoodDollar/GoodDAPP/assets/40654585/d8146bfe-e93c-4860-8c57-9c179760ba9a)

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
