### PR TITLE
fix: add eventtype for receiving bridge tx

### DIFF
--- a/src/components/dashboard/FeedItems/FeedListItem.js
+++ b/src/components/dashboard/FeedItems/FeedListItem.js
@@ -38,13 +38,7 @@ const FeedListItem = React.memo((props: FeedListItemProps) => {
   const { feedLoadAnimShown } = useContext(GlobalTogglesContext)
   const disableAnimForTests = Config.env === 'test'
   const { theme, item, handleFeedSelection, styles } = props
-  const {
-    id,
-    type,
-    displayType,
-    action,
-    data: { link },
-  } = item
+  const { id, type, displayType, action, data: { link } = {} } = item
 
   const itemType = displayType || type
   const isItemEmpty = itemType === 'empty'

--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -163,8 +163,10 @@ const ListEvent = ({ item: feed, theme, index, styles }: FeedEventProps) => {
   const avatar = get(feed, 'data.endpoint.avatar')
   const chainId = feed.chainId || '122'
   const ownerAddress = feed?.data?.endpoint?.address
+  const isBridge = feed?.data?.endpoint?.isBridge
   const txHash = feed.data.receiptHash || feed.id
-  const isTransfer = isTransferTx(itemType)
+
+  const isTransfer = isTransferTx(itemType) && !isBridge
 
   if (itemType === 'empty') {
     return <EmptyEventFeed />

--- a/src/components/dashboard/FeedItems/ListEventItem.js
+++ b/src/components/dashboard/FeedItems/ListEventItem.js
@@ -164,7 +164,7 @@ const ListEvent = ({ item: feed, theme, index, styles }: FeedEventProps) => {
   const chainId = feed.chainId || '122'
   const ownerAddress = feed?.data?.endpoint?.address
   const isBridge = feed?.data?.endpoint?.isBridge
-  const txHash = feed.data.receiptHash || feed.id
+  const txHash = feed.data?.receiptHash || feed.id
 
   const isTransfer = isTransferTx(itemType) && !isBridge
 

--- a/src/components/dashboard/SendLinkSummary.js
+++ b/src/components/dashboard/SendLinkSummary.js
@@ -367,6 +367,7 @@ const SendLinkSummary = ({ screenProps, styles }: AmountProps) => {
           reason: t`Bridged G$`,
           counterPartyFullName: t`Bridge`,
           amount,
+          isBridge: true,
         },
       }
 

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -820,6 +820,8 @@ export class UserStorage {
     } = data
     const { address, asset, initiator, initiatorType, value, displayName, message, avatar } = this._extractData(event)
 
+    const isBridge = this.wallet.getBridgeAddresses().includes(address.toLowerCase())
+
     // displayType is used by FeedItem and ModalItem to decide on colors/icons etc of tx feed card
     const displayType = this._extractDisplayType(event)
 
@@ -846,6 +848,7 @@ export class UserStorage {
           address,
           displayName,
           avatar,
+          isBridge,
         },
         amount: value,
         senderEmail,

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -820,7 +820,7 @@ export class UserStorage {
     } = data
     const { address, asset, initiator, initiatorType, value, displayName, message, avatar } = this._extractData(event)
 
-    const isBridge = this.wallet.getBridgeAddresses().includes(address.toLowerCase())
+    const isBridge = typeof address === 'string' && this.wallet.getBridgeAddresses().includes(address.toLowerCase())
 
     // displayType is used by FeedItem and ModalItem to decide on colors/icons etc of tx feed card
     const displayType = this._extractDisplayType(event)

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -818,9 +818,17 @@ export class UserStorage {
       sponsoredLink,
       sponsoredLogo,
     } = data
-    const { address, asset, initiator, initiatorType, value, displayName, message, avatar } = this._extractData(event)
-
-    const isBridge = typeof address === 'string' && this.wallet.getBridgeAddresses().includes(address.toLowerCase())
+    const {
+      address,
+      asset,
+      initiator,
+      initiatorType,
+      value,
+      displayName,
+      message,
+      avatar,
+      isBridge,
+    } = this._extractData(event)
 
     // displayType is used by FeedItem and ModalItem to decide on colors/icons etc of tx feed card
     const displayType = this._extractDisplayType(event)
@@ -886,6 +894,7 @@ export class UserStorage {
       counterPartySmallAvatar,
       amount,
       asset,
+      isBridge = false,
     },
   }) {
     const fromNative =
@@ -941,6 +950,8 @@ export class UserStorage {
       customName || counterPartyFullName || fromEmailMobile || fromGDUbi || fromGD || fromNativeAddress || 'Unknown'
 
     data.avatar = status === 'error' || fromGD ? -1 : counterPartySmallAvatar
+
+    data.isBridge = isBridge ?? this.wallet.getBridgeAddresses().includes((data.address || '').toLowerCase())
 
     logger.debug('formatEvent: parsed data', {
       id,

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -951,7 +951,8 @@ export class UserStorage {
 
     data.avatar = status === 'error' || fromGD ? -1 : counterPartySmallAvatar
 
-    data.isBridge = isBridge ?? this.wallet.getBridgeAddresses().includes((data.address || '').toLowerCase())
+    data.isBridge =
+      isBridge ?? (typeof address == 'string' && this.wallet.getBridgeAddresses().includes(data.address.toLowerCase()))
 
     logger.debug('formatEvent: parsed data', {
       id,

--- a/src/lib/wallet/utils.js
+++ b/src/lib/wallet/utils.js
@@ -276,7 +276,7 @@ export const fromDecimals = (amount, chainOrToken = null) => {
   return parseUnits(float, decimals).toString()
 }
 
-export const isTransferTx = (txType: string) => /(send|receive)(?!.*bridge)/.test(txType)
+export const isTransferTx = (txType: string) => /(send|receive)(?!.*bridge|pending)/.test(txType)
 
 export const isDuplicateTxError = message =>
   message


### PR DESCRIPTION
# Description

The bridge receive tx on the feed was set to the same type as a regular receive event.
for wallet-chat integration, this means it would show up a chat icon.
Without this separation of events, there would be no normal way to distinct between the two types.

- [x] - add event type for receivebridge

