### PR TITLE
fix: check more specifically if userStorage methods are set

### DIFF
--- a/src/components/faceVerification/screens/IntroScreen.js
+++ b/src/components/faceVerification/screens/IntroScreen.js
@@ -1,5 +1,5 @@
 // libraries
-import React, { useCallback, useContext, useEffect, useMemo } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 import { Platform, View } from 'react-native'
 
 import { get } from 'lodash'
@@ -57,51 +57,54 @@ const WalletDeletedPopupText = ({ styles }) => (
   </View>
 )
 
-const Intro = ({ styles, firstName, ready, onVerify, onLearnMore }) => (
-  <Wrapper>
-    <Section style={styles.topContainer} grow>
-      <View style={styles.mainContent}>
-        <Section.Title fontWeight="bold" textTransform="none" style={styles.mainTitle}>
-          {firstName && `${firstName},`}
-          <Section.Text fontWeight="regular" textTransform="none" fontSize={24} lineHeight={30}>
-            {firstName ? `\n` : ''}
-            {'Verify you are a real\nlive person'}
+const Intro = ({ styles, ready, onVerify, onLearnMore }) => {
+  const { fullName } = useProfile()
+  const firstName = getFirstWord(fullName)
+
+  return (
+    <Wrapper>
+      <Section style={styles.topContainer} grow>
+        <View style={styles.mainContent}>
+          <Section.Title fontWeight="bold" textTransform="none" style={styles.mainTitle}>
+            {firstName && `${firstName},`}
+            <Section.Text fontWeight="regular" textTransform="none" fontSize={24} lineHeight={30}>
+              {firstName ? `\n` : ''}
+              {'Verify you are a real\nlive person'}
+            </Section.Text>
+          </Section.Title>
+          <Section.Text fontSize={18} lineHeight={25} letterSpacing={0.18} style={styles.mainText}>
+            {t`Your image is only used to prevent the creation of duplicate accounts and will never be transferred to any third party`}
           </Section.Text>
-        </Section.Title>
-        <Section.Text fontSize={18} lineHeight={25} letterSpacing={0.18} style={styles.mainText}>
-          {t`Your image is only used to prevent the creation of duplicate accounts and will never be transferred to any third party`}
-        </Section.Text>
-        <Section.Text
-          fontWeight="bold"
-          fontSize={18}
-          lineHeight={26}
-          textDecorationLine="underline"
-          style={styles.learnMore}
-          onPress={onLearnMore}
-        >
-          {t`Learn More`}
-        </Section.Text>
-        <View style={styles.illustration}>
-          <FashionShootSVG />
+          <Section.Text
+            fontWeight="bold"
+            fontSize={18}
+            lineHeight={26}
+            textDecorationLine="underline"
+            style={styles.learnMore}
+            onPress={onLearnMore}
+          >
+            {t`Learn More`}
+          </Section.Text>
+          <View style={styles.illustration}>
+            <FashionShootSVG />
+          </View>
+          <CustomButton style={[styles.button]} onPress={onVerify} disabled={!ready}>
+            {t`OK, VERIFY ME`}
+          </CustomButton>
         </View>
-        <CustomButton style={[styles.button]} onPress={onVerify} disabled={!ready}>
-          {t`OK, VERIFY ME`}
-        </CustomButton>
-      </View>
-    </Section>
-  </Wrapper>
-)
+      </Section>
+    </Wrapper>
+  )
+}
 
 const IntroScreen = ({ styles, screenProps, navigation }) => {
-  const { fullName } = useProfile()
   const { showDialog } = useDialog()
 
-  const { firstName, isFVFlow, isFVFlowReady } = useContext(FVFlowContext)
+  const { isFVFlow, isFVFlowReady } = useContext(FVFlowContext)
   const { screenState, goToRoot, navigateTo, pop, push } = screenProps
   const isValid = get(screenState, 'isValid', false)
 
   const { faceIdentifier: enrollmentIdentifier, v1FaceIdentifier: fvSigner } = useEnrollmentIdentifier()
-  const userName = useMemo(() => (isFVFlow ? firstName : getFirstWord(fullName)), [isFVFlow, firstName, fullName])
 
   const navigateToHome = useCallback(() => navigateTo('Home'), [navigateTo])
 
@@ -161,7 +164,7 @@ const IntroScreen = ({ styles, screenProps, navigation }) => {
   useEffect(() => log.debug({ isIOS: isIOSWeb, isMobileSafari }), [])
 
   useEffect(() => {
-    log.debug({ enrollmentIdentifier, userName, isFVFlow, isValid, isFVFlowReady })
+    log.debug({ enrollmentIdentifier, isFVFlow, isValid, isFVFlowReady })
 
     if (isValid) {
       const state = { isValid }
@@ -201,15 +204,7 @@ const IntroScreen = ({ styles, screenProps, navigation }) => {
     )
   }
 
-  return (
-    <Intro
-      styles={styles}
-      firstName={userName}
-      onLearnMore={openPrivacy}
-      onVerify={handleVerifyClick}
-      ready={false === disposing}
-    />
-  )
+  return <Intro styles={styles} onLearnMore={openPrivacy} onVerify={handleVerifyClick} ready={false === disposing} />
 }
 
 const getStylesFromProps = ({ theme }) => ({

--- a/src/lib/userStorage/useProfile.js
+++ b/src/lib/userStorage/useProfile.js
@@ -11,9 +11,13 @@ const useProfileHook = (fields, allowRefresh = false, display = false) => {
 
   const getProfile = useCallback(
     (fields, display) => {
-      if (!userStorage) {
+      // the function checks are for when in FV-Standalone flow
+      // sometimes it loses the context if it is fvFlow or not since it is using
+      // some shared components with the regular flow
+      if (!userStorage || (display && !userStorage.getDisplayProfile) || (!display && !userStorage.getPrivateProfile)) {
         return {}
       }
+
       const profile = display ? userStorage.getDisplayProfile() : userStorage.getPrivateProfile()
 
       return fields ? pick(profile, fields) : profile


### PR DESCRIPTION
# Description

In the fvFlow-standalone, isFVFlow is used to determine standalone or not
this value cannot always be relied on because of reload/redirects within the flow and it using shared components with the regular flow

This fix should be enough, and reduces the need to duplicate all the code for the stand-alone flow

About # (link your issue here)
#3998 

# How Has This Been Tested?
locally: fv-build

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
