### PR TITLE
Add: try-anyway button for fv flow

### DIFF
--- a/src/components/browserSupport/components/UnsupportedBrowser.js
+++ b/src/components/browserSupport/components/UnsupportedBrowser.js
@@ -1,8 +1,9 @@
 // libraries
 import React from 'react'
+import { t } from '@lingui/macro'
+import { noop } from 'lodash'
 
 // components
-import { t } from '@lingui/macro'
 import ExplanationDialog from '../../common/dialogs/ExplanationDialog'
 import { useClipboardCopy } from '../../../lib/hooks/useClipboard'
 
@@ -33,7 +34,7 @@ export default ({ onDismiss }) => (
 
 // Modal for blocking user further access to functionality
 // Example usage: functionalties which are webviews and we know don't work at all
-export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined }) => {
+export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined, onDismissWebView = noop }) => {
   const { showDialog } = useDialog()
 
   const navigateTo = copyUrl ?? Config.publicUrl
@@ -63,6 +64,10 @@ export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined }) =
         {
           text: `Go back`,
           action: onDismiss,
+        },
+        {
+          text: `Try Anyway`,
+          action: onDismissWebView,
         },
       ]}
     />

--- a/src/components/browserSupport/components/UnsupportedBrowser.js
+++ b/src/components/browserSupport/components/UnsupportedBrowser.js
@@ -34,7 +34,7 @@ export default ({ onDismiss }) => (
 
 // Modal for blocking user further access to functionality
 // Example usage: functionalties which are webviews and we know don't work at all
-export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined, onDismissWebView = noop }) => {
+export const BlockingUnsupportedBrowser = ({ onDismiss = noop, copyUrl = undefined }) => {
   const { showDialog } = useDialog()
 
   const navigateTo = copyUrl ?? Config.publicUrl
@@ -43,7 +43,7 @@ export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined, onD
     showDialog({
       isMinHeight: false,
       showButtons: false,
-      onDismiss,
+      onDismiss: noop,
       title: t`Link copied to clipboard`,
     })
   }
@@ -62,12 +62,8 @@ export const BlockingUnsupportedBrowser = ({ onDismiss, copyUrl = undefined, onD
           action: copyToClipboard,
         },
         {
-          text: `Go back`,
-          action: onDismiss,
-        },
-        {
           text: `Try Anyway`,
-          action: onDismissWebView,
+          action: onDismiss,
         },
       ]}
     />

--- a/src/components/browserSupport/hooks/useBrowserSupport.js
+++ b/src/components/browserSupport/hooks/useBrowserSupport.js
@@ -33,7 +33,6 @@ export default (options = {}) => {
     onChecked = noop,
     onSupported = noop,
     onUnsupported = noop,
-    onDismissWebview = noop,
     checkOnMounted = true,
     unsupportedPopup = null,
     outdatedPopup = null,
@@ -75,16 +74,9 @@ export default (options = {}) => {
         onUnsupported()
       }
 
-      const _onDismissWebview = () => {
-        onChecked(true)
-        onDismissWebview()
-      }
-
       showPopup({
         type: 'error',
-        content: (
-          <PopupComponent onDismiss={onDismiss} {...(isOutdated ? {} : { onDismissWebView: _onDismissWebview })} />
-        ),
+        content: <PopupComponent onDismiss={onDismiss} />,
         onDismiss: onDismiss,
       })
     },

--- a/src/components/browserSupport/hooks/useBrowserSupport.js
+++ b/src/components/browserSupport/hooks/useBrowserSupport.js
@@ -33,6 +33,7 @@ export default (options = {}) => {
     onChecked = noop,
     onSupported = noop,
     onUnsupported = noop,
+    onDismissWebview = noop,
     checkOnMounted = true,
     unsupportedPopup = null,
     outdatedPopup = null,
@@ -74,9 +75,16 @@ export default (options = {}) => {
         onUnsupported()
       }
 
+      const _onDismissWebview = () => {
+        onChecked(true)
+        onDismissWebview()
+      }
+
       showPopup({
         type: 'error',
-        content: <PopupComponent onDismiss={onDismiss} />,
+        content: (
+          <PopupComponent onDismiss={onDismiss} {...(isOutdated ? {} : { onDismissWebView: _onDismissWebview })} />
+        ),
         onDismiss: onDismiss,
       })
     },

