### PR TITLE
chore: add bounty spec — FV standalone intro screen flow

### DIFF
--- a/.bounties/20260417-fv-intro-screen-flow/01_clarified_intent.md
+++ b/.bounties/20260417-fv-intro-screen-flow/01_clarified_intent.md
@@ -1,0 +1,63 @@
+# Clarified Intent
+
+## Interpreted intent
+
+The standalone face-verification (FV) intro flow currently lives inside a monolithic `IntroScreen.jsx` that also houses deprecated local-native flow components (`Intro`, `IntroReVerification`). The `standalone/AppRouter` reaches back into the main `faceVerification` package index to import `FaceVerificationIntro`, pulling in all that dead code. This bounty does two things together: (1) **extract** the standalone intro components into `standalone/screens/IntroScreen.jsx` and **delete** the deprecated native-flow code (confirmed deleted), leaving `screens/IntroScreen.jsx` empty and removable; and (2) **improve** the UX within the new file by routing first-time users and reverifying users to distinct screens — reverify users skip the overview, see a wallet block with "Last verified" instead of "Valid until", get the over-18 checkbox added, and go straight to FV on confirm.
+
+## Assumptions
+
+- "Standalone flow" = the app running via `standalone/AppRouter.jsx` with `FVFlowProvider` context — `isFVFlow === true` everywhere inside it.
+- "First-time user" = `isReverify === false` (derived at line 447: `expiryDate?.lastAuthenticated?.isZero() === false`).
+- "Last verified" date = formatted from `expiryDate.lastAuthenticated` (BigNumber unix timestamp from `useIdentityExpiryDate`).
+- `Intro` and `IntroReVerification` (local native flow) are **confirmed deleted** in this PR.
+- With those deleted, `screens/IntroScreen.jsx` becomes empty and should be deleted; `faceVerification/index.js` should have `FaceVerificationIntro` removed.
+- `WalletDeletedPopupText` (used by `useDisposingState` in `IntroScreen`) must travel with the standalone screen, not be dropped.
+- The new standalone screen handles `isReverify` routing directly — no `isFVFlow` flag needed anywhere.
+- Standalone-only styles (`standalone*`-prefixed keys in `getStylesFromProps`, plus `walletBlock`, `blockHeader`, `warningBlock`, etc.) move into the new file.
+
+## Clarifying questions
+
+### Must-answer (blocking)
+
+_None — the codebase provides enough context and the request is sufficiently specific._
+
+### Should-answer
+
+- **Last verified format** — `moment().format('l')` (locale short) or something like `MMM D, YYYY`?
+- **Wallet Linked box on reverify** — show wallet address (shortened) alongside the date, or date only?
+- **Button label on reverify** — keep "Verify Me" or change (e.g. "Re-verify")?
+- **"How verification works" link** — keep or remove on the reverify action screen?
+- **`withStyles` to use** — `standalone/theme/withStyles.js` or the app-wide `lib/styles` version? (Follow whatever `FVFlowSuccess.jsx` uses.)
+
+### Nice-to-have
+
+- Should the "How verification works" link remain on the reverify action screen?
+- Any design mock-up or Figma reference for the reverify screen layout?
+
+## Required context & documents
+
+- [x] `src/components/faceVerification/screens/IntroScreen.jsx` — all components to migrate/delete live here
+- [x] `src/components/faceVerification/standalone/AppRouter.jsx` — import to rewire
+- [x] `src/components/faceVerification/standalone/index.js` — barrel to update
+- [x] `src/components/faceVerification/index.js` — `FaceVerificationIntro` export to remove
+- [x] `src/components/faceVerification/standalone/context/FVFlowContext.jsx` — context the new screen should consume
+- [x] `src/components/faceVerification/standalone/screens/FVFlowSuccess.jsx` — reference pattern for standalone screen structure
+- [x] `useIdentityExpiryDate` from `@gooddollar/web3sdk-v2` — provides `lastAuthenticated` BigNumber
+- [ ] Design mock-up for the updated reverify screen layout (optional)
+
+## Provisional acceptance criteria (draft)
+
+- [ ] `standalone/screens/IntroScreen.jsx` exists; contains only standalone-relevant components with no `isFVFlow` references.
+- [ ] `standalone/AppRouter.jsx` imports from `standalone/screens/` — not from `faceVerification/index.js`.
+- [ ] `Intro`, `IntroReVerification` deleted from `screens/IntroScreen.jsx`; file deleted; `FaceVerificationIntro` removed from `faceVerification/index.js`.
+- [ ] First-time users see the existing two-screen sequence (Overview → Action) unchanged.
+- [ ] Reverifying users skip Overview and land directly on the action screen.
+- [ ] The reverify action screen includes the Wallet Linked box with "Last verified: {date}".
+- [ ] The reverify action screen shows both checkboxes ("I'm over 18" + GoodDollar-only consent), both required.
+- [ ] Confirming on the reverify screen starts FaceVerification immediately.
+- [ ] All `standalone*`-prefixed styles removed from the original file and live in the new one.
+- [ ] Tests passing; snapshot updated; at least one test case covers `isReverify === true`.
+
+## Next step
+
+Scan the repo for all touch points across `IntroScreen.jsx`, the standalone directory, and both barrel files to produce a full context report.

