### PR TITLE
Add modal when wc pair exists

### DIFF
--- a/src/lib/wallet/WalletConnectClient.js
+++ b/src/lib/wallet/WalletConnectClient.js
@@ -17,6 +17,7 @@ import logger from '../logger/js-logger'
 import { useSessionApproveModal } from '../../components/walletconnect/WalletConnectModals'
 import Config from '../../config/config'
 import { useWallet } from './GoodWalletProvider'
+import { useDialog } from '../../lib/dialog/useDialog'
 
 const log = logger.child({ from: 'WalletConnectClient' })
 
@@ -162,6 +163,7 @@ export const useWalletConnectSession = () => {
 
   const wallet = useWallet()
   const { show: showApprove, isDialogShown } = useSessionApproveModal()
+  const { showErrorDialog } = useDialog()
   const chains = useChainsList()
 
   const decodeTx = useCallback(
@@ -716,12 +718,12 @@ export const useWalletConnectSession = () => {
             setConnector(cachedV2Connector)
           } catch (e) {
             if (e.message.includes('Pairing already exists')) {
+              showErrorDialog(`Failed to pair, please try with a new QR code`)
               log.debug('v2 pairing failed: ', {
                 message: e.message,
                 e,
                 cachedV2Connector,
                 uri,
-                activateResult,
                 connect: cachedV2Connector.connect,
               })
             }

--- a/src/lib/wallet/WalletConnectClient.js
+++ b/src/lib/wallet/WalletConnectClient.js
@@ -718,7 +718,7 @@ export const useWalletConnectSession = () => {
             setConnector(cachedV2Connector)
           } catch (e) {
             if (e.message.includes('Pairing already exists')) {
-              showErrorDialog(`Failed to pair, please try with a new QR code`)
+              showErrorDialog(`Failed to connect. Please try again with a new QR Code.`)
               log.debug('v2 pairing failed: ', {
                 message: e.message,
                 e,


### PR DESCRIPTION
# Description

We pushed a fix for better handling pairing-exist error when using wc2
the modal was not added to notify a user it needs a new qr-code/wc-uri

- [x] - Copy needs to be confirmed with @patpedrosa 

