### PR TITLE
4221 fix explorer calls

### DIFF
--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -1,7 +1,7 @@
 // @flow
 
 import axios from 'axios'
-import { find } from 'lodash'
+import { find, isArray } from 'lodash'
 
 import type { $AxiosXHR, AxiosInstance, AxiosPromise } from 'axios'
 import Config, { fuseNetwork } from '../../config/config'
@@ -505,7 +505,10 @@ export class APIService {
     const txs = []
     const explorer = Config.ethereum[chainId].explorerAPI
 
-    const sender32 = `0x${sender.toLowerCase().slice(2).padStart(64, '0')}`
+    const sender32 = `0x${sender
+      .toLowerCase()
+      .slice(2)
+      .padStart(64, '0')}`
 
     const params = {
       module: 'logs',
@@ -529,6 +532,10 @@ export class APIService {
         params,
         baseURL: explorer,
       })
+
+      if (!isArray(events)) {
+        return
+      }
 
       params.page += 1
       txs.push(...events)

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -453,9 +453,8 @@ export class APIService {
     })
 
     if (!isArray(result)) {
-      throw Object.assign(new Error('Failed to fetch contract ABI'), {
-        data: { result, params, chainId },
-      })
+      log.warn('Failed to fetch contract ABI', { result, params, chainId })
+      throw new Error('Failed to fetch contract ABI')
     }
 
     return result
