### PR TITLE
alternative flow for storing/persisting logmethod

### DIFF
--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -15,6 +15,7 @@ import { theme } from '../theme/styles'
 import { useUserStorage, useWallet } from '../../lib/wallet/GoodWalletProvider'
 import IdentifierRow from '../common/view/IdentifierRow'
 
+import AsyncStorage from '../../lib/utils/asyncStorage'
 import EditProfile from './EditProfile'
 import ProfileDataTable from './ProfileDataTable'
 import ViewAvatar from './ViewOrUploadAvatar'
@@ -36,6 +37,18 @@ const ProfileWrapper = ({ screenProps, styles }) => {
   const handleAvatarPress = useCallback(() => screenProps.push(`ViewAvatar`), [screenProps])
 
   const handleEditProfilePress = useCallback(() => screenProps.push(`EditProfile`), [screenProps])
+
+  useEffect(() => {
+    if (userStorage) {
+      ;(async () => {
+        const localLogMethod = await AsyncStorage.getItem('logMethod')
+        if (localLogMethod) {
+          await userStorage.userProperties.safeSet('logMethod', localLogMethod)
+          await AsyncStorage.removeItem('logMethod')
+        }
+      })()
+    }
+  }, [logMethod, userStorage])
 
   useEffect(() => {
     if (userStorage) {

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -15,7 +15,6 @@ import { theme } from '../theme/styles'
 import { useUserStorage, useWallet } from '../../lib/wallet/GoodWalletProvider'
 import IdentifierRow from '../common/view/IdentifierRow'
 
-import AsyncStorage from '../../lib/utils/asyncStorage'
 import EditProfile from './EditProfile'
 import ProfileDataTable from './ProfileDataTable'
 import ViewAvatar from './ViewOrUploadAvatar'
@@ -37,18 +36,6 @@ const ProfileWrapper = ({ screenProps, styles }) => {
   const handleAvatarPress = useCallback(() => screenProps.push(`ViewAvatar`), [screenProps])
 
   const handleEditProfilePress = useCallback(() => screenProps.push(`EditProfile`), [screenProps])
-
-  useEffect(() => {
-    if (userStorage) {
-      ;(async () => {
-        const localLogMethod = await AsyncStorage.getItem('logMethod')
-        if (localLogMethod) {
-          await userStorage.userProperties.safeSet('logMethod', localLogMethod)
-          await AsyncStorage.removeItem('logMethod')
-        }
-      })()
-    }
-  }, [logMethod, userStorage])
 
   useEffect(() => {
     if (userStorage) {

--- a/src/lib/wallet/GoodWalletProvider.jsx
+++ b/src/lib/wallet/GoodWalletProvider.jsx
@@ -8,6 +8,7 @@ import { View } from 'react-native'
 import { RadioButton } from 'react-native-paper'
 import { t } from '@lingui/macro'
 
+import AsyncStorage from '../utils/asyncStorage'
 import Config from '../../config/config'
 import logger from '../logger/js-logger'
 import GoodWalletLogin from '../login/GoodWalletLoginClass'
@@ -222,7 +223,7 @@ export const GoodWalletProvider = ({ children, disableLoginAndWatch = false }) =
           await doLogin(wallet, storage, false)
         }
 
-        if (isLoggedInRouter || (seedOrWeb3 && Config.env !== 'test')) {
+        if (isLoggedInRouter) {
           await storage.initRegistered()
 
           if (loginAndWatch) {
@@ -240,7 +241,7 @@ export const GoodWalletProvider = ({ children, disableLoginAndWatch = false }) =
         global.wallet = wallet
 
         if (logMethod) {
-          await storage.userProperties.safeSet('logMethod', logMethod)
+          await AsyncStorage.setItem('logMethod', logMethod)
         }
 
         setWalletAndStorage({


### PR DESCRIPTION
# Description
Previous 'fix' was an attempt to persist user properties during signing. that broke the flow for creating new accounts.

The current fix waits with persisting props back to db until someone visits the profile page.