--- a/.bounties/20260417-fv-intro-screen-flow/02_repo_context.md
+++ b/.bounties/20260417-fv-intro-screen-flow/02_repo_context.md
@@ -1,0 +1,86 @@
+# Repo Context Report
+
+## Repo & package targets
+
+- Repo(s): `GoodDAPP` (https://github.com/GoodDollar/GoodDAPP)
+- Package(s)/workspaces: root workspace (single package)
+- Primary paths: `src/components/faceVerification/screens/IntroScreen.jsx`, `src/components/faceVerification/standalone/`
+- Build/test/lint commands found: `yarn test`, `yarn lint`, `yarn build`
+
+## Closest existing patterns (paths)
+
+- `src/components/faceVerification/standalone/screens/FVFlowSuccess.jsx` — example of a standalone-only screen living in `standalone/screens/`; new intro screen should follow this file's pattern (own styles, no `isFVFlow` gate)
+- `src/components/faceVerification/standalone/screens/FVFlowError.jsx` — same pattern; both exported from `standalone/index.js`
+- `src/components/faceVerification/standalone/context/FVFlowContext.jsx` — provides `firstName`, `isFVFlow`, `isDelta`, `externalAccount`; already consumed by all standalone screens
+- `src/components/faceVerification/screens/IntroScreen.jsx:208` — `IntroFVFlowOverview` (source to migrate)
+- `src/components/faceVerification/screens/IntroScreen.jsx:313` — `IntroFVFlowAction` (source to migrate + modify)
+- `src/components/faceVerification/screens/IntroScreen.jsx:412` — `IntroFVFlow` routing wrapper (source to migrate + simplify)
+
+## Likely change points (ranked)
+
+### Core logic / services
+
+- None — no service-layer changes required.
+
+### UI / components
+
+- **NEW** `src/components/faceVerification/standalone/screens/IntroScreen.jsx` — new file; contains migrated `IntroFVFlowOverview`, modified `IntroFVFlowAction` (adds reverify wallet block + over-18 checkbox), and simplified `IntroFVFlow` routing wrapper (no `isFVFlow` check). Owns its own `getStylesFromProps` function with only standalone-relevant styles.
+- `src/components/faceVerification/standalone/AppRouter.jsx:5` — replace `FaceVerificationIntro` import from `'..'` to the new standalone screen (e.g., `'./screens/IntroScreen'` or via updated `standalone/index.js`).
+- `src/components/faceVerification/standalone/index.js` — add export for the new standalone intro screen.
+- `src/components/faceVerification/screens/IntroScreen.jsx` — **delete**: migrate standalone components, delete `Intro` + `IntroReVerification` (confirmed deprecated), delete the now-empty file.
+- `src/components/faceVerification/index.js` — **remove** `FaceVerificationIntro` export (no longer backed by a file).
+
+### Hooks / state
+
+- `useIdentityExpiryDate` (consumed at `IntroScreen.jsx:446`) — the new standalone screen needs `expiryDate.lastAuthenticated` (BigNumber); pass via prop or re-hook inside the new file; follow the same `moment.unix(n.toNumber()).format('l')` pattern used for `connectedUntil`.
+- `useFVLoginInfoCheck`, `useDisposingState` — currently in the monolithic `IntroScreen`; need to remain accessible for both flows. Confirm whether these are standalone-specific (they import from `standalone/hooks/`) or shared.
+
+### SDK / API wrappers
+
+- None required.
+
+### Contracts / onchain
+
+- None required.
+
+### Config / env
+
+- None required.
+
+## Dependencies & integration notes
+
+- **`moment`** — already imported in `IntroScreen.jsx`; import in new file too.
+- **`@gooddollar/web3sdk-v2` `useIdentityExpiryDate`** — `lastAuthenticated` is BigNumber; guard against zero.
+- **`shortenWalletAddress`** helper (line 205) — small pure function; copy or extract to a shared utils file.
+- **`WarningBlock`** component (line 182) — used by both `IntroFVFlowOverview` and `IntroFVFlowAction`; extract to `standalone/components/` or inline in the new file.
+- **`withStyles`** — current file uses the app-wide `lib/styles` version. The standalone directory has its own `standalone/theme/withStyles.js`; consider using that for the new file if it already wraps the correct theme provider.
+- **`FVFlowContext`** — already used by existing standalone screens; the new intro screen should consume it for `firstName`, `externalAccount`, `isDelta`, etc., rather than relying on the monolithic `IntroScreen`'s prop chain.
+- **`GDLogoSVG`, `BillyVerifies`, `BillySecurity`** — assets already used by the inline components; import them directly in the new file.
+
+## Testing & verification plan
+
+- **Unit/integration**: `src/components/faceVerification/__tests__/IntroScreen.jsx` — existing single snapshot test; update to point at the old `IntroScreen` (legacy path) or add a new test file for the standalone intro at `standalone/screens/__tests__/IntroScreen.jsx`.
+- **New test cases needed**:
+  - `isReverify === false` path: Overview renders, Action renders after "Get Started".
+  - `isReverify === true` path: Overview is NOT rendered; Action renders immediately with Wallet Linked box, "Last verified" label, and over-18 checkbox.
+- **Snapshot**: Regenerate with `yarn test -u`.
+- **Manual QA**:
+  1. New user standalone flow: Overview screen → action screen → FV starts.
+  2. Reverify standalone flow: directly on action screen → Wallet Linked box with "Last verified" → both checkboxes required → FV starts immediately.
+  3. Legacy native flow (if still active): unchanged.
+
+## Risks & edge cases
+
+- **High**: `AppRouter.jsx` import change — if the old `FaceVerificationIntro` from `..` is removed and other parts of the app still import from that path, a runtime error will occur. Confirm only `AppRouter.jsx` consumes `FaceVerificationIntro` for the standalone path.
+- **Medium**: `useFVLoginInfoCheck` and `useDisposingState` are called in the monolithic `IntroScreen` — ensure the new standalone screen also calls them (or that they're not relevant to the standalone context).
+- **Medium**: Standalone-prefixed styles in `IntroScreen.jsx` (`standaloneTitle`, `standaloneBlocks`, `walletBlock`, `standaloneConsentWrapper`, etc.) — must be moved wholesale to the new file; removing them from the original breaks the legacy components if any share them (audit before deleting).
+- **Low**: `lastAuthenticated.toNumber()` — safe for realistic unix timestamps; add `isZero()` fallback.
+- **Low**: `shortenWalletAddress` is defined as a module-level function in `IntroScreen.jsx`; if kept private it needs to be re-declared or moved to a shared util.
+
+## Open questions (blocking only)
+
+_None — legacy component deletion confirmed in scope. `Intro`, `IntroReVerification`, `screens/IntroScreen.jsx`, and the `FaceVerificationIntro` barrel export are all deleted as part of this PR._
+
+## Handoff summary
+
+Create `src/components/faceVerification/standalone/screens/IntroScreen.jsx` by migrating `IntroFVFlowOverview`, `IntroFVFlowAction`, `IntroFVFlow`, `WarningBlock`, `WalletDeletedPopupText`, `shortenWalletAddress`, and all gate hooks / camera permission logic out of the monolithic `screens/IntroScreen.jsx`. Add the UX changes (reverify routing, wallet block, "Last verified", over-18 checkbox for reverify). Wire `standalone/AppRouter.jsx` to import directly from the new file. Delete `Intro`, `IntroReVerification`, and the now-empty `screens/IntroScreen.jsx`; remove `FaceVerificationIntro` from `faceVerification/index.js`. The result is a self-contained standalone intro with zero dependency on deprecated native-flow code.

--- a/.bounties/20260417-fv-intro-screen-flow/03_bounty_spec.md
+++ b/.bounties/20260417-fv-intro-screen-flow/03_bounty_spec.md
@@ -1,0 +1,87 @@
+## 1) Summary
+
+The standalone face-verification intro flow currently lives inside a monolithic `screens/IntroScreen.jsx` that also houses deprecated local-native flow components (`Intro`, `IntroReVerification`). The standalone `AppRouter` reaches back into the main package index to import `FaceVerificationIntro`, dragging in all that dead code. This bounty extracts the standalone intro into its own file at `standalone/screens/IntroScreen.jsx`, deletes the deprecated native components, and improves the UX so that first-time users and reverifying users see distinct, purpose-built screens rather than the same generic two-screen sequence.
+
+## 2) Desired behavior (acceptance criteria)
+
+- `standalone/AppRouter.jsx` imports the intro screen from `standalone/screens/` — not from `faceVerification/index.js`.
+- The new standalone intro file has no `isFVFlow` check anywhere — it is always the FV-flow context.
+- First-time users (`isReverify === false`) see the existing two-screen sequence (Overview → Action) with behaviour unchanged.
+- Reverifying users (`isReverify === true`) skip the Overview screen and land directly on the action screen.
+- The reverify action screen includes the **Wallet Linked** box showing the wallet address and "Last verified: {date}" (not "Valid until").
+- The reverify action screen shows **both** consent checkboxes — "I'm over 18" **and** the GoodDollar-only consent — and both are required before "Verify Me" is enabled.
+- Confirming on the reverify screen triggers FaceVerification immediately (no additional intermediate screen).
+- `Intro`, `IntroReVerification`, and `WalletDeletedPopupText` are removed from `screens/IntroScreen.jsx`; `WalletDeletedPopupText` moves with the standalone components that use it.
+- `screens/IntroScreen.jsx` is deleted and `FaceVerificationIntro` is removed from `faceVerification/index.js`.
+- Styles used only by standalone components are defined in the new file; none remain in the deleted original.
+
+## 3) Scope (in / out)
+
+**In scope**
+
+- **New file** `src/components/faceVerification/standalone/screens/IntroScreen.jsx` — migrated and improved standalone intro (contains `IntroFVFlowOverview`, `IntroFVFlowAction`, routing wrapper, `WarningBlock`, `WalletDeletedPopupText`, `shortenWalletAddress`, own `getStylesFromProps`).
+- `standalone/AppRouter.jsx` — rewire intro import.
+- `standalone/index.js` — add export for new intro screen.
+- `src/components/faceVerification/screens/IntroScreen.jsx` — **delete** `Intro`, `IntroReVerification`, migrated standalone components, and the `IntroScreen` wrapper; delete file when empty.
+- `src/components/faceVerification/index.js` — remove `FaceVerificationIntro` export.
+- `IntroFVFlowAction` reverify branch — add Wallet Linked box with "Last verified" date; remove `!isReverify` guard on over-18 checkbox; update button `disabled` condition.
+- Thread `lastAuthenticated` (formatted) and `walletAddress` into the action screen.
+- Add/update tests for the new standalone intro.
+
+**Out of scope**
+
+- Any changes to `FaceVerification` (the camera/scan screen), `FaceVerificationError`, or other standalone screens.
+- Analytics event taxonomy.
+- Backend, contracts, or SDK changes.
+- Any redesign of `IntroFVFlowOverview` beyond what is needed for the migration.
+
+## 4) Starting points (top paths + notes)
+
+- `src/components/faceVerification/screens/IntroScreen.jsx:208` — `IntroFVFlowOverview`: migrate verbatim; no logic changes for new-user path.
+- `src/components/faceVerification/screens/IntroScreen.jsx:313` — `IntroFVFlowAction`: migrate + add reverify wallet block (lines 234–259 of Overview are the source), remove `!isReverify` guard (line 368), update `disabled` (line 389).
+- `src/components/faceVerification/screens/IntroScreen.jsx:412` — `IntroFVFlow`: migrate + add `isReverify` routing guard to skip Overview; drop `isFVFlow` check entirely.
+- `src/components/faceVerification/screens/IntroScreen.jsx:439` — `IntroScreen` wrapper: contains gate hooks (`useDisposingState`, `useFVLoginInfoCheck`, camera permission logic) and `lastAuthenticated` / `walletAddress` — these must be preserved in the new standalone screen, not silently dropped.
+- `src/components/faceVerification/standalone/screens/FVFlowSuccess.jsx` — reference pattern: own `withStyles`, consumes `FVFlowContext`, no `isFVFlow` checks.
+- `src/components/faceVerification/standalone/AppRouter.jsx:5` — single-line import change.
+- `src/components/faceVerification/__tests__/IntroScreen.jsx` — existing snapshot test to update or replace with a new test file in `standalone/screens/__tests__/`.
+
+## 5) Definition of Done (DoD) + How to test
+
+**DoD**
+
+- [ ] `standalone/screens/IntroScreen.jsx` created; no `isFVFlow` references; contains all migrated + improved standalone intro logic.
+- [ ] `standalone/AppRouter.jsx` imports intro from `standalone/screens/` (not from of `faceVerification/index.js`).
+- [ ] `IntroFVFlow` skips `IntroFVFlowOverview` when `isReverify === true`.
+- [ ] Reverify action screen renders Wallet Linked box with `"Last verified: {date}"` (`moment.unix(lastAuthenticated.toNumber()).format('l')`; zero-value fallback present).
+- [ ] Over-18 checkbox visible and required for reverify users; button `disabled` until both checkboxes ticked.
+- [ ] Gate hooks (`useDisposingState`, `useFVLoginInfoCheck`) and camera permission logic present in the new standalone screen.
+- [ ] `screens/IntroScreen.jsx` deleted; `FaceVerificationIntro` removed from `faceVerification/index.js`.
+- [ ] `yarn lint` and `yarn test` pass; snapshot regenerated; at least one test covers `isReverify === true` path.
+- [ ] PR includes screenshots for both user paths (mobile + desktop).
+
+**How to test**
+
+```bash
+# Install
+yarn install
+
+# Lint
+yarn lint src/components/faceVerification/
+
+# Test (update snapshots on first run)
+yarn test --testPathPattern=IntroScreen -u
+
+# Manual QA — start dev server
+yarn start
+
+# Path A (new user):  wallet with lastAuthenticated == 0
+#   → Overview screen visible → "Get Started" → Action screen → both checkboxes → FV starts
+# Path B (reverify):  wallet with lastAuthenticated != 0
+#   → Overview NOT shown → Action with Wallet Linked box ("Last verified: {date}")
+#   → over-18 + GD consent both required → "Verify Me" → FV starts immediately
+```
+
+---
+
+> **Contribution guidelines:** https://github.com/GoodDollar/GoodDAPP/blob/master/CONTRIBUTING.md
+> For questions, use the Builders Telegram channel or comment on the GitHub issue.

--- a/.bounties/20260417-fv-intro-screen-flow/04_review_dod.md
+++ b/.bounties/20260417-fv-intro-screen-flow/04_review_dod.md
@@ -1,0 +1,161 @@
+# Review DoD — 20260417-fv-intro-screen-flow
+
+## 1) Review Context
+
+- Bounty: Extract standalone FV intro screen and clean up deprecated native flow
+- Reviewer: TBD (pipeline pre-review)
+- Date: 2026-04-17
+- PR / Branch: TBD
+- Related Issue(s): TBD
+- Scope Reviewed: `03_bounty_spec.md` DoD against `01_clarified_intent.md` + `02_repo_context.md`
+- Scope Excluded: Camera/scan screen, error screens, analytics, contracts
+- Source DoD Artifact: `.bounties/20260417-fv-intro-screen-flow/03_bounty_spec.md`
+
+## 2) DoD Status
+
+1. `standalone/screens/IntroScreen.jsx created; no isFVFlow references`: **N/A (pre-implementation)**
+   - Evidence: Pattern established by `FVFlowSuccess.jsx` and `FVFlowError.jsx` in same directory.
+   - Notes: Contributor should follow those files' structure (own `withStyles`, standalone context imports).
+
+2. `AppRouter.jsx imports intro from standalone/screens/ — not from faceVerification/index.js`: **N/A (pre-implementation)**
+   - Evidence: Single import line change at `AppRouter.jsx:5`; low risk.
+   - Notes: Verify no other caller still imports `FaceVerificationIntro` from `..` for the standalone path.
+
+3. `IntroFVFlow skips IntroFVFlowOverview when isReverify === true`: **N/A (pre-implementation)**
+   - Evidence: Routing guard is a simple conditional at the top of `IntroFVFlow`; `isReverify` is already a prop.
+   - Notes: Straightforward; guard lives in `IntroFVFlow`, not inside `IntroFVFlowOverview`.
+
+4. `Reverify action screen renders Wallet Linked box with "Last verified" and zero-value fallback`: **N/A (pre-implementation)**
+   - Evidence: Wallet Linked box markup exists verbatim at `IntroFVFlowOverview:234–259`; needs `lastAuthenticated` + `walletAddress` threaded in.
+   - Notes: `lastAuthenticated.isZero()` guard required before calling `.toNumber()`.
+
+5. `Over-18 checkbox visible and required for reverify; both checkboxes gate button`: **N/A (pre-implementation)**
+   - Evidence: Guard at line 368 (`!isReverify ? ... : null`) removed; `disabled` at line 389 updated to drop `!isReverify &&`.
+   - Notes: Both `ageConfirmed` and `goodDollarOnlyConfirmed` state must be tracked for reverify path.
+
+6. `Gate hooks (useDisposingState, useFVLoginInfoCheck) and camera permission logic present in new screen`: **N/A (pre-implementation)**
+   - Evidence: These are called in the monolithic `IntroScreen` wrapper (lines 465, 484–514, 530); they must be preserved in the new standalone screen.
+   - Notes: This is the highest-risk item — silently dropping these hooks would break wallet disposal detection and login info gating.
+
+7. `screens/IntroScreen.jsx deleted; FaceVerificationIntro removed from faceVerification/index.js`: **N/A (pre-implementation)**
+   - Evidence: Once all components are migrated/deleted, the file is empty; `index.js` reference becomes a dead export.
+   - Notes: Confirm no other non-standalone caller imports `FaceVerificationIntro` before deleting.
+
+8. `yarn lint and yarn test pass; snapshot regenerated; isReverify === true test case added`: **N/A (pre-implementation)**
+   - Evidence: Existing test at `__tests__/IntroScreen.jsx` is a bare single snapshot; will need a new or augmented test targeting the standalone screen.
+   - Notes: Snapshot must be regenerated (`yarn test -u`); add FVFlowContext mock with non-zero `lastAuthenticated` BigNumber.
+
+9. `PR includes screenshots for both user paths (mobile + desktop)`: **N/A (pre-implementation)**
+   - Evidence: Required per contribution guidelines.
+   - Notes: Reviewer should block merge if absent.
+
+## 3) DoD Coverage Summary
+
+- Total DoD Items: 9
+- Pass: 0 (pre-implementation review)
+- Partial: 0
+- Fail: 0
+- N/A: 9
+
+## 4) Findings (Primary Output)
+
+### Critical
+
+- [x] None
+
+### High
+
+- [ ] Finding: Gate hooks must be preserved in the new standalone screen
+  - DoD Item: 6
+  - Problem: `useDisposingState`, `useFVLoginInfoCheck`, camera permission, and emulator check are all in the monolithic `IntroScreen` wrapper (lines 465–530). If the contributor only migrates the visual components and forgets this logic, the standalone flow silently loses wallet disposal detection and login info gating.
+  - Evidence: `IntroScreen.jsx:465` (`useDisposingState`), `490–514` (camera permission flow), `530` (`useFVLoginInfoCheck`).
+  - Required Fix: These hooks and the `handleVerifyClick` callback must be re-implemented (or re-called) in the new `standalone/screens/IntroScreen.jsx`.
+
+- [ ] Finding: `lastAuthenticated` zero-value guard
+  - DoD Item: 4
+  - Problem: `lastAuthenticated.toNumber()` will throw if the value is undefined or a BigNumber zero; even though `isReverify` guards this logically, defensive coding is required.
+  - Evidence: `expiryDate?.lastAuthenticated` — optional chain present but BigNumber methods need the value.
+  - Required Fix: `lastAuthenticated?.isZero() ? t\`N/A\` : moment.unix(lastAuthenticated.toNumber()).format('l')`.
+
+### Medium
+
+- [ ] Finding: `WarningBlock` and `WalletDeletedPopupText` travel with the standalone components
+  - DoD Item: 1, 7
+  - Problem: Both are defined in `IntroScreen.jsx` and used only by standalone components (`WarningBlock` at lines 301 and 364; `WalletDeletedPopupText` via `useDisposingState`). They must move to the new file or `standalone/components/`.
+  - Evidence: `IntroScreen.jsx:60` (`WalletDeletedPopupText`), `IntroScreen.jsx:182` (`WarningBlock`).
+  - Required Fix: Move both to the new standalone screen file (or extract to `standalone/components/` if reuse is anticipated).
+
+- [ ] Finding: No test coverage for the reverify path currently
+  - DoD Item: 8
+  - Problem: The existing test uses no FVFlowContext mock; `isReverify`, `walletAddress`, and `lastAuthenticated` are all undefined, so the reverify branch is never exercised.
+  - Evidence: `__tests__/IntroScreen.jsx` — bare `getWebRouterComponentWithMocks`, no context values.
+  - Required Fix: Add a test case mocking `useIdentityExpiryDate` to return a non-zero `lastAuthenticated`; assert Overview absent, Wallet Linked box and both checkboxes present in the reverify snapshot.
+
+### Low
+
+- [ ] Finding: `shortenWalletAddress` helper must move
+  - DoD Item: 7
+  - Problem: Defined at `IntroScreen.jsx:205`; used only by standalone components. If file is deleted and helper not moved, build fails.
+  - Evidence: Used in `IntroFVFlowOverview:210` and the new reverify wallet block.
+  - Required Fix: Inline in new file or extract to `faceVerification/utils/`.
+
+- [ ] Finding: `withStyles` — confirm which variant to use
+  - DoD Item: 1
+  - Problem: `standalone/theme/withStyles.js` exists; `IntroScreen.jsx` uses `lib/styles` version. Using the wrong one could cause theme gaps in the standalone app.
+  - Evidence: `standalone/screens/FVFlowSuccess.jsx` — check which `withStyles` it imports and be consistent.
+  - Required Fix: Match the `withStyles` import used by the other standalone screens.
+
+## 5) Validation Summary
+
+- Lint: `yarn lint src/components/faceVerification/`
+- Typecheck: N/A (JavaScript project)
+- Tests: `yarn test --testPathPattern=IntroScreen -u`
+- Build: `yarn build` (or dev server)
+- Manual QA: New-user path + reverify path, mobile + desktop screenshots
+
+## 6) Decision
+
+- Review Outcome: `Approved with follow-ups` _(scope is clear and well-bounded; two High findings must be addressed during implementation)_
+- Blocking Items:
+  - Gate hooks (`useDisposingState`, `useFVLoginInfoCheck`, camera permission) must be present in the new standalone screen.
+  - `lastAuthenticated` zero-guard required.
+  - Screenshots required before merge.
+- Non-blocking Follow-ups:
+  - Consider extracting `WarningBlock` to `standalone/components/` for future reuse.
+
+## 7) Required Contributor Actions
+
+1. Create `standalone/screens/IntroScreen.jsx`; migrate `IntroFVFlowOverview`, `IntroFVFlowAction`, `IntroFVFlow`, `WarningBlock`, `WalletDeletedPopupText`, `shortenWalletAddress`, and all gate hooks / camera permission logic from the old `IntroScreen` wrapper.
+2. Add UX improvements: `isReverify` routing guard in `IntroFVFlow`; Wallet Linked box with "Last verified" date (+ zero-value fallback) in the reverify action branch; over-18 checkbox and updated `disabled` condition for reverify path.
+3. Rewire `standalone/AppRouter.jsx` to import from `standalone/screens/`; update `standalone/index.js`.
+4. Delete `Intro`, `IntroReVerification`, migrated components, and `standalone*`-prefixed styles from `screens/IntroScreen.jsx`; delete the file; remove `FaceVerificationIntro` from `faceVerification/index.js`.
+5. Add `isReverify === true` test case with mocked context; regenerate snapshot.
+6. Submit PR with screenshots for both user paths (mobile + desktop).
+
+## 8) Reproducibility Notes
+
+```bash
+# Install
+yarn install
+
+# Lint
+yarn lint src/components/faceVerification/
+
+# Tests (update snapshot)
+yarn test --testPathPattern=IntroScreen -u
+
+# Start dev server for manual QA
+yarn start
+```
+
+## 9) Open Questions
+
+- [ ] Should `WarningBlock` be extracted to `standalone/components/` for reuse, or inlined in the new screen file?
+- [ ] Which `withStyles` does `FVFlowSuccess.jsx` use — `standalone/theme/withStyles.js` or `lib/styles`? Contributor must check and match.
+- [ ] Date format for "Last verified": `moment.format('l')` (locale short) or explicit format like `MMM D, YYYY`?
+
+## 10) Sign-off
+
+- Reviewer: TBD
+- Final Comment: Spec is clear and well-scoped. The main risk is silently dropping gate hooks during the migration; the High finding covers this explicitly. All other changes are mechanical. Ready for implementation.
+- Date: 2026-04-17

--- a/.bounties/20260417-fv-intro-screen-flow/meta.yaml
+++ b/.bounties/20260417-fv-intro-screen-flow/meta.yaml
@@ -1,0 +1,4 @@
+id: 20260417-fv-intro-screen-flow
+title: 'FV Standalone Flow — Differentiate first-time vs. reverify intro screens'
+type: Feature
+created_at: 2026-04-17

--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,5 @@ dev-dist
 .continueignore
 .yalc
 yalc.lock
-.codex
 codex-resume
+.codex


### PR DESCRIPTION
## Summary

Adds bounty specification artifacts for the standalone Face Verification intro screen flow improvement.

**Bounty ID:** `20260417-fv-intro-screen-flow`
**Type:** Feature

## What's in this PR

- `.bounties/20260417-fv-intro-screen-flow/meta.yaml` — bounty metadata
- `01_clarified_intent.md` — clarified scope and assumptions
- `02_repo_context.md` — repo context report with touch points
- `03_bounty_spec.md` — full bounty specification (acceptance criteria, scope, starting points, DoD)
- `04_review_dod.md` — pre-implementation DoD review

## Bounty Scope

Extract the standalone FV intro components from the monolithic `screens/IntroScreen.jsx` into `standalone/screens/IntroScreen.jsx` and improve the UX so first-time users and reverifying users see distinct, purpose-built screens:

- Reverify users skip the Overview screen and land directly on the Action screen
- Reverify Action screen shows Wallet Linked box with "Last verified: {date}"
- Both consent checkboxes required for reverify users
- Deprecated `Intro` and `IntroReVerification` components deleted
- `screens/IntroScreen.jsx` deleted; `FaceVerificationIntro` removed from `faceVerification/index.js`

## Related

See [03_bounty_spec.md](.bounties/20260417-fv-intro-screen-flow/03_bounty_spec.md) for full details, acceptance criteria and testing instructions.