### PR TITLE
fix: wc-widget should only show for wallet to wallet transactions

### DIFF
--- a/src/components/dashboard/FeedItems/FeedModalItem.js
+++ b/src/components/dashboard/FeedItems/FeedModalItem.js
@@ -46,6 +46,7 @@ const FeedModalItem = (props: FeedEventProps) => {
   const sellerWebsite = get(item, 'data.sellerWebsite', '')
   const chainId = item.chainId || '122'
   const ownerAddress = item?.data?.endpoint?.address
+  const isRegTx = /(send|receive)(?!.*bridge)/
 
   return (
     <ModalWrapper
@@ -120,24 +121,27 @@ const FeedModalItem = (props: FeedEventProps) => {
                   { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginRight: 15 },
                 ]}
               >
-                {!eventSettings.withoutAmount && ownerAddress.length > 0 && walletChatEnabled && (
-                  <TouchableOpacity>
-                    <ChatWithOwner
-                      ownerAddress={ownerAddress}
-                      render={
-                        <Icon
-                          style={{
-                            marginRight: 10,
-                            marginTop: 5,
-                          }}
-                          name="chat"
-                          size={25}
-                          color="gray80Percent"
-                        />
-                      }
-                    />
-                  </TouchableOpacity>
-                )}
+                {walletChatEnabled &&
+                  isRegTx.test(itemType) &&
+                  !eventSettings.withoutAmount &&
+                  ownerAddress.length > 0 && (
+                    <TouchableOpacity>
+                      <ChatWithOwner
+                        ownerAddress={ownerAddress}
+                        render={
+                          <Icon
+                            style={{
+                              marginRight: 10,
+                              marginTop: 5,
+                            }}
+                            name="chat"
+                            size={25}
+                            color="gray80Percent"
+                          />
+                        }
+                      />
+                    </TouchableOpacity>
+                  )}
                 <EventIcon type={itemType} showAnim={!topImageExists} />
               </View>
             </View>

--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -162,6 +162,7 @@ const ListEvent = ({ item: feed, theme, index, styles }: FeedEventProps) => {
   const chainId = feed.chainId || '122'
   const txHash = feed.data.receiptHash || feed.id
   const ownerAddress = feed?.data?.endpoint?.address
+  const isRegTx = /(send|receive)(?!.*bridge)/
 
   if (itemType === 'empty') {
     return <EmptyEventFeed />
@@ -242,7 +243,7 @@ const ListEvent = ({ item: feed, theme, index, styles }: FeedEventProps) => {
               )}
             </View>
             <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
-              {!eventSettings.withoutAmount && ownerAddress.length > 0 && walletChatEnabled && (
+              {walletChatEnabled && isRegTx.test(itemType) && !eventSettings.withoutAmount && ownerAddress.length > 0 && (
                 <TouchableOpacity>
                   <ChatWithOwner
                     ownerAddress={ownerAddress}


### PR DESCRIPTION
# Description

Walletchat icon on the feed is showing for invite rewards and bridge transactions.

- [x] - it should only show for wallet <> wallet x's

