### PR TITLE
fix: never checking system language, fix detecting system language

### DIFF
--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -42,23 +42,19 @@ const I18n = new class {
   async getInitialLocale() {
     const { defaultLocale, locales } = this
 
+    // first we check for any system defined languages
     const detectedLocale = await this._detect(
-      // eslint-disable-next-line require-await
-      async () => {
-        const lang = await AsyncStorage.getItem('lang')
-
-        log.debug('Delect locale - AsyncStorage', { lang })
-        return lang
-      },
-
       () => {
         const sysLocales = uniq(
-          flatten(RNLocalize.getLocales().map(locale => ['Code', 'Tag'].map(prop => locale[`language${prop}`]))),
+          flatten(
+            RNLocalize.getLocales().map(locale => ['Code', 'Tag'].map(prop => locale[`language${prop}`].toLowerCase())),
+          ),
         )
 
         log.debug('Delect locale - System', { sysLocales })
 
-        const { languageTag } = RNLocalize.findBestAvailableLanguage(intersection(locales, sysLocales))
+        const { languageTag } = RNLocalize.findBestAvailableLanguage(intersection(locales, sysLocales)) ?? {}
+        log.info('LocaleTesting -- should find languageTag or undefined -->', { languageTag })
 
         if (this.isLocaleValid(languageTag)) {
           log.debug('Delect locale - System', { languageTag })
@@ -75,6 +71,17 @@ const I18n = new class {
         }
       },
 
+      // else we check if previous language is used
+
+      // eslint-disable-next-line require-await
+      async () => {
+        const lang = await AsyncStorage.getItem('lang')
+
+        log.debug('Delect locale - AsyncStorage', { lang })
+        return lang
+      },
+
+      // if all fail, we use default 'en'
       () => {
         log.debug('Delect locale - Fallback', { defaultLocale })
         return defaultLocale


### PR DESCRIPTION
# Description

We set a default language, after which it will never check for any other languages because of order of execution.
System detect had two bugs: not using lowercase, not handling undefined languageTag

- [x] - first check for system language
- [x] - fix system detect

About # (link your issue here)
#4065 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