@@ -541,13 +540,12 @@ export class APIService {
 
       params.page += 1
 
-      if (isArray(events)) {
-        txs.push(...events)
-      } else {
-        throw Object.assign(new Error('Failed to fetch OTP events from explorer'), {
-          data: { events, params, chainId },
-        })
+      if (!isArray(events)) {
+        log.warn('Failed to fetch OTP events from explorer', { events, params, chainId })
+        throw new Error('Failed to fetch OTP events from explorer')
       }
+
+      txs.push(...events)
 
       if (events.length < params.offset) {
         // default page size by explorer.fuse.io
@@ -631,13 +629,12 @@ export class APIService {
 
       params.page += 1
 
-      if (isArray(result)) {
-        txs.push(...chunk)
-      } else {
-        throw Object.assign(new Error('Failed to fetch transactions from explorer'), {
-          data: { result, params, chainId },
-        })
+      if (!isArray(result)) {
+        log.warn('Failed to fetch transactions from explorer', { result, params, chainId })
+        throw new Error('Failed to fetch transactions from explorer')
       }
+
+      txs.push(...chunk)
 
       if (allPages === false || result.length < params.offset) {
         // default page size by explorer.fuse.io

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -453,7 +453,9 @@ export class APIService {
     })
 
     if (!isArray(result)) {
-      throw new Error('Failed to fetch contract ABI')
+      throw Object.assign(new Error('Failed to fetch contract ABI'), {
+        data: { result, params, chainId },
+      })
     }
 
     return result
@@ -541,6 +543,10 @@ export class APIService {
 
       if (isArray(events)) {
         txs.push(...events)
+      } else {
+        throw Object.assign(new Error('Failed to fetch OTP events from explorer'), {
+          data: { events, params, chainId },
+        })
       }
 
       if (events.length < params.offset) {
@@ -624,7 +630,14 @@ export class APIService {
       const chunk = result.filter(({ value }) => value !== '0')
 
       params.page += 1
-      txs.push(...chunk)
+
+      if (isArray(result)) {
+        txs.push(...chunk)
+      } else {
+        throw Object.assign(new Error('Failed to fetch transactions from explorer'), {
+          data: { result, params, chainId },
+        })
+      }
 
       if (allPages === false || result.length < params.offset) {
         // default page size by explorer.fuse.io

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -449,6 +449,11 @@ export class APIService {
       params,
       baseURL: explorer,
     })
+
+    if (!isArray(result)) {
+      throw new Error('Failed to fetch contract ABI')
+    }
+
     return result
   }
 

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -533,12 +533,11 @@ export class APIService {
         baseURL: explorer,
       })
 
-      if (!isArray(events)) {
-        return
-      }
-
       params.page += 1
-      txs.push(...events)
+
+      if (isArray(events)) {
+        txs.push(...events)
+      }
 
       if (events.length < params.offset) {
         // default page size by explorer.fuse.io

--- a/src/lib/API/api.js
+++ b/src/lib/API/api.js
@@ -4,6 +4,8 @@ import axios from 'axios'
 import { find, isArray } from 'lodash'
 
 import type { $AxiosXHR, AxiosInstance, AxiosPromise } from 'axios'
+import { padLeft } from 'web3-utils'
+
 import Config, { fuseNetwork } from '../../config/config'
 
 import { JWT } from '../constants/localStorage'
@@ -510,10 +512,7 @@ export class APIService {
     const txs = []
     const explorer = Config.ethereum[chainId].explorerAPI
 
-    const sender32 = `0x${sender
-      .toLowerCase()
-      .slice(2)
-      .padStart(64, '0')}`
+    const sender32 = padLeft(sender, 64)
 
     const params = {
       module: 'logs',

--- a/src/lib/userStorage/FeedStorage.js
+++ b/src/lib/userStorage/FeedStorage.js
@@ -568,7 +568,7 @@ export class FeedStorage {
     // because of a possible bug when handleReceipt creates the feed-item for receiving a bridge transaction,
     // bridge check might not be done correctly causing a unneccessary check for contract name
     // so we do it here again
-    const isBridgeReceive = this.wallet.getBridgeAddresses().includes(feedEvent.data.receiptEvent.from.toLowerCase())
+    const isBridgeReceive = this.wallet.getBridgeAddresses().includes(feedEvent.data.receiptEvent.from?.toLowerCase())
 
     const isBridgeOrBuy = [TxType.TX_BRIDGE_IN, TxType.TX_BRIDGE_OUT, TxType.TX_BUYGD].includes(feedEvent.txType)
 

--- a/src/lib/userStorage/FeedStorage.js
+++ b/src/lib/userStorage/FeedStorage.js
@@ -564,9 +564,15 @@ export class FeedStorage {
     }
 
     const isContract = await this.wallet.wallet.eth.getCode(address)
+
+    // because of a possible bug when handleReceipt creates the feed-item for receiving a bridge transaction,
+    // bridge check might not be done correctly causing a unneccessary check for contract name
+    // so we do it here again
+    const isBridgeReceive = this.wallet.getBridgeAddresses().includes(feedEvent.data.receiptEvent.from.toLowerCase())
+
     const isBridgeOrBuy = [TxType.TX_BRIDGE_IN, TxType.TX_BRIDGE_OUT, TxType.TX_BUYGD].includes(feedEvent.txType)
 
-    if (isContract !== '0x' && !isBridgeOrBuy) {
+    if (isContract !== '0x' && !isBridgeOrBuy && !isBridgeReceive) {
       feedEvent.data.counterPartyFullName = await API.getContractName(address, chainId)
     }
 

--- a/src/lib/userStorage/FeedStorage.js
+++ b/src/lib/userStorage/FeedStorage.js
@@ -566,14 +566,9 @@ export class FeedStorage {
 
     const isContract = await this.wallet.wallet.eth.getCode(address)
 
-    // because of a possible bug when handleReceipt creates the feed-item for receiving a bridge transaction,
-    // bridge check might not be done correctly causing a unneccessary check for contract name
-    // so we do it here again
-    const isBridgeReceive = this.wallet.getBridgeAddresses().includes(feedEvent.data.receiptEvent.from?.toLowerCase())
-
     const isBridgeOrBuy = [TxType.TX_BRIDGE_IN, TxType.TX_BRIDGE_OUT, TxType.TX_BUYGD].includes(feedEvent.txType)
 
-    if (isContract !== '0x' && !isBridgeOrBuy && !isBridgeReceive) {
+    if (isContract !== '0x' && !isBridgeOrBuy) {
       feedEvent.data.counterPartyFullName = await API.getContractName(address, chainId)
     }
 

--- a/src/lib/userStorage/FeedStorage.js
+++ b/src/lib/userStorage/FeedStorage.js
@@ -6,6 +6,7 @@ import { t } from '@lingui/macro'
 
 import * as TextileCrypto from '@textile/crypto'
 import delUndefValNested from '../utils/delUndefValNested'
+import { retry } from '../utils/async'
 import Config from '../../config/config'
 import logger from '../../lib/logger/js-logger'
 import { fireEvent, REWARD_RECEIVED } from '../analytics/analytics'
@@ -517,7 +518,7 @@ export class FeedStorage {
       })
 
       const [counterPartyData, txData] = await Promise.all([
-        this.getCounterParty(updatedFeedEvent),
+        retry(() => this.getCounterParty(updatedFeedEvent), 3, 1000),
         this.getFromOutbox(updatedFeedEvent),
       ])
 

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -1,6 +1,6 @@
 //@flow
 
-import { assign, get, invokeMap, isEqual, keys, memoize, pick } from 'lodash'
+import { assign, get, invokeMap, memoize } from 'lodash'
 import { isAddress } from 'web3-utils'
 import moment from 'moment'
 
@@ -750,7 +750,7 @@ export class UserStorage {
   // eslint-disable-next-line require-await
   async formatEvent(event: FeedEvent) {
     try {
-      return await this._formatEvent(event)
+      return this._formatEvent(event)
     } catch (e) {
       logger.error('formatEvent: failed formatting event:', e.message, e, { event })
 
@@ -768,37 +768,10 @@ export class UserStorage {
     )
   }
 
-  _formatEvent = memoize(async event => {
+  _formatEvent = memoize(event => {
     logger.debug('formatEvent: incoming event', event.id, { event })
 
-    const { feedStorage } = this
     const { data, type } = event
-    const { counterPartyFullName } = data
-
-    const counterPartyNativeEvents = [FeedItemType.EVENT_TYPE_SENDNATIVE, FeedItemType.EVENT_TYPE_RECEIVENATIVE]
-
-    const counterPartyEvents = [
-      ...counterPartyNativeEvents,
-      FeedItemType.EVENT_TYPE_SENDDIRECT,
-      FeedItemType.EVENT_TYPE_SEND,
-      FeedItemType.EVENT_TYPE_WITHDRAW,
-      FeedItemType.EVENT_TYPE_RECEIVE,
-      FeedItemType.EVENT_TYPE_SENDBRIDGE,
-    ]
-
-    if (counterPartyEvents.includes(type) && !counterPartyFullName) {
-      const counterPartyData = await feedStorage.getCounterParty(event)
-
-      if (!isEqual(counterPartyData, pick(data, keys(counterPartyData)))) {
-        assign(data, counterPartyData)
-
-        if (counterPartyNativeEvents.includes(type)) {
-          feedStorage.updateNativeTx(event)
-        } else {
-          feedStorage.updateFeedEvent(event)
-        }
-      }
-    }
 
     const { date, id, status, createdDate, animationExecuted, action, chainId } = event
     const {

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -750,7 +750,7 @@ export class UserStorage {
   // eslint-disable-next-line require-await
   async formatEvent(event: FeedEvent) {
     try {
-      return this._formatEvent(event)
+      return await this._formatEvent(event)
     } catch (e) {
       logger.error('formatEvent: failed formatting event:', e.message, e, { event })
 
@@ -768,7 +768,8 @@ export class UserStorage {
     )
   }
 
-  _formatEvent = memoize(event => {
+  // eslint-disable-next-line require-await
+  _formatEvent = memoize(async event => {
     logger.debug('formatEvent: incoming event', event.id, { event })
 
     const { data, type } = event

--- a/src/lib/userStorage/UserStorageClass.js
+++ b/src/lib/userStorage/UserStorageClass.js
@@ -773,7 +773,7 @@ export class UserStorage {
 
     const { feedStorage } = this
     const { data, type } = event
-    const { counterPartyFullName, counterPartySmallAvatar } = data
+    const { counterPartyFullName } = data
 
     const counterPartyNativeEvents = [FeedItemType.EVENT_TYPE_SENDNATIVE, FeedItemType.EVENT_TYPE_RECEIVENATIVE]
 
@@ -786,7 +786,7 @@ export class UserStorage {
       FeedItemType.EVENT_TYPE_SENDBRIDGE,
     ]
 
-    if (counterPartyEvents.includes(type) && (!counterPartyFullName || !counterPartySmallAvatar)) {
+    if (counterPartyEvents.includes(type) && !counterPartyFullName) {
       const counterPartyData = await feedStorage.getCounterParty(event)
 
       if (!isEqual(counterPartyData, pick(data, keys(counterPartyData)))) {

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -485,7 +485,13 @@ export class GoodWallet {
 
     await this.processEvents([...txEvents, ...withdrawEvents, ...cancelEvents])
 
-    const lastBlock = Number(last(txEvents)?.blockNumber)
+    const lastBlockNumbers = [
+      last(txEvents)?.blockNumber,
+      last(withdrawEvents)?.blockNumber,
+      last(cancelEvents)?.blockNumber,
+    ].filter(blockNumber => !!blockNumber)
+
+    const lastBlock = lastBlockNumbers.length > 0 ? Math.max(...lastBlockNumbers) : undefined
 
     return lastBlock ? lastBlock + 1 : startBlock
   }

--- a/src/lib/wallet/GoodWalletClass.js
+++ b/src/lib/wallet/GoodWalletClass.js
@@ -17,7 +17,7 @@ import BuyGDCloneABI from '@gooddollar/goodprotocol/artifacts/abis/BuyGDClone.mi
 
 import { MultiCall } from 'eth-multicall'
 import Web3 from 'web3'
-import { BN, toBN } from 'web3-utils'
+import { BN, hexToNumber, toBN } from 'web3-utils'
 
 import abiDecoder from 'abi-decoder'
 import {
@@ -487,8 +487,8 @@ export class GoodWallet {
 
     const lastBlockNumbers = [
       last(txEvents)?.blockNumber,
-      last(withdrawEvents)?.blockNumber,
-      last(cancelEvents)?.blockNumber,
+      hexToNumber(last(withdrawEvents)?.blockNumber),
+      hexToNumber(last(cancelEvents)?.blockNumber),
     ].filter(blockNumber => !!blockNumber)
 
     const lastBlock = lastBlockNumbers.length > 0 ? Math.max(...lastBlockNumbers) : undefined


### PR DESCRIPTION
# Description

Several errors and failed api calls were reported. also it seemed the API was called extensively which should be roughly every 30 seconds, not accounting for when someone scrolls over the feed. that triggers the sync again.

One bug was found (cause of it not found yet) where a BRIDGE_IN transaction is wrongly created on the feed with regular txtype receive. this results in it thinking its a regular contract transaction and tries to fetch the contract name for it as a result
- [x] - for these items an additional isBridgeReceive check is added when using getCounterParty

Additional fixes
- [x] - counterPartySmallAvatar does not seem to be used, resulting in getCounterParty always being called for gd-contracts
- [x] - API can return a valid 200 response with an error message about 'limit reached'. so verify that the events from get logs is an array 
- [x] - we call getOTPLEvents for withdraw/cancel tx's simultaneously, possible resulting in to many requests p/s (likely when someone scrolls over the feed)


About # (link your issue here)
#4221 