### PR TITLE
fix: add buygd flow for tx events, bump goodprotocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@expo/react-native-action-sheet": "^3.9.0",
     "@fingerprintjs/fingerprintjs-pro": "^3.8.1",
     "@gooddollar/goodcontracts": "^2.6.2",
-    "@gooddollar/goodprotocol": "^2.0.21",
+    "@gooddollar/goodprotocol": "^2.0.24",
     "@gooddollar/react-native-facetec": "^1.0.41",
     "@gooddollar/react-native-side-menu": "^2.0.2",
     "@gooddollar/web3sdk-v2": "^0.1.91",

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -13,7 +13,7 @@ import StakingModelAddress from '@gooddollar/goodcontracts/stakingModel/releases
 import InvitesABI from '@gooddollar/goodprotocol/artifacts/abis/InvitesV2.min.json'
 import FaucetABI from '@gooddollar/goodprotocol/artifacts/abis/Faucet.min.json'
 
-// import BuyGDCloneABI from '@gooddollar/goodprotocol/artifacts/abis/BuyGDClone.min.json'
+import BuyGDCloneABI from '@gooddollar/goodprotocol/artifacts/abis/BuyGDClone.min.json'
 
 import { MultiCall } from 'eth-multicall'
 import Web3 from 'web3'
@@ -303,7 +303,7 @@ export class GoodWallet {
         this.GOODContract = addContract(GOODToken, 'GReputation')
 
         // BuyGDClone Contract
-        // this.BuyGDClone = addContract(BuyGDCloneABI, 'BuyGDFactoryV2')
+        this.BuyGDClone = addContract(BuyGDCloneABI, 'BuyGDFactoryV2')
 
         // debug print contracts addresses
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4184,7 +4184,7 @@ __metadata:
     "@expo/react-native-action-sheet": ^3.9.0
     "@fingerprintjs/fingerprintjs-pro": ^3.8.1
     "@gooddollar/goodcontracts": ^2.6.2
-    "@gooddollar/goodprotocol": ^2.0.21
+    "@gooddollar/goodprotocol": ^2.0.24
     "@gooddollar/react-native-facetec": ^1.0.41
     "@gooddollar/react-native-side-menu": ^2.0.2
     "@gooddollar/web3sdk-v2": ^0.1.91
@@ -4450,9 +4450,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gooddollar/goodprotocol@npm:^2.0.21":
-  version: 2.0.21
-  resolution: "@gooddollar/goodprotocol@npm:2.0.21"
+"@gooddollar/goodprotocol@npm:^2.0.24":
+  version: 2.0.24
+  resolution: "@gooddollar/goodprotocol@npm:2.0.24"
   dependencies:
     "@gooddollar/goodcontracts": ^2.6.6
     "@jsier/retrier": ^1.2.4
@@ -4468,7 +4468,7 @@ __metadata:
     press-any-key: ^0.1.1
     truffle-plugin-verify: ^0.6.1
     truffle-source-verify: ^0.0.6
-  checksum: 8c74daadc1786dd66effb370e6b98dc3d8938df6d4f0177aa79523244683da3f80961a6f8124add85e0adced4d2ec58d05d1466cb6b129932e3f6af77a6ad1b7
+  checksum: b1ba09ac716da3eddfe9f841ce540cc7b277a3806415f873605a3d548642eb459abd7acb6a7ac68316696f2e48b1c2ab3b3aa056a40653db5561a00592fb7e24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

By updating to show contract-names, for buy-gd tokens this meant that it was shown as 'UniswapV3Pool'
this pr is for adding the same flow as for the other gd contract tx events
- [x] - add abi for abi-decoding
- [x] - add new txType BUYGD
- [x] - show BuyGD as sender of transaction

About # (link your issue here)
#4151