### PR TITLE
fix: use sessionTopic on native to decide if new connection should be made

### DIFF
--- a/src/components/common/dialogs/ExplanationDialog.js
+++ b/src/components/common/dialogs/ExplanationDialog.js
@@ -1,6 +1,6 @@
 // libraries
 import React, { useCallback, useMemo } from 'react'
-import { Image, View } from 'react-native'
+import { Image, Platform, View } from 'react-native'
 import { isEmpty, noop } from 'lodash'
 
 // components
@@ -149,7 +149,11 @@ const mapStylesToProps = ({ theme }) => ({
     justifyContent: 'flex-end',
     paddingLeft: 0,
     paddingRight: 0,
-    gap: '10px',
+    ...Platform.select({
+      web: {
+        gap: '10px',
+      },
+    }),
   },
   buttonText: {
     paddingLeft: 5,

--- a/src/components/walletconnect/WalletConnectScan.js
+++ b/src/components/walletconnect/WalletConnectScan.js
@@ -8,7 +8,7 @@ import { first, get } from 'lodash'
 import Wrapper from '../common/layout/Wrapper'
 
 import { withStyles } from '../../lib/styles'
-import { isAndroidNative, isMobile } from '../../lib/utils/platform'
+import { isMobile } from '../../lib/utils/platform'
 import QRCameraPermissionDialog from '../dashboard/SendRecieveQRCameraPermissionDialog'
 
 // hooks
@@ -61,10 +61,10 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
 
   const { navigateTo } = screenProps
 
-  const hasSessionTopic = (uri: string) => {
-    const topicRegex = /sessionTopic=([^&]+)/
-    const [, sessionTopic] = uri.match(topicRegex) || []
-    return sessionTopic
+  const isSignRequest = uri => {
+    const requestRegex = /requestId=([^&]+)/
+    const [, requestId] = uri.match(requestRegex) || []
+    return requestId
   }
 
   const handleChange = useCallback(
@@ -87,10 +87,6 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
             showErrorDialog(t`Invalid QR Code.`)
             setQrDelay(QR_DEFAULT_DELAY)
           } else {
-            let sessionTopic
-            if (isAndroidNative && (sessionTopic = hasSessionTopic(validUri))) {
-              activeSessionTopic.current = sessionTopic
-            }
             incomingLinkRef.current = validUri
             log.info('walletconnect uri:', { validUri })
             setWalletConnectUri(validUri)
@@ -106,21 +102,8 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
   )
 
   useEffect(() => {
-    // sign requests on native contain requestId and sessionTopic
-    // requestId is on every request different
-    // which makes incomingLinkRef === wcIncomingLink always be false
-    let sessionTopic
-    if (
-      isAndroidNative &&
-      (sessionTopic = hasSessionTopic(wcIncomingLink)) &&
-      sessionTopic === activeSessionTopic.current
-    ) {
-      // dont retrigger connection
-      return
-    }
-
-    // check for initial connection request
-    if (incomingLinkRef.current === wcIncomingLink) {
+    // check for initial connection request or if its a sign request
+    if (incomingLinkRef.current === wcIncomingLink || isSignRequest(wcIncomingLink)) {
       return
     } else if (wcIncomingLink && uri !== wcIncomingLink && readWalletConnectUri(wcIncomingLink)) {
       setUri(wcIncomingLink)

--- a/src/components/walletconnect/WalletConnectScan.js
+++ b/src/components/walletconnect/WalletConnectScan.js
@@ -113,7 +113,7 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
     if (
       isAndroidNative &&
       (sessionTopic = hasSessionTopic(wcIncomingLink)) &&
-      sessionTopic !== activeSessionTopic.current
+      sessionTopic === activeSessionTopic.current
     ) {
       // dont retrigger connection
       return

--- a/src/components/walletconnect/WalletConnectScan.js
+++ b/src/components/walletconnect/WalletConnectScan.js
@@ -61,7 +61,7 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
 
   const { navigateTo } = screenProps
 
-  const isSignRequest = uri => {
+  const isDeeplinkRedirect = uri => {
     const requestRegex = /requestId=([^&]+)/
     const [, requestId] = uri.match(requestRegex) || []
     return requestId
@@ -102,8 +102,8 @@ const WalletConnectScan = ({ screenProps, styles, theme, navigation }: WalletCon
   )
 
   useEffect(() => {
-    // check for initial connection request or if its a sign request
-    if (incomingLinkRef.current === wcIncomingLink || isSignRequest(wcIncomingLink)) {
+    // check for initial connection request or if its a deeplink redirect request
+    if (incomingLinkRef.current === wcIncomingLink || isDeeplinkRedirect(wcIncomingLink)) {
       return
     } else if (wcIncomingLink && uri !== wcIncomingLink && readWalletConnectUri(wcIncomingLink)) {
       setUri(wcIncomingLink)


### PR DESCRIPTION
# Description

Based on a false-positive during local testing, the reconnect bug seemed to be fixed for both web/android.
android was not correctly handled...

the request URI (and how the request is sent) for a sign transaction when deep linking is a bit different than on web environment
there is a requestId in the URI which is different for every new request done on an existing connection.

this makes the original check we run on a connection request not valid because the incoming link is always different then what we cache in reference.

This PR is for adding an additional check for android-native based on sessionTopic

About # (link your issue here)
#4035 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
