### PR TITLE
(Chore) Log network errors once per session/refresh

### DIFF
--- a/src/lib/API/utils.js
+++ b/src/lib/API/utils.js
@@ -3,7 +3,7 @@
 import axios from 'axios'
 import { assign, isError, isObject, isPlainObject, isString } from 'lodash'
 
-import logger from '../logger/js-logger'
+import logger, { isConnectionError } from '../logger/js-logger'
 
 import type { NameRecord } from '../../components/signup/NameForm'
 import type { EmailRecord } from '../../components/signup/EmailForm'
@@ -27,6 +27,25 @@ export type UserRecord = NameRecord &
 
 export const log = logger.child({ from: 'API' })
 export const defaultErrorMessage = 'Unexpected error happened during api call'
+
+const hostsBeenLogged = new Map()
+
+export const logNetworkError = exception => {
+  const { config, message } = exception
+  const { url, baseURL } = config || {}
+  const remoteUrl = baseURL || url
+
+  if (isConnectionError(exception) && remoteUrl) {
+    const { protocol, host } = new URL(remoteUrl)
+
+    if (hostsBeenLogged.has(host)) {
+      return
+    }
+
+    hostsBeenLogged.set(host, true)
+    log.exception('Connection error:', message, exception, { url: `${protocol}//${host}` })
+  }
+}
 
 export const getErrorMessage = apiError => {
   let errorMessage
@@ -102,6 +121,8 @@ export const responseErrorHandler = error => {
   const { message, response } = exception
   const { data } = response || {}
 
+  logNetworkError(exception)
   log.warn('axios response error', message, exception)
+
   throw data || exception
 }

--- a/src/lib/API/utils.js
+++ b/src/lib/API/utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import axios from 'axios'
-import { assign, isError, isObject, isPlainObject, isString } from 'lodash'
+import { assign, isError, isObject, isPlainObject, isString, trim } from 'lodash'
 
 import logger, { isConnectionError } from '../logger/js-logger'
 
@@ -28,22 +28,22 @@ export type UserRecord = NameRecord &
 export const log = logger.child({ from: 'API' })
 export const defaultErrorMessage = 'Unexpected error happened during api call'
 
-const hostsBeenLogged = new Map()
+const urlsBeenLogged = new Map()
 
 export const logNetworkError = exception => {
   const { config, message } = exception
   const { url, baseURL } = config || {}
-  const remoteUrl = baseURL || url
+  const trimUrl = url => trim(url, '/')
 
-  if (isConnectionError(exception) && remoteUrl) {
-    const { protocol, host } = new URL(remoteUrl)
+  if (isConnectionError(exception) && url) {
+    const targetUrl = baseURL ? [baseURL, url].map(trimUrl).join('/') : url
 
-    if (hostsBeenLogged.has(host)) {
+    if (urlsBeenLogged.has(targetUrl)) {
       return
     }
 
-    hostsBeenLogged.set(host, true)
-    log.exception('Connection error:', message, exception, { url: `${protocol}//${host}` })
+    urlsBeenLogged.set(targetUrl, true)
+    log.exception('Connection error:', message, exception, { url: targetUrl })
   }
 }
 

--- a/src/lib/wallet/MultipleHttpProvider.js
+++ b/src/lib/wallet/MultipleHttpProvider.js
@@ -93,21 +93,21 @@ export class MultipleHttpProvider extends HttpProvider {
    * */
   // eslint-disable-next-line require-await
   async _sendRequest(payload) {
-    const { promise, callback } = makePromiseWrapper()
+    const { promise, callback: pcallback } = makePromiseWrapper()
 
     const checkRpcError = (error, response) => {
       //regular network error
       if (error) {
-        return callback(error)
+        return pcallback(error)
       }
 
       //rpc responded with error or no result
       if (response.error || has(response, 'result') === false) {
-        return callback(response)
+        return pcallback(response)
       }
 
       //response ok
-      return callback(null, response)
+      return pcallback(null, response)
     }
 
     super.send(payload, checkRpcError)

--- a/src/lib/wallet/MultipleHttpProvider.js
+++ b/src/lib/wallet/MultipleHttpProvider.js
@@ -48,6 +48,7 @@ export class MultipleHttpProvider extends HttpProvider {
       } catch (exception) {
         if (isConnectionError(exception) && !loggedProviders.has(provider)) {
           loggedProviders.set(provider, true)
+          // log.exception bypass network error filtering
           log.exception('HTTP Provider failed to send:', exception.message, exception, { provider })
         }
 

--- a/src/lib/wallet/utils.js
+++ b/src/lib/wallet/utils.js
@@ -11,8 +11,6 @@ import logger from '../logger/js-logger'
 import { retry } from '../utils/async'
 import Config from '../../config/config'
 
-export const log = logger.child({ from: 'GoodWalletV2' })
-
 const DECIMALS = 2
 const ethAddressRegex = /(\w+)?:?(0x[a-fA-F0-9]{40})/
 const { env, showAllChainsEth } = Config
@@ -283,12 +281,3 @@ export const isTransferTx = (txType: string) => /(send|receive|withdraw)(?!.*bri
 
 export const isDuplicateTxError = message =>
   message.toLowerCase().search(/(sames*(nonce|hash)|alreadys*known|(fee|nonce)s*toos*low|underpriced)/i) >= 0
-
-export const isConnectionError = error =>
-  /((connection|network) (error|timeout)|invalid json rpc)/i.test(error instanceof Error ? error.message : error || '')
-
-export const logError = (label, error, data = undefined) => {
-  if (!isConnectionError(error)) {
-    log.error(label, error.message, error, data)
-  }
-}


### PR DESCRIPTION
# Description

- ignore network errors at log.error globally
- add log.exception as alias of the old one log.error without changes
- log http provider and axis network errors once per session/reload per each rpc url / full request url correspondingly

About #4175 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