--- a/src/components/common/dialogs/ExplanationDialog.js
+++ b/src/components/common/dialogs/ExplanationDialog.js
@@ -145,6 +145,7 @@ const mapStylesToProps = ({ theme }) => ({
   },
   buttonsContainer: {
     display: 'flex',
+    flexWrap: 'wrap',
     flexDirection: 'row',
     justifyContent: 'flex-end',
     paddingLeft: 0,

--- a/src/components/faceVerification/screens/IntroScreen.js
+++ b/src/components/faceVerification/screens/IntroScreen.js
@@ -104,6 +104,7 @@ const IntroScreen = ({ styles, screenProps, navigation }) => {
 
   const { firstName, isFVFlow, isFVFlowReady } = useContext(FVFlowContext)
   const { goToRoot, navigateTo, push } = screenProps
+  const dismissedWebView = navigation.getParam('dismissedWebView')
 
   const { faceIdentifier: enrollmentIdentifier, v1FaceIdentifier: fvSigner } = useEnrollmentIdentifier()
   const userName = useMemo(() => (firstName ? (isFVFlow ? firstName : getFirstWord(fullName)) : ''), [
@@ -112,7 +113,13 @@ const IntroScreen = ({ styles, screenProps, navigation }) => {
     fullName,
   ])
 
-  const navigateToHome = useCallback(() => navigateTo('Home'), [navigateTo])
+  const dismissWebViewNotice = useCallback(() => {
+    push('FaceVerificationIntro', { dismissedWebView: true })
+  })
+
+  // goToRoot is used as there is a unknown issue with navigateTo('Home')
+  // that causes Dashboard to open with loading icon
+  const navigateToHome = useCallback(() => goToRoot(), [goToRoot])
 
   const [disposing, checkDisposalState] = useDisposingState(
     {
@@ -150,8 +157,9 @@ const IntroScreen = ({ styles, screenProps, navigation }) => {
     checkOnMounted: false,
     onSupported: requestCameraPermissions,
     onUnsupported: navigateToHome,
+    onDismissWebview: dismissWebViewNotice,
     unsupportedPopup: BlockingUnsupportedBrowser,
-    onCheck: () => !isWebView && (!isIOSWeb || iosSupportedWeb),
+    onCheck: () => dismissedWebView || (!isWebView && (!isIOSWeb || iosSupportedWeb)),
   })
 
   const handleVerifyClick = useCallback(async () => {

--- a/src/components/faceVerification/standalone/hooks/useFVLoginInfoCheck.js
+++ b/src/components/faceVerification/standalone/hooks/useFVLoginInfoCheck.js
@@ -3,17 +3,16 @@ import useEnrollmentIdentifier from '../../hooks/useEnrollmentIdentifier'
 import { FVFlowContext } from '../context/FVFlowContext'
 
 const useFVLoginInfoCheck = navigation => {
-  const { isFVFlow, fvFlowError, isWebView } = useContext(FVFlowContext)
+  const { isFVFlow, fvFlowError } = useContext(FVFlowContext)
   const { faceIdentifier } = useEnrollmentIdentifier()
   const { navigate } = navigation
 
   useEffect(() => {
-    const dismissedWebView = navigation.getParam('dismissedWebView')
-    if (!isFVFlow || !navigate || dismissedWebView) {
+    if (!isFVFlow || !navigate) {
       return
     }
 
-    if (isWebView || fvFlowError || !faceIdentifier) {
+    if (fvFlowError || !faceIdentifier) {
       navigate('FVFlowError')
     }
   }, [isFVFlow, faceIdentifier, fvFlowError, navigate])

--- a/src/components/faceVerification/standalone/hooks/useFVLoginInfoCheck.js
+++ b/src/components/faceVerification/standalone/hooks/useFVLoginInfoCheck.js
@@ -8,7 +8,8 @@ const useFVLoginInfoCheck = navigation => {
   const { navigate } = navigation
 
   useEffect(() => {
-    if (!isFVFlow || !navigate) {
+    const dismissedWebView = navigation.getParam('dismissedWebView')
+    if (!isFVFlow || !navigate || dismissedWebView) {
       return
     }
 

--- a/src/components/faceVerification/standalone/screens/FVFlowError.js
+++ b/src/components/faceVerification/standalone/screens/FVFlowError.js
@@ -1,40 +1,23 @@
 // libraries
-import React, { useCallback, useContext } from 'react'
+import React from 'react'
 import { View } from 'react-native'
-
-import { FVFlowContext } from '../context/FVFlowContext'
 
 // components
 import Text from '../../../common/view/Text'
 import { CustomButton, Section, Wrapper } from '../../../common'
-import { BlockingUnsupportedBrowser } from '../../../browserSupport/components/UnsupportedBrowser'
 
 // utils
 import { getDesignRelativeHeight } from '../../../../lib/utils/sizes'
 import { exitApp } from '../../../../lib/utils/system'
-import { openLink, redirectTo } from '../../../../lib/utils/linking'
-import useCameraSupport from '../../../browserSupport/hooks/useCameraSupport'
+import { openLink } from '../../../../lib/utils/linking'
 
 import withStyles from '../theme/withStyles'
 
 const DOCS_URL = 'https://doc.gooddollar/sdk/identity'
 const openDocs = () => openLink(DOCS_URL, '_blank')
 
-const BlockingUnsupportedModal = () => {
-  const { unsupportedCopyUrl, rdu } = useContext(FVFlowContext)
-  const navigateBack = useCallback(() => redirectTo(rdu), [rdu])
-  return <BlockingUnsupportedBrowser onDismiss={navigateBack} copyUrl={unsupportedCopyUrl} />
-}
-
 const FVFlowError = ({ styles }) => {
-  const { isWebView } = useContext(FVFlowContext)
-
-  useCameraSupport({
-    unsupportedPopup: BlockingUnsupportedModal,
-    onCheck: () => !isWebView,
-  })
-
-  const reasonCopy = isWebView ? 'Unsupported Browser' : 'Login information is missing, for instructions please visit:'
+  const reasonCopy = 'Login information is missing, for instructions please visit:'
 
   return (
     <Wrapper>
@@ -43,18 +26,16 @@ const FVFlowError = ({ styles }) => {
           <View style={styles.descriptionContainer}>
             <View style={styles.descriptionWrapper}>
               <Text style={styles.text}>{reasonCopy}</Text>
-              {!isWebView && (
-                <Text
-                  color={'primary'}
-                  fontSize={getDesignRelativeHeight(16)}
-                  lineHeight={getDesignRelativeHeight(16)}
-                  letterSpacing={0.26}
-                  fontFamily="Roboto"
-                  fontWeight="bold"
-                  textDecorationLine="underline"
-                  onPress={openDocs}
-                >{`${DOCS_URL}`}</Text>
-              )}
+              <Text
+                color={'primary'}
+                fontSize={getDesignRelativeHeight(16)}
+                lineHeight={getDesignRelativeHeight(16)}
+                letterSpacing={0.26}
+                fontFamily="Roboto"
+                fontWeight="bold"
+                textDecorationLine="underline"
+                onPress={openDocs}
+              >{`${DOCS_URL}`}</Text>
             </View>
           </View>
         </View>

--- a/src/components/permissions/hooks/usePermissions.js
+++ b/src/components/permissions/hooks/usePermissions.js
@@ -113,6 +113,9 @@ const usePermissions = (permission: Permission, options = {}) => {
     async options => {
       // re-checking mounted state after each delayed / async operation as send link
       // screen could call redirect back if error happens during processing transaction
+      if (options.ignoreMountedState) {
+        mountedState.current = true
+      }
       if (!mountedState.current) {
         return
       }


### PR DESCRIPTION
# Description

If a user reads the notice about webviews that are unsupported and still wants to continue with FV
it should be able to do so.

- [x] - add try-anyway button for wallet fv-flow
- [x] - add try-anyway button in fv-standalone flow

About # (link your issue here)
#4037 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
